### PR TITLE
Assorted changes

### DIFF
--- a/src/main/java/com/yahoo/memory/AccessByteBuffer.java
+++ b/src/main/java/com/yahoo/memory/AccessByteBuffer.java
@@ -19,6 +19,23 @@ import java.nio.ByteBuffer;
  */
 final class AccessByteBuffer {
 
+  private static final Field BYTE_BUFFER_OFFSET_FIELD;
+  private static final Field BYTE_BUFFER_HB_FIELD;
+
+  static {
+    try {
+      BYTE_BUFFER_OFFSET_FIELD = ByteBuffer.class.getDeclaredField("offset");
+      BYTE_BUFFER_OFFSET_FIELD.setAccessible(true);
+
+      BYTE_BUFFER_HB_FIELD = ByteBuffer.class.getDeclaredField("hb");
+      BYTE_BUFFER_HB_FIELD.setAccessible(true);
+    }
+    catch (NoSuchFieldException e) {
+      throw new RuntimeException(
+              "Could not get offset/byteArray from OnHeap ByteBuffer instance: " + e.getClass());
+    }
+  }
+
   private AccessByteBuffer() { }
 
   //The provided ByteBuffer may be either readOnly or writable
@@ -44,16 +61,13 @@ final class AccessByteBuffer {
       final Object unsafeObj;
       final long regionOffset;
       try {
-        Field field = ByteBuffer.class.getDeclaredField("offset");
-        field.setAccessible(true);
         //includes the slice() offset for heap.
-        regionOffset = ((Integer)field.get(byteBuf)).longValue() * ARRAY_BYTE_INDEX_SCALE;
+        regionOffset = ((Integer)BYTE_BUFFER_OFFSET_FIELD.get(byteBuf)).longValue()
+                * ARRAY_BYTE_INDEX_SCALE;
 
-        field = ByteBuffer.class.getDeclaredField("hb"); //the backing byte[] from HeapByteBuffer
-        field.setAccessible(true);
-        unsafeObj = field.get(byteBuf);
+        unsafeObj = BYTE_BUFFER_HB_FIELD.get(byteBuf); //the backing byte[] from HeapByteBuffer
       }
-      catch (final IllegalAccessException | NoSuchFieldException e) {
+      catch (final IllegalAccessException e) {
         throw new RuntimeException(
                 "Could not get offset/byteArray from OnHeap ByteBuffer instance: " + e.getClass());
       }

--- a/src/main/java/com/yahoo/memory/BaseBuffer.java
+++ b/src/main/java/com/yahoo/memory/BaseBuffer.java
@@ -21,7 +21,7 @@ package com.yahoo.memory;
  *
  * @author Lee Rhodes
  */
-class BaseBuffer {
+public class BaseBuffer {
   private final long cap;
   private long start = 0;
   private long pos = 0;

--- a/src/main/java/com/yahoo/memory/Memory.java
+++ b/src/main/java/com/yahoo/memory/Memory.java
@@ -116,7 +116,7 @@ public abstract class Memory {
    * @return Memory for read operations
    */
   public static Memory wrap(final byte[] arr) {
-    return wrap(arr, ByteOrder.nativeOrder());
+    return wrap(arr, 0, arr.length, ByteOrder.nativeOrder());
   }
 
   /**
@@ -125,13 +125,16 @@ public abstract class Memory {
    * @param byteOrder the byte order
    * @return Memory for read operations
    */
-  public static Memory wrap(final byte[] arr, ByteOrder byteOrder) {
+  public static Memory wrap(final byte[] arr, final int offset, final int length,
+          ByteOrder byteOrder) {
       nullCheck(arr);
       nullCheck(byteOrder);
-      if (arr.length == 0) {
+      UnsafeUtil.checkBounds(offset, length, arr.length);
+      if (length == 0) {
           return WritableMemoryImpl.ZERO_SIZE_MEMORY;
       }
-      ResourceState state = new ResourceState(arr, Prim.BYTE, arr.length);
+      ResourceState state = new ResourceState(arr, Prim.BYTE, length);
+      state.putRegionOffset(offset);
       state.order(byteOrder);
       return new WritableMemoryImpl(state);
   }

--- a/src/main/java/com/yahoo/memory/Memory.java
+++ b/src/main/java/com/yahoo/memory/Memory.java
@@ -426,8 +426,8 @@ public abstract class Memory {
 
   /**
    * Checks that the specified range of bytes is within bounds of this Memory object, throws
-   * {@link IllegalArgumentException} if it's not: i. e. if offsetBytes < 0, or length < 0, or
-   * offsetBytes + length > {@link #getCapacity()}.
+   * {@link IllegalArgumentException} if it's not: i. e. if offsetBytes &lt; 0, or length &lt; 0, or
+   * offsetBytes + length &gt; {@link #getCapacity()}.
    * @param offsetBytes the offset of the range of bytes to check
    * @param length the length of the range of bytes to check
    */

--- a/src/main/java/com/yahoo/memory/Memory.java
+++ b/src/main/java/com/yahoo/memory/Memory.java
@@ -6,7 +6,6 @@
 package com.yahoo.memory;
 
 import static com.yahoo.memory.UnsafeUtil.LS;
-import static com.yahoo.memory.UnsafeUtil.checkBounds;
 import static com.yahoo.memory.UnsafeUtil.unsafe;
 import static com.yahoo.memory.Util.nullCheck;
 
@@ -426,6 +425,15 @@ public abstract class Memory {
   public abstract long getCumulativeOffset(final long offsetBytes);
 
   /**
+   * Checks that the specified range of bytes is within bounds of this Memory object, throws
+   * {@link IllegalArgumentException} if it's not: i. e. if offsetBytes < 0, or length < 0, or
+   * offsetBytes + length > {@link #getCapacity()}.
+   * @param offsetBytes the offset of the range of bytes to check
+   * @param length the length of the range of bytes to check
+   */
+  public abstract void checkBounds(final long offsetBytes, final long length);
+
+  /**
    * Returns the ByteOrder for the backing resource.
    * @return the ByteOrder for the backing resource.
    */
@@ -498,7 +506,7 @@ public abstract class Memory {
    */
   static String toHex(final String preamble, final long offsetBytes, final int lengthBytes,
       final ResourceState state) {
-    checkBounds(offsetBytes, lengthBytes, state.getCapacity());
+    UnsafeUtil.checkBounds(offsetBytes, lengthBytes, state.getCapacity());
     final StringBuilder sb = new StringBuilder();
     final Object uObj = state.getUnsafeObject();
     final String uObjStr = (uObj == null) ? "null"

--- a/src/main/java/com/yahoo/memory/Memory.java
+++ b/src/main/java/com/yahoo/memory/Memory.java
@@ -98,7 +98,7 @@ public abstract class Memory {
 
   //ACCESS PRIMITIVE HEAP ARRAYS for readOnly XXX
   /**
-   * Wraps the given primitive array for read operations
+   * Wraps the given primitive array for read operations, with native byte order.
    * @param arr the given primitive array
    * @return Memory for read operations
    */
@@ -111,20 +111,33 @@ public abstract class Memory {
   }
 
   /**
-   * Wraps the given primitive array for read operations
+   * Wraps the given primitive array for read operations, with native byte order.
    * @param arr the given primitive array
    * @return Memory for read operations
    */
   public static Memory wrap(final byte[] arr) {
-    nullCheck(arr);
-    if (arr.length == 0) {
-      return WritableMemoryImpl.ZERO_SIZE_MEMORY;
-    }
-    return new WritableMemoryImpl(new ResourceState(arr, Prim.BYTE, arr.length));
+    return wrap(arr, ByteOrder.nativeOrder());
   }
 
   /**
-   * Wraps the given primitive array for read operations
+   * Wraps the given primitive array for read operations, with the given byte order.
+   * @param arr the given primitive array
+   * @param byteOrder the byte order
+   * @return Memory for read operations
+   */
+  public static Memory wrap(final byte[] arr, ByteOrder byteOrder) {
+      nullCheck(arr);
+      nullCheck(byteOrder);
+      if (arr.length == 0) {
+          return WritableMemoryImpl.ZERO_SIZE_MEMORY;
+      }
+      ResourceState state = new ResourceState(arr, Prim.BYTE, arr.length);
+      state.order(byteOrder);
+      return new WritableMemoryImpl(state);
+  }
+
+  /**
+   * Wraps the given primitive array for read operations, with native byte order.
    * @param arr the given primitive array
    * @return Memory for read operations
    */
@@ -137,7 +150,7 @@ public abstract class Memory {
   }
 
   /**
-   * Wraps the given primitive array for read operations
+   * Wraps the given primitive array for read operations, with native byte order.
    * @param arr the given primitive array
    * @return Memory for read operations
    */
@@ -150,7 +163,7 @@ public abstract class Memory {
   }
 
   /**
-   * Wraps the given primitive array for read operations
+   * Wraps the given primitive array for read operations, with native byte order.
    * @param arr the given primitive array
    * @return Memory for read operations
    */
@@ -163,7 +176,7 @@ public abstract class Memory {
   }
 
   /**
-   * Wraps the given primitive array for read operations
+   * Wraps the given primitive array for read operations, with native byte order.
    * @param arr the given primitive array
    * @return Memory for read operations
    */
@@ -176,7 +189,7 @@ public abstract class Memory {
   }
 
   /**
-   * Wraps the given primitive array for read operations
+   * Wraps the given primitive array for read operations, with native byte order.
    * @param arr the given primitive array
    * @return Memory for read operations
    */
@@ -189,7 +202,7 @@ public abstract class Memory {
   }
 
   /**
-   * Wraps the given primitive array for read operations
+   * Wraps the given primitive array for read operations, with native byte order.
    * @param arr the given primitive array
    * @return Memory for read operations
    */

--- a/src/main/java/com/yahoo/memory/ResourceState.java
+++ b/src/main/java/com/yahoo/memory/ResourceState.java
@@ -183,9 +183,6 @@ final class ResourceState {
     this.resourceOrder_ = toCopy.resourceOrder_; //retains resourseOrder
     this.swapBytes_ = toCopy.swapBytes_;
     compute();
-
-    //POSITIONAL
-    this.baseBuf_ = new BaseBuffer(this);
   }
 
   ResourceState copy() { //shallow copy

--- a/src/main/java/com/yahoo/memory/StepBoolean.java
+++ b/src/main/java/com/yahoo/memory/StepBoolean.java
@@ -5,20 +5,16 @@
 
 package com.yahoo.memory;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 /**
  * This is a step boolean function that can change its state only once and is thread-safe.
  *
  * @author Lee Rhodes
  */
 final class StepBoolean {
-  private final boolean initial;
-  private AtomicBoolean state = new AtomicBoolean(false);
+  private volatile boolean state;
 
   StepBoolean(final boolean initialState) {
-    this.initial = initialState;
-    this.state.set(initialState);
+    this.state = initialState;
   }
 
   /**
@@ -26,23 +22,11 @@ final class StepBoolean {
    * @return the current state.
    */
   boolean get() {
-    return this.state.get();
+    return this.state;
   }
 
-  /**
-   * This changes the state of this step boolean function if it has not yet changed.
-   * If the state has already changed this does nothing and returns false.
-   * @return true if the state changed due to this operation
-   */
-  boolean change() {
-    return this.state.compareAndSet(this.initial, !this.initial);
-  }
-
-  /**
-   * Return true if the state has changed from the initial state
-   * @return true if the state has changed from the initial state
-   */
-  boolean hasChanged() {
-    return !change();
+  void set(boolean state)
+  {
+    this.state = state;
   }
 }

--- a/src/main/java/com/yahoo/memory/WritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableBufferImpl.java
@@ -94,8 +94,7 @@ class WritableBufferImpl extends WritableBuffer {
 
   private WritableBuffer doRegion(final long offsetBytes, final long capacityBytes) {
     checkValid();
-    assert (offsetBytes + capacityBytes) <= capacity
-            : "newOff + newCap: " + (offsetBytes + capacityBytes) + ", origCap: " + capacity;
+    checkBounds(offsetBytes, capacityBytes, capacity);
     final ResourceState newState = state.copy();
     newState.putRegionOffset(newState.getRegionOffset() + offsetBytes);
     newState.putCapacity(capacityBytes);
@@ -106,8 +105,7 @@ class WritableBufferImpl extends WritableBuffer {
 
   private WritableBuffer doDuplicate(final long offsetBytes, final long capacityBytes) {
     checkValid();
-    assert (offsetBytes + capacityBytes) <= capacity
-            : "newOff + newCap: " + (offsetBytes + capacityBytes) + ", origCap: " + capacity;
+    checkBounds(offsetBytes, capacityBytes, capacity);
     final ResourceState newState = state.copy();
     newState.putRegionOffset(newState.getRegionOffset() + offsetBytes);
     newState.putCapacity(capacityBytes);

--- a/src/main/java/com/yahoo/memory/WritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableBufferImpl.java
@@ -96,7 +96,7 @@ class WritableBufferImpl extends WritableBuffer {
     checkValid();
     assert (offsetBytes + capacityBytes) <= capacity
             : "newOff + newCap: " + (offsetBytes + capacityBytes) + ", origCap: " + capacity;
-    final ResourceState newState = state.copy(); //creates new BaseBuffer(newState)
+    final ResourceState newState = state.copy();
     newState.putRegionOffset(newState.getRegionOffset() + offsetBytes);
     newState.putCapacity(capacityBytes);
     final WritableBufferImpl wBufImpl = new WritableBufferImpl(newState);
@@ -108,7 +108,7 @@ class WritableBufferImpl extends WritableBuffer {
     checkValid();
     assert (offsetBytes + capacityBytes) <= capacity
             : "newOff + newCap: " + (offsetBytes + capacityBytes) + ", origCap: " + capacity;
-    final ResourceState newState = state.copy(); //creates new BaseBuffer(newState)
+    final ResourceState newState = state.copy();
     newState.putRegionOffset(newState.getRegionOffset() + offsetBytes);
     newState.putCapacity(capacityBytes);
     final WritableBufferImpl wBufImpl = new WritableBufferImpl(newState);

--- a/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
@@ -88,8 +88,7 @@ class WritableMemoryImpl extends WritableMemory {
   @Override
   public WritableMemory writableRegion(final long offsetBytes, final long capacityBytes) {
     assertValid();
-    assert (offsetBytes + capacityBytes) <= capacity
-        : "newOff + newCap: " + (offsetBytes + capacityBytes) + ", origCap: " + capacity;
+    checkBounds(offsetBytes, capacityBytes, capacity);
     final ResourceState newState = state.copy();
     newState.putRegionOffset(newState.getRegionOffset() + offsetBytes);
     newState.putCapacity(capacityBytes);

--- a/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
@@ -104,7 +104,7 @@ class WritableMemoryImpl extends WritableMemory {
   @Override
   public WritableBuffer asWritableBuffer() {
     final ResourceState newState = state.copy();
-    final WritableBufferImpl impl = new WritableBufferImpl(newState); //with new BaseBuffer
+    final WritableBufferImpl impl = new WritableBufferImpl(newState);
     final ByteBuffer byteBuf = newState.getByteBuffer();
     if (byteBuf != null) {
       impl.setStartPositionEnd(0, byteBuf.position(), byteBuf.limit());

--- a/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
@@ -32,7 +32,6 @@ import static com.yahoo.memory.UnsafeUtil.LS;
 import static com.yahoo.memory.UnsafeUtil.SHORT_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.UNSAFE_COPY_THRESHOLD;
 import static com.yahoo.memory.UnsafeUtil.assertBounds;
-import static com.yahoo.memory.UnsafeUtil.checkBounds;
 import static com.yahoo.memory.UnsafeUtil.checkOverlap;
 import static com.yahoo.memory.UnsafeUtil.unsafe;
 
@@ -88,7 +87,7 @@ class WritableMemoryImpl extends WritableMemory {
   @Override
   public WritableMemory writableRegion(final long offsetBytes, final long capacityBytes) {
     assertValid();
-    checkBounds(offsetBytes, capacityBytes, capacity);
+    checkBounds(offsetBytes, capacityBytes);
     final ResourceState newState = state.copy();
     newState.putRegionOffset(newState.getRegionOffset() + offsetBytes);
     newState.putCapacity(capacityBytes);
@@ -125,8 +124,8 @@ class WritableMemoryImpl extends WritableMemory {
       final int length) {
     assertValid();
     final long copyBytes = length << BOOLEAN_SHIFT;
-    checkBounds(offsetBytes, copyBytes, capacity);
-    checkBounds(dstOffset, length, dstArray.length);
+    checkBounds(offsetBytes, copyBytes);
+    UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
     unsafe.copyMemory(
         unsafeObj,
         cumBaseOffset + offsetBytes,
@@ -147,8 +146,8 @@ class WritableMemoryImpl extends WritableMemory {
       final int length) {
     assertValid();
     final long copyBytes = length << BYTE_SHIFT;
-    checkBounds(offsetBytes, copyBytes, capacity);
-    checkBounds(dstOffset, length, dstArray.length);
+    checkBounds(offsetBytes, copyBytes);
+    UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
     unsafe.copyMemory(
         unsafeObj,
         cumBaseOffset + offsetBytes,
@@ -169,8 +168,8 @@ class WritableMemoryImpl extends WritableMemory {
       final int length) {
     assertValid();
     final long copyBytes = length << CHAR_SHIFT;
-    checkBounds(offsetBytes, copyBytes, capacity);
-    checkBounds(dstOffset, length, dstArray.length);
+    checkBounds(offsetBytes, copyBytes);
+    UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
     unsafe.copyMemory(
         unsafeObj,
         cumBaseOffset + offsetBytes,
@@ -197,8 +196,8 @@ class WritableMemoryImpl extends WritableMemory {
       final int length) {
     assertValid();
     final long copyBytes = length << DOUBLE_SHIFT;
-    checkBounds(offsetBytes, copyBytes, capacity);
-    checkBounds(dstOffset, length, dstArray.length);
+    checkBounds(offsetBytes, copyBytes);
+    UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
     unsafe.copyMemory(
         unsafeObj,
         cumBaseOffset + offsetBytes,
@@ -219,8 +218,8 @@ class WritableMemoryImpl extends WritableMemory {
       final int length) {
     assertValid();
     final long copyBytes = length << FLOAT_SHIFT;
-    checkBounds(offsetBytes, copyBytes, capacity);
-    checkBounds(dstOffset, length, dstArray.length);
+    checkBounds(offsetBytes, copyBytes);
+    UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
     unsafe.copyMemory(
         unsafeObj,
         cumBaseOffset + offsetBytes,
@@ -241,8 +240,8 @@ class WritableMemoryImpl extends WritableMemory {
       final int length) {
     assertValid();
     final long copyBytes = length << INT_SHIFT;
-    checkBounds(offsetBytes, copyBytes, capacity);
-    checkBounds(dstOffset, length, dstArray.length);
+    checkBounds(offsetBytes, copyBytes);
+    UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
     unsafe.copyMemory(
         unsafeObj,
         cumBaseOffset + offsetBytes,
@@ -263,8 +262,8 @@ class WritableMemoryImpl extends WritableMemory {
       final int length) {
     assertValid();
     final long copyBytes = length << LONG_SHIFT;
-    checkBounds(offsetBytes, copyBytes, capacity);
-    checkBounds(dstOffset, length, dstArray.length);
+    checkBounds(offsetBytes, copyBytes);
+    UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
     unsafe.copyMemory(
         unsafeObj,
         cumBaseOffset + offsetBytes,
@@ -285,8 +284,8 @@ class WritableMemoryImpl extends WritableMemory {
       final int length) {
     assertValid();
     final long copyBytes = length << SHORT_SHIFT;
-    checkBounds(offsetBytes, copyBytes, capacity);
-    checkBounds(dstOffset, length, dstArray.length);
+    checkBounds(offsetBytes, copyBytes);
+    UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
     unsafe.copyMemory(
         unsafeObj,
         cumBaseOffset + offsetBytes,
@@ -301,8 +300,8 @@ class WritableMemoryImpl extends WritableMemory {
       final long thatOffsetBytes, final long thatLengthBytes) {
     assertValid();
     ((WritableMemoryImpl)that).assertValid();
-    checkBounds(thisOffsetBytes, thisLengthBytes, capacity);
-    checkBounds(thatOffsetBytes, thatLengthBytes, that.getCapacity());
+    checkBounds(thisOffsetBytes, thisLengthBytes);
+    that.checkBounds(thatOffsetBytes, thatLengthBytes);
     final long thisAdd = getCumulativeOffset(thisOffsetBytes);
     final long thatAdd = that.getCumulativeOffset(thatOffsetBytes);
     final Object thisObj = (isDirect()) ? null : unsafeObj;
@@ -321,8 +320,8 @@ class WritableMemoryImpl extends WritableMemory {
   public void copyTo(final long srcOffsetBytes, final WritableMemory destination,
       final long dstOffsetBytes, final long lengthBytes) {
     assertValid();
-    checkBounds(srcOffsetBytes, lengthBytes, capacity);
-    checkBounds(dstOffsetBytes, lengthBytes, destination.getCapacity());
+    checkBounds(srcOffsetBytes, lengthBytes);
+    destination.checkBounds(dstOffsetBytes, lengthBytes);
     assert ((this == destination)
         ? checkOverlap(srcOffsetBytes, dstOffsetBytes, lengthBytes)
         : true) : "Region Overlap" ;
@@ -353,6 +352,12 @@ class WritableMemoryImpl extends WritableMemory {
   public long getCumulativeOffset(final long offsetBytes) {
     assertValid();
     return cumBaseOffset + offsetBytes;
+  }
+
+  @Override
+  public void checkBounds(long offsetBytes, long length) {
+    assertValid();
+    UnsafeUtil.checkBounds(offsetBytes, length, capacity);
   }
 
   @Override
@@ -434,8 +439,8 @@ class WritableMemoryImpl extends WritableMemory {
       final int length) {
     assertValid();
     final long copyBytes = length << BOOLEAN_SHIFT;
-    checkBounds(srcOffset, length, srcArray.length);
-    checkBounds(offsetBytes, copyBytes, capacity);
+    UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
+    checkBounds(offsetBytes, copyBytes);
     unsafe.copyMemory(
         srcArray,
         ARRAY_BOOLEAN_BASE_OFFSET + (srcOffset << BOOLEAN_SHIFT),
@@ -457,8 +462,8 @@ class WritableMemoryImpl extends WritableMemory {
       final int length) {
     assertValid();
     final long copyBytes = length << BYTE_SHIFT;
-    checkBounds(srcOffset, length, srcArray.length);
-    checkBounds(offsetBytes, copyBytes, capacity);
+    UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
+    checkBounds(offsetBytes, copyBytes);
     unsafe.copyMemory(
         srcArray,
         ARRAY_BYTE_BASE_OFFSET + (srcOffset << BYTE_SHIFT),
@@ -480,8 +485,8 @@ class WritableMemoryImpl extends WritableMemory {
       final int length) {
     assertValid();
     final long copyBytes = length << CHAR_SHIFT;
-    checkBounds(srcOffset, length, srcArray.length);
-    checkBounds(offsetBytes, copyBytes, capacity);
+    UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
+    checkBounds(offsetBytes, copyBytes);
     unsafe.copyMemory(
         srcArray,
         ARRAY_CHAR_BASE_OFFSET + (srcOffset << CHAR_SHIFT),
@@ -508,8 +513,8 @@ class WritableMemoryImpl extends WritableMemory {
       final int length) {
     assertValid();
     final long copyBytes = length << DOUBLE_SHIFT;
-    checkBounds(srcOffset, length, srcArray.length);
-    checkBounds(offsetBytes, copyBytes, capacity);
+    UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
+    checkBounds(offsetBytes, copyBytes);
     unsafe.copyMemory(
         srcArray,
         ARRAY_DOUBLE_BASE_OFFSET + (srcOffset << DOUBLE_SHIFT),
@@ -531,8 +536,8 @@ class WritableMemoryImpl extends WritableMemory {
       final int length) {
     assertValid();
     final long copyBytes = length << FLOAT_SHIFT;
-    checkBounds(srcOffset, length, srcArray.length);
-    checkBounds(offsetBytes, copyBytes, capacity);
+    UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
+    checkBounds(offsetBytes, copyBytes);
     unsafe.copyMemory(
         srcArray,
         ARRAY_FLOAT_BASE_OFFSET + (srcOffset << FLOAT_SHIFT),
@@ -554,8 +559,8 @@ class WritableMemoryImpl extends WritableMemory {
       final int length) {
     assertValid();
     final long copyBytes = length << INT_SHIFT;
-    checkBounds(srcOffset, length, srcArray.length);
-    checkBounds(offsetBytes, copyBytes, capacity);
+    UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
+    checkBounds(offsetBytes, copyBytes);
     unsafe.copyMemory(
         srcArray,
         ARRAY_INT_BASE_OFFSET + (srcOffset << INT_SHIFT),
@@ -577,8 +582,8 @@ class WritableMemoryImpl extends WritableMemory {
       final int length) {
     assertValid();
     final long copyBytes = length << LONG_SHIFT;
-    checkBounds(srcOffset, length, srcArray.length);
-    checkBounds(offsetBytes, copyBytes, capacity);
+    UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
+    checkBounds(offsetBytes, copyBytes);
     unsafe.copyMemory(
         srcArray,
         ARRAY_LONG_BASE_OFFSET + (srcOffset << LONG_SHIFT),
@@ -600,8 +605,8 @@ class WritableMemoryImpl extends WritableMemory {
       final int length) {
     assertValid();
     final long copyBytes = length << SHORT_SHIFT;
-    checkBounds(srcOffset, length, srcArray.length);
-    checkBounds(offsetBytes, copyBytes, capacity);
+    UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
+    checkBounds(offsetBytes, copyBytes);
     unsafe.copyMemory(
         srcArray,
         ARRAY_SHORT_BASE_OFFSET + (srcOffset << SHORT_SHIFT),
@@ -676,7 +681,7 @@ class WritableMemoryImpl extends WritableMemory {
   @Override
   public void fill(final long offsetBytes, final long lengthBytes, final byte value) {
     assertValid();
-    checkBounds(offsetBytes, lengthBytes, capacity);
+    checkBounds(offsetBytes, lengthBytes);
     unsafe.setMemory(unsafeObj, cumBaseOffset + offsetBytes, lengthBytes, value);
   }
 

--- a/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
@@ -314,9 +314,7 @@ class WritableMemoryImpl extends WritableMemory {
       if (thisByte < thatByte) { return -1; }
       if (thisByte > thatByte) { return  1; }
     }
-    if (thisLengthBytes < thatLengthBytes) { return -1; }
-    if (thisLengthBytes > thatLengthBytes) { return  1; }
-    return 0;
+    return Long.compare(thisLengthBytes, thatLengthBytes);
   }
 
   @Override

--- a/src/test/java/com/yahoo/memory/ResourceStateTest.java
+++ b/src/test/java/com/yahoo/memory/ResourceStateTest.java
@@ -117,24 +117,6 @@ public class ResourceStateTest {
     assertTrue(wbuf.isSameResource(buf));
   }
 
-  //StepBoolean checks
-  @Test
-  public void checkStepBoolean() {
-    checkStepBoolean(true);
-    checkStepBoolean(false);
-  }
-
-  private static void checkStepBoolean(boolean init) {
-    StepBoolean step = new StepBoolean(init);
-    assertTrue(step.get() == init); //confirm init
-    assertTrue(step.change());      //1st change was successful
-    assertTrue(step.get() != init); //confirm it is different from init
-    assertTrue(step.hasChanged());  //confirm it was changed from init
-    assertFalse(step.change());     //2nd change, not successful
-    assertTrue(step.get() != init); //Still different from init
-    assertTrue(step.hasChanged());  //confirm it was changed from initial value
-  }
-
   @Test
   public void checkPrim() {
     assertEquals(Prim.DOUBLE.scale(), ARRAY_DOUBLE_INDEX_SCALE);

--- a/src/test/java/com/yahoo/memory/WritableBufferImplTest.java
+++ b/src/test/java/com/yahoo/memory/WritableBufferImplTest.java
@@ -419,7 +419,7 @@ public class WritableBufferImplTest {
 //    }
 //  }
 
-  @Test(expectedExceptions = AssertionError.class)
+  @Test(expectedExceptions = IllegalArgumentException.class)
   public void checkRegionBounds() {
     int memCapacity = 64;
     try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {

--- a/src/test/java/com/yahoo/memory/WritableMemoryImplTest.java
+++ b/src/test/java/com/yahoo/memory/WritableMemoryImplTest.java
@@ -418,7 +418,7 @@ public class WritableMemoryImplTest {
 
   }
 
-  @Test(expectedExceptions = AssertionError.class)
+  @Test(expectedExceptions = IllegalArgumentException.class)
   public void checkRegionBounds() {
     int memCapacity = 64;
     try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {


### PR DESCRIPTION
I didn't want to create a separate PR for each change, please review them in one place.

Also:
 - What's the point of `Memory.duplicate()` method? Memory is immutable in terms of bounds/offsets, and this method doesn't change them, unlike region(off, cap).
 - Why `ResourceState` is copied at each place where it is copied? Like region(), asBuffer(), asMemory(), etc.
 - Buffers generally always created from Memory, so instead of creating another one object in Buffer.asMemory(), suggested to save original Memory in a field of Buffer and return it. Then method should probably be called "getMemory()".
 - Buffer.compareTo() could accept `Memory` as "that".