### PR TITLE
Assorted changes 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <enableAssertions>true</enableAssertions>
+                </configuration>
             </plugin>
             
             <plugin>

--- a/src/main/java/com/yahoo/memory/BaseBuffer.java
+++ b/src/main/java/com/yahoo/memory/BaseBuffer.java
@@ -22,7 +22,6 @@ package com.yahoo.memory;
  * @author Lee Rhodes
  */
 public class BaseBuffer {
-  final ResourceState state;
   final long capacity;
   private long start = 0;
   private long pos = 0;
@@ -30,7 +29,6 @@ public class BaseBuffer {
 
 
   BaseBuffer(final ResourceState state) {
-    this.state = state;
     capacity = state.getCapacity();
     end = capacity;
     state.putBaseBuffer(this);
@@ -229,9 +227,5 @@ public class BaseBuffer {
               + ", (cap - end): " + (cap - end)
       );
     }
-  }
-
-  final ResourceState getResourceState() {
-    return state;
   }
 }

--- a/src/main/java/com/yahoo/memory/BaseBuffer.java
+++ b/src/main/java/com/yahoo/memory/BaseBuffer.java
@@ -130,6 +130,15 @@ public class BaseBuffer {
     return (end - pos) > 0;
   }
 
+  /**
+   * The invariants equation is: {@code 0 <= start <= position <= end <= capacity}.
+   * If this equation is violated and assertions are enabled,
+   * an <i>AssertionError</i> will be thrown.
+   * @param start the lowest start position
+   * @param pos the current position
+   * @param end the highest position
+   * @param cap the capacity of the backing buffer.
+   */
   static final void assertInvariants(final long start, final long pos, final long end,
       final long cap) {
     assert (start | pos | end | cap | (pos - start) | (end - pos) | (cap - end) ) >= 0L
@@ -143,6 +152,14 @@ public class BaseBuffer {
         + ", (cap - end): " + (cap - end);
   }
 
+  /**
+   * The invariants equation is: {@code 0 <= start <= position <= end <= capacity}.
+   * If this equation is violated an <i>IllegalArgumentException</i> will be thrown.
+   * @param start the lowest start position
+   * @param pos the current position
+   * @param end the highest position
+   * @param cap the capacity of the backing buffer.
+   */
   static final void checkInvariants(final long start, final long pos, final long end,
         final long cap) {
     if ((start | pos | end | cap | (pos - start) | (end - pos) | (cap - end) ) < 0L) {

--- a/src/main/java/com/yahoo/memory/BaseBuffer.java
+++ b/src/main/java/com/yahoo/memory/BaseBuffer.java
@@ -44,7 +44,7 @@ public class BaseBuffer {
    * @return BaseBuffer
    */
   public BaseBuffer incrementPosition(final long increment) {
-    incrementPositionAndAssert(pos, increment);
+    incrementAndAssertPosition(pos, increment);
     return this;
   }
 
@@ -55,8 +55,8 @@ public class BaseBuffer {
    * @param increment the given increment
    * @return BaseBuffer
    */
-  public BaseBuffer incrementPositionAndCheck(final long increment) {
-    incrementPositionAndCheck(pos, increment);
+  public BaseBuffer incrementAndCheckPosition(final long increment) {
+    incrementAndCheckPosition(pos, increment);
     return this;
   }
 
@@ -130,7 +130,7 @@ public class BaseBuffer {
    * @param position the given current position.
    * @return BaseBuffer
    */
-  public BaseBuffer setPositionAndCheck(final long position) {
+  public BaseBuffer setAndCheckPosition(final long position) {
     checkInvariants(start, position, end, capacity);
     pos = position;
     return this;
@@ -163,7 +163,7 @@ public class BaseBuffer {
    * @param end the end position in the buffer
    * @return BaseBuffer
    */
-  public final BaseBuffer setStartPositionEndAndCheck(final long start, final long position,
+  public final BaseBuffer setAndCheckStartPositionEnd(final long start, final long position,
         final long end) {
     checkInvariants(start, position, end, capacity);
     this.start = start;
@@ -173,15 +173,13 @@ public class BaseBuffer {
   }
 
   //RESTRICTED XXX
-  void incrementPositionAndAssert(final long position, final long increment) {
-    assertValid();
+  void incrementAndAssertPosition(final long position, final long increment) {
     final long newPos = position + increment;
     assertInvariants(start, newPos, end, capacity);
     pos = newPos;
   }
 
-  void incrementPositionAndCheck(final long pos, final long increment) {
-    checkValid();
+  void incrementAndCheckPosition(final long pos, final long increment) {
     final long newPos = pos + increment;
     checkInvariants(start, newPos, end, capacity);
     this.pos = newPos;
@@ -230,16 +228,6 @@ public class BaseBuffer {
               + ", (end - pos): " + (end - pos)
               + ", (cap - end): " + (cap - end)
       );
-    }
-  }
-
-  final void assertValid() { //applies to both readable and writable
-    assert state.isValid() : "Memory not valid.";
-  }
-
-  final void checkValid() {
-    if (!state.isValid()) {
-      throw new IllegalStateException("Memory not valid.");
     }
   }
 

--- a/src/main/java/com/yahoo/memory/BaseBuffer.java
+++ b/src/main/java/com/yahoo/memory/BaseBuffer.java
@@ -37,35 +37,27 @@ public class BaseBuffer {
   }
 
   /**
-   * Sets start position, current position, and end position
-   * @param start the start position in the buffer
-   * @param position the current position between the start and end
-   * @param end the end position in the buffer
+   * Increments the current position by the given increment.
+   * Asserts that the resource is valid and that the positional invariants are not violated,
+   * otherwise, if asserts are enabled throws an {@link AssertionError}.
+   * @param increment the given increment
    * @return BaseBuffer
    */
-  public final BaseBuffer setStartPositionEnd(final long start, final long position,
-        final long end) {
-    assertInvariants(start, position, end, capacity);
-    this.start = start;
-    this.end = end;
-    pos = position;
+  public BaseBuffer incrementPosition(final long increment) {
+    incrementPositionAndAssert(pos, increment);
     return this;
   }
 
   /**
-   * Gets start position
-   * @return start position
+   * Increments the current position by the given increment.
+   * Checks that the resource is valid and that the positional invariants are not violated,
+   * otherwise throws an {@link IllegalArgumentException}.
+   * @param increment the given increment
+   * @return BaseBuffer
    */
-  public long getStart() {
-    return start;
-  }
-
-  /**
-   * Gets the current position
-   * @return the current position
-   */
-  public long getPosition() {
-    return pos;
+  public BaseBuffer incrementPositionAndCheck(final long increment) {
+    incrementPositionAndCheck(pos, increment);
+    return this;
   }
 
   /**
@@ -77,41 +69,19 @@ public class BaseBuffer {
   }
 
   /**
-   * Sets the current position
-   * @param position the given current position
-   * @return BaseBuffer
+   * Gets the current position
+   * @return the current position
    */
-  public BaseBuffer setPosition(final long position) {
-    assertInvariants(start, position, end, capacity);
-    pos = position;
-    return this;
+  public long getPosition() {
+    return pos;
   }
 
   /**
-   * Increments the current position by the given increment
-   * @param increment the given increment
-   * @return BaseBuffer
+   * Gets start position
+   * @return start position
    */
-  public BaseBuffer incrementPosition(final long increment) {
-    incrementPosition(pos, increment);
-    return this;
-  }
-
-  void incrementPosition(final long pos, final long increment) {
-    assertValid();
-    final long newPos = pos + increment;
-    assertInvariants(start, newPos, end, capacity);
-    this.pos = newPos;
-  }
-
-  /**
-   * Resets the current position to the start position,
-   * This does not modify any data.
-   * @return BaseBuffer
-   */
-  public BaseBuffer resetPosition() {
-    pos = start;
-    return this;
+  public long getStart() {
+    return start;
   }
 
   /**
@@ -128,6 +98,93 @@ public class BaseBuffer {
    */
   public boolean hasRemaining() {
     return (end - pos) > 0;
+  }
+
+  /**
+   * Resets the current position to the start position,
+   * This does not modify any data.
+   * @return BaseBuffer
+   */
+  public BaseBuffer resetPosition() {
+    pos = start;
+    return this;
+  }
+
+  /**
+   * Sets the current position.
+   * Asserts that the positional invariants are not violated,
+   * otherwise, if asserts are enabled throws an {@link AssertionError}.
+   * @param position the given current position.
+   * @return BaseBuffer
+   */
+  public BaseBuffer setPosition(final long position) {
+    assertInvariants(start, position, end, capacity);
+    pos = position;
+    return this;
+  }
+
+  /**
+   * Sets the current position.
+   * Checks that the positional invariants are not violated,
+   * otherwise, throws an {@link IllegalArgumentException}.
+   * @param position the given current position.
+   * @return BaseBuffer
+   */
+  public BaseBuffer setPositionAndCheck(final long position) {
+    checkInvariants(start, position, end, capacity);
+    pos = position;
+    return this;
+  }
+
+  /**
+   * Sets start position, current position, and end position.
+   * Asserts that the positional invariants are not violated,
+   * otherwise, if asserts are enabled throws an {@link AssertionError}.
+   * @param start the start position in the buffer
+   * @param position the current position between the start and end
+   * @param end the end position in the buffer
+   * @return BaseBuffer
+   */
+  public final BaseBuffer setStartPositionEnd(final long start, final long position,
+        final long end) {
+    assertInvariants(start, position, end, capacity);
+    this.start = start;
+    this.end = end;
+    pos = position;
+    return this;
+  }
+
+  /**
+   * Sets start position, current position, and end position.
+   * Checks that the positional invariants are not violated,
+   * otherwise, throws an {@link IllegalArgumentException}.
+   * @param start the start position in the buffer
+   * @param position the current position between the start and end
+   * @param end the end position in the buffer
+   * @return BaseBuffer
+   */
+  public final BaseBuffer setStartPositionEndAndCheck(final long start, final long position,
+        final long end) {
+    checkInvariants(start, position, end, capacity);
+    this.start = start;
+    this.end = end;
+    pos = position;
+    return this;
+  }
+
+  //RESTRICTED XXX
+  void incrementPositionAndAssert(final long position, final long increment) {
+    assertValid();
+    final long newPos = position + increment;
+    assertInvariants(start, newPos, end, capacity);
+    pos = newPos;
+  }
+
+  void incrementPositionAndCheck(final long pos, final long increment) {
+    checkValid();
+    final long newPos = pos + increment;
+    checkInvariants(start, newPos, end, capacity);
+    this.pos = newPos;
   }
 
   /**
@@ -176,7 +233,6 @@ public class BaseBuffer {
     }
   }
 
-  //RESTRICTED READ AND WRITE XXX
   final void assertValid() { //applies to both readable and writable
     assert state.isValid() : "Memory not valid.";
   }

--- a/src/main/java/com/yahoo/memory/Buffer.java
+++ b/src/main/java/com/yahoo/memory/Buffer.java
@@ -410,6 +410,15 @@ public abstract class Buffer extends BaseBuffer {
   public abstract void checkBounds(final long offsetBytes, final long length);
 
   /**
+   * Checks that the specified range of bytes is within limits of this Buffer object, throws
+   * {@link IllegalArgumentException} if it's not: i. e. if offsetBytes &lt; 0, or length &lt; 0,
+   * or offsetBytes &lt; {@link #getStart()}, or offsetBytes + length &gt; {@link #getEnd()}.
+   * @param offsetBytes the offset of the range of bytes to check
+   * @param length the length of the range of bytes to check
+   */
+  public abstract void checkLimits(final long offsetBytes, final long length);
+
+  /**
    * Returns the ByteOrder for the backing resource.
    * @return the ByteOrder for the backing resource.
    */
@@ -473,6 +482,4 @@ public abstract class Buffer extends BaseBuffer {
    * @return a formatted hex string in a human readable array
    */
   public abstract String toHexString(String header, long offsetBytes, int lengthBytes);
-
-  abstract ResourceState getResourceState();
 }

--- a/src/main/java/com/yahoo/memory/Buffer.java
+++ b/src/main/java/com/yahoo/memory/Buffer.java
@@ -46,7 +46,7 @@ public abstract class Buffer extends BaseBuffer {
   //MAP XXX
   //Use Memory for mapping files
 
-  //REGIONS/DUPLICATES XXX
+  //DUPLICATES & REGIONS XXX
   /**
    * Returns a read only duplicate view of this Buffer with the same but independent values of
    * start, position, and end.
@@ -387,6 +387,15 @@ public abstract class Buffer extends BaseBuffer {
 
   //OTHER READ METHODS XXX
   /**
+   * Checks that the specified range of bytes is within bounds of this Memory object, throws
+   * {@link IllegalArgumentException} if it's not: i. e. if offsetBytes &lt; 0, or length &lt; 0,
+   * or offsetBytes + length &gt; {@link #getCapacity()}.
+   * @param offsetBytes the offset of the range of bytes to check
+   * @param length the length of the range of bytes to check
+   */
+  public abstract void checkValidAndBounds(final long offsetBytes, final long length);
+
+  /**
    * Gets the capacity of this Buffer in bytes
    * @return the capacity of this Buffer in bytes
    */
@@ -399,15 +408,6 @@ public abstract class Buffer extends BaseBuffer {
    * @return the cumulative offset in bytes of this Buffer.
    */
   public abstract long getCumulativeOffset();
-
-  /**
-   * Checks that the specified range of bytes is within bounds of this Memory object, throws
-   * {@link IllegalArgumentException} if it's not: i. e. if offsetBytes &lt; 0, or length &lt; 0,
-   * or offsetBytes + length &gt; {@link #getCapacity()}.
-   * @param offsetBytes the offset of the range of bytes to check
-   * @param length the length of the range of bytes to check
-   */
-  public abstract void checkBounds(final long offsetBytes, final long length);
 
   /**
    * Returns the ByteOrder for the backing resource.

--- a/src/main/java/com/yahoo/memory/Buffer.java
+++ b/src/main/java/com/yahoo/memory/Buffer.java
@@ -473,4 +473,6 @@ public abstract class Buffer extends BaseBuffer {
    * @return a formatted hex string in a human readable array
    */
   public abstract String toHexString(String header, long offsetBytes, int lengthBytes);
+
+  abstract ResourceState getResourceState();
 }

--- a/src/main/java/com/yahoo/memory/Buffer.java
+++ b/src/main/java/com/yahoo/memory/Buffer.java
@@ -410,15 +410,6 @@ public abstract class Buffer extends BaseBuffer {
   public abstract void checkBounds(final long offsetBytes, final long length);
 
   /**
-   * Checks that the specified range of bytes is within limits of this Buffer object, throws
-   * {@link IllegalArgumentException} if it's not: i. e. if offsetBytes &lt; 0, or length &lt; 0,
-   * or offsetBytes &lt; {@link #getStart()}, or offsetBytes + length &gt; {@link #getEnd()}.
-   * @param offsetBytes the offset of the range of bytes to check
-   * @param length the length of the range of bytes to check
-   */
-  public abstract void checkLimits(final long offsetBytes, final long length);
-
-  /**
    * Returns the ByteOrder for the backing resource.
    * @return the ByteOrder for the backing resource.
    */

--- a/src/main/java/com/yahoo/memory/Memory.java
+++ b/src/main/java/com/yahoo/memory/Memory.java
@@ -94,7 +94,7 @@ public abstract class Memory {
 
   //ACCESS PRIMITIVE HEAP ARRAYS for readOnly XXX
   /**
-   * Wraps the given primitive array for read operations, with native byte order.
+   * Wraps the given primitive array for read operations assuming native byte order.
    * @param arr the given primitive array
    * @return Memory for read operations
    */
@@ -107,7 +107,7 @@ public abstract class Memory {
   }
 
   /**
-   * Wraps the given primitive array for read operations, with native byte order.
+   * Wraps the given primitive array for read operations assuming native byte order.
    * @param arr the given primitive array
    * @return Memory for read operations
    */
@@ -116,7 +116,17 @@ public abstract class Memory {
   }
 
   /**
-   * Wraps the given primitive array for read operations, with the given byte order.
+   * Wraps the given primitive array for read operations assuming the given byte order.
+   * @param arr the given primitive array
+   * @param byteOrder the byte order
+   * @return Memory for read operations
+   */
+  public static Memory wrap(final byte[] arr, final ByteOrder byteOrder) {
+      return wrap(arr, 0, arr.length, byteOrder);
+  }
+
+  /**
+   * Wraps the given primitive array for read operations assuming the given byte order.
    * @param arr the given primitive array
    * @param offset the byte offset into the given array
    * @param length the number of bytes to include from the given array
@@ -138,7 +148,7 @@ public abstract class Memory {
   }
 
   /**
-   * Wraps the given primitive array for read operations, with native byte order.
+   * Wraps the given primitive array for read operations assuming native byte order.
    * @param arr the given primitive array
    * @return Memory for read operations
    */
@@ -151,7 +161,7 @@ public abstract class Memory {
   }
 
   /**
-   * Wraps the given primitive array for read operations, with native byte order.
+   * Wraps the given primitive array for read operations assuming native byte order.
    * @param arr the given primitive array
    * @return Memory for read operations
    */
@@ -164,7 +174,7 @@ public abstract class Memory {
   }
 
   /**
-   * Wraps the given primitive array for read operations, with native byte order.
+   * Wraps the given primitive array for read operations assuming native byte order.
    * @param arr the given primitive array
    * @return Memory for read operations
    */
@@ -177,7 +187,7 @@ public abstract class Memory {
   }
 
   /**
-   * Wraps the given primitive array for read operations, with native byte order.
+   * Wraps the given primitive array for read operations assuming native byte order.
    * @param arr the given primitive array
    * @return Memory for read operations
    */
@@ -190,7 +200,7 @@ public abstract class Memory {
   }
 
   /**
-   * Wraps the given primitive array for read operations, with native byte order.
+   * Wraps the given primitive array for read operations assuming native byte order.
    * @param arr the given primitive array
    * @return Memory for read operations
    */
@@ -203,7 +213,7 @@ public abstract class Memory {
   }
 
   /**
-   * Wraps the given primitive array for read operations, with native byte order.
+   * Wraps the given primitive array for read operations assuming native byte order.
    * @param arr the given primitive array
    * @return Memory for read operations
    */
@@ -394,7 +404,7 @@ public abstract class Memory {
   public abstract void getShortArray(long offsetBytes, short[] dstArray, int dstOffset,
       int length);
 
-  //OTHER PRIMITIVE READ METHODS: copyTo, compareTo XXX
+  //OTHER PRIMITIVE READ METHODS: compareTo, copyTo XXX
   /**
    * Compares the bytes of this Memory to <i>that</i> Memory.
    * Returns <i>(this &lt; that) ? -1 : (this &gt; that) ? 1 : 0;</i>.
@@ -423,6 +433,8 @@ public abstract class Memory {
       long lengthBytes);
 
   //OTHER READ METHODS XXX
+  public abstract void checkValidAndBounds(long offset, long length);
+
   /**
    * Gets the capacity of this Memory in bytes
    * @return the capacity of this Memory in bytes
@@ -437,15 +449,6 @@ public abstract class Memory {
    * @return the cumulative offset in bytes of this Memory including the given offsetBytes.
    */
   public abstract long getCumulativeOffset(final long offsetBytes);
-
-  /**
-   * Checks that the specified range of bytes is within bounds of this Memory object, throws
-   * {@link IllegalArgumentException} if it's not: i. e. if offsetBytes &lt; 0, or length &lt; 0,
-   * or offsetBytes + length &gt; {@link #getCapacity()}.
-   * @param offsetBytes the offset of the range of bytes to check
-   * @param length the length of the range of bytes to check
-   */
-  public abstract void checkBounds(final long offsetBytes, final long length);
 
   /**
    * Returns the ByteOrder for the backing resource.

--- a/src/main/java/com/yahoo/memory/Prim.java
+++ b/src/main/java/com/yahoo/memory/Prim.java
@@ -30,6 +30,7 @@ import static com.yahoo.memory.UnsafeUtil.DOUBLE_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.FLOAT_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.INT_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.LONG_SHIFT;
+import static com.yahoo.memory.UnsafeUtil.OBJECT_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.SHORT_SHIFT;
 
 /**
@@ -46,27 +47,27 @@ enum Prim {
   LONG(ARRAY_LONG_BASE_OFFSET, ARRAY_LONG_INDEX_SCALE, LONG_SHIFT),
   FLOAT(ARRAY_FLOAT_BASE_OFFSET, ARRAY_FLOAT_INDEX_SCALE, FLOAT_SHIFT),
   DOUBLE(ARRAY_DOUBLE_BASE_OFFSET, ARRAY_DOUBLE_INDEX_SCALE, DOUBLE_SHIFT),
-  OBJECT(ARRAY_OBJECT_BASE_OFFSET, ARRAY_OBJECT_INDEX_SCALE, 1);
+  OBJECT(ARRAY_OBJECT_BASE_OFFSET, ARRAY_OBJECT_INDEX_SCALE, OBJECT_SHIFT);
 
-  private final int arrBaseOff_;
-  private final int arrIdxScale_;
-  private final int sizeShift_;
+  private final long arrBaseOff_;
+  private final long arrIdxScale_;
+  private final long sizeShift_;
 
-  private Prim(final int arrBaseOff, final int arrIdxScale, final int sizeShift) {
+  private Prim(final long arrBaseOff, final long arrIdxScale, final long sizeShift) {
     this.arrBaseOff_ = arrBaseOff;
     this.arrIdxScale_ = arrIdxScale;
     this.sizeShift_ = sizeShift;
   }
 
-  int off() {
+  long off() {
     return arrBaseOff_;
   }
 
-  int scale() {
+  long scale() {
     return arrIdxScale_;
   }
 
-  int shift() {
+  long shift() {
     return sizeShift_;
   }
 

--- a/src/main/java/com/yahoo/memory/ResourceState.java
+++ b/src/main/java/com/yahoo/memory/ResourceState.java
@@ -154,38 +154,38 @@ final class ResourceState {
     compute();
   }
 
-  private ResourceState(final ResourceState toCopy) {
+  private ResourceState(final ResourceState src) {
     //FOUNDATION PARAMETERS
-    nativeBaseOffset_ = toCopy.nativeBaseOffset_;
-    unsafeObj_ = toCopy.unsafeObj_;
-    unsafeObjHeader_ = toCopy.unsafeObjHeader_;
-    capacity_ = toCopy.capacity_;
+    nativeBaseOffset_ = src.nativeBaseOffset_;
+    unsafeObj_ = src.unsafeObj_;
+    unsafeObjHeader_ = src.unsafeObjHeader_;
+    capacity_ = src.capacity_;
     //cumBaseOffset is computed
-    memReqSvr_ = toCopy.memReqSvr_; //retains memReqSvr reference
+    memReqSvr_ = src.memReqSvr_; //retains memReqSvr reference
 
     //FLAGS
-    resourceIsReadOnly_ = toCopy.resourceIsReadOnly_;
-    valid_ = toCopy.valid_; //retains valid reference
+    resourceIsReadOnly_ = src.resourceIsReadOnly_;
+    valid_ = src.valid_; //retains valid reference
 
     //REGIONS
-    regionOffset_ = toCopy.regionOffset_;
+    regionOffset_ = src.regionOffset_;
 
     //BYTE BUFFER
-    byteBuf_ = toCopy.byteBuf_; //retains ByteBuffer reference
+    byteBuf_ = src.byteBuf_; //retains ByteBuffer reference
 
     //MEMORY MAPPED FILES
-    file_ = toCopy.file_; //retains file reference
-    fileOffset_ = toCopy.fileOffset_;
-    raf_ = toCopy.raf_;
-    mbb_ = toCopy.mbb_;
+    file_ = src.file_; //retains file reference
+    fileOffset_ = src.fileOffset_;
+    raf_ = src.raf_;
+    mbb_ = src.mbb_;
 
     //ENDIANNESS
-    resourceOrder_ = toCopy.resourceOrder_; //retains resourseOrder
-    swapBytes_ = toCopy.swapBytes_;
+    resourceOrder_ = src.resourceOrder_; //retains resourseOrder
+    swapBytes_ = src.swapBytes_;
     compute();
   }
 
-  ResourceState copy() { //shallow copy
+  ResourceState copy() {
     return new ResourceState(this);
   }
 
@@ -268,14 +268,6 @@ final class ResourceState {
     resourceIsReadOnly_.change();
   }
 
-  boolean isValid() {
-    return valid_.get();
-  }
-
-  void setInvalid() {
-    valid_.change();
-  }
-
   boolean isDirect() {
     return nativeBaseOffset_ > 0L;
   }
@@ -288,6 +280,24 @@ final class ResourceState {
             && (getCapacity() == that.getCapacity())
             && (getUnsafeObject() == that.getUnsafeObject())
             && (getByteBuffer() == that.getByteBuffer());
+  }
+
+  boolean isValid() {
+    return valid_.get();
+  }
+
+  void setInvalid() {
+    valid_.change();
+  }
+
+  final void assertValid() {
+    assert valid_.get() : "Memory not valid.";
+  }
+
+  final void checkValid() {
+    if (!valid_.get()) {
+      throw new IllegalStateException("Memory not valid.");
+    }
   }
 
   //REGIONS

--- a/src/main/java/com/yahoo/memory/UnsafeUtil.java
+++ b/src/main/java/com/yahoo/memory/UnsafeUtil.java
@@ -26,40 +26,48 @@ public final class UnsafeUtil {
   public static final int JDK;
   static final JDKCompatibility compatibilityMethods;
 
-
-  public static final int ADDRESS_SIZE; //not an indicator of whether compressed references are used.
+  //not an indicator of whether compressed references are used.
+  public static final int ADDRESS_SIZE;
 
   //For 64-bit JVMs: varies depending on coop: 16 for JVM <= 32GB; 24 for JVM > 32GB
-  public static final int ARRAY_BOOLEAN_BASE_OFFSET;
-  public static final int ARRAY_BYTE_BASE_OFFSET;
-  public static final int ARRAY_SHORT_BASE_OFFSET;
-  public static final int ARRAY_CHAR_BASE_OFFSET;
-  public static final int ARRAY_INT_BASE_OFFSET;
-  public static final int ARRAY_LONG_BASE_OFFSET;
-  public static final int ARRAY_FLOAT_BASE_OFFSET;
-  public static final int ARRAY_DOUBLE_BASE_OFFSET;
-  public static final int ARRAY_OBJECT_BASE_OFFSET;
+  // Making this constant long-typed, rather than int, to exclude possibility of accidental overflow
+  // in expressions like arrayLength * ARRAY_BYTE_BASE_OFFSET, where arrayLength is int-typed. The
+  // same consideration for constants below: ARRAY_*_INDEX_SCALE, ARRAY_*_INDEX_SHIFT.
+  public static final long ARRAY_BOOLEAN_BASE_OFFSET;
+  public static final long ARRAY_BYTE_BASE_OFFSET;
+  public static final long ARRAY_SHORT_BASE_OFFSET;
+  public static final long ARRAY_CHAR_BASE_OFFSET;
+  public static final long ARRAY_INT_BASE_OFFSET;
+  public static final long ARRAY_LONG_BASE_OFFSET;
+  public static final long ARRAY_FLOAT_BASE_OFFSET;
+  public static final long ARRAY_DOUBLE_BASE_OFFSET;
+  public static final long ARRAY_OBJECT_BASE_OFFSET;
 
   //@formatter:off
-  public static final int ARRAY_BOOLEAN_INDEX_SCALE; // 1
-  public static final int ARRAY_BYTE_INDEX_SCALE;    // 1
-  public static final int ARRAY_SHORT_INDEX_SCALE;   // 2
-  public static final int ARRAY_CHAR_INDEX_SCALE;    // 2
-  public static final int ARRAY_INT_INDEX_SCALE;     // 4
-  public static final int ARRAY_LONG_INDEX_SCALE;    // 8
-  public static final int ARRAY_FLOAT_INDEX_SCALE;   // 4
-  public static final int ARRAY_DOUBLE_INDEX_SCALE;  // 8
-  public static final int ARRAY_OBJECT_INDEX_SCALE;  // varies, 4 or 8 depending on coop
+
+  // Setting those values directly instead of using unsafe.arrayIndexScale(), because it may be
+  // beneficial for runtime execution, those values are backed into generated machine code as
+  // constants. E. g. see https://shipilev.net/jvm-anatomy-park/14-constant-variables/
+  public static final int ARRAY_BOOLEAN_INDEX_SCALE = 1;
+  public static final int ARRAY_BYTE_INDEX_SCALE    = 1;
+  public static final long ARRAY_SHORT_INDEX_SCALE  = 2;
+  public static final long ARRAY_CHAR_INDEX_SCALE   = 2;
+  public static final long ARRAY_INT_INDEX_SCALE    = 4;
+  public static final long ARRAY_LONG_INDEX_SCALE   = 8;
+  public static final long ARRAY_FLOAT_INDEX_SCALE  = 4;
+  public static final long ARRAY_DOUBLE_INDEX_SCALE = 8;
+  public static final long ARRAY_OBJECT_INDEX_SCALE;  // varies, 4 or 8 depending on coop
 
   //Used to convert "type" to bytes:  bytes = longs << LONG_SHIFT
-  public static final int BOOLEAN_SHIFT   = 0;
-  public static final int BYTE_SHIFT      = 0;
-  public static final int SHORT_SHIFT     = 1;
-  public static final int CHAR_SHIFT      = 1;
-  public static final int INT_SHIFT       = 2;
-  public static final int LONG_SHIFT      = 3;
-  public static final int FLOAT_SHIFT     = 2;
-  public static final int DOUBLE_SHIFT    = 3;
+  public static final int BOOLEAN_SHIFT    = 0;
+  public static final int BYTE_SHIFT       = 0;
+  public static final long SHORT_SHIFT     = 1;
+  public static final long CHAR_SHIFT      = 1;
+  public static final long INT_SHIFT       = 2;
+  public static final long LONG_SHIFT      = 3;
+  public static final long FLOAT_SHIFT     = 2;
+  public static final long DOUBLE_SHIFT    = 3;
+  public static final long OBJECT_SHIFT;     // varies, 2 or 3 depending on coop
 
   public static final String LS = System.getProperty("line.separator");
 
@@ -103,15 +111,8 @@ public final class UnsafeUtil {
     ARRAY_DOUBLE_BASE_OFFSET = unsafe.arrayBaseOffset(double[].class);
     ARRAY_OBJECT_BASE_OFFSET = unsafe.arrayBaseOffset(Object[].class);
 
-    ARRAY_BOOLEAN_INDEX_SCALE = unsafe.arrayIndexScale(boolean[].class);
-    ARRAY_BYTE_INDEX_SCALE = unsafe.arrayIndexScale(byte[].class);
-    ARRAY_SHORT_INDEX_SCALE = unsafe.arrayIndexScale(short[].class);
-    ARRAY_CHAR_INDEX_SCALE = unsafe.arrayIndexScale(char[].class);
-    ARRAY_INT_INDEX_SCALE = unsafe.arrayIndexScale(int[].class);
-    ARRAY_LONG_INDEX_SCALE = unsafe.arrayIndexScale(long[].class);
-    ARRAY_FLOAT_INDEX_SCALE = unsafe.arrayIndexScale(float[].class);
-    ARRAY_DOUBLE_INDEX_SCALE = unsafe.arrayIndexScale(double[].class);
     ARRAY_OBJECT_INDEX_SCALE = unsafe.arrayIndexScale(Object[].class);
+    OBJECT_SHIFT = ARRAY_OBJECT_INDEX_SCALE == 4 ? 2 : 3;
 
     final String jdkVer = System.getProperty("java.version");
     if (jdkVer.startsWith("1.7")) {
@@ -153,7 +154,7 @@ public final class UnsafeUtil {
   public static void checkBounds(final long reqOff, final long reqLen, final long allocSize) {
     if ((reqOff | reqLen | (reqOff + reqLen) | (allocSize - (reqOff + reqLen))) < 0) {
       throw new IllegalArgumentException(
-          "reqOffset: " + reqOff + ", reqLength: "
+          "reqOffset: " + reqOff + ", reqLength: " + reqLen
               + ", (reqOff + reqLen): " + (reqOff + reqLen) + ", allocSize: " + allocSize);
     }
   }

--- a/src/main/java/com/yahoo/memory/UnsafeUtil.java
+++ b/src/main/java/com/yahoo/memory/UnsafeUtil.java
@@ -159,19 +159,6 @@ public final class UnsafeUtil {
     }
   }
 
-  /**
-   * Return true if the given offsets and length do not overlap.
-   * @param srcOff the start of the source region
-   * @param dstOff the start of the destination region
-   * @param length the length of both regions
-   * @return true if the given offsets and length do not overlap.
-   */
-  public static boolean checkOverlap(final long srcOff, final long dstOff, final long length) {
-    final long min = Math.min(srcOff, dstOff);
-    final long max = Math.max(srcOff, dstOff);
-    return (min + length) <= max;
-  }
-
   interface JDKCompatibility {
 
     long getAndAddLong(Object obj, long address, long increment);

--- a/src/main/java/com/yahoo/memory/UnsafeUtil.java
+++ b/src/main/java/com/yahoo/memory/UnsafeUtil.java
@@ -129,9 +129,9 @@ public final class UnsafeUtil {
   private UnsafeUtil() {}
 
   /**
-   * Perform bounds checking using java assert (if enabled) checking the requested offset and
-   * length against the allocated size.
-   * If reqOff + reqLen &gt; allocSize or any of the parameters are negative an exception will
+   * Assert the requested offset and length against the allocated size.
+   * The invariants equation is: {@code 0 <= reqOff <= reqLen <= reqOff + reqLen <= allocSize}.
+   * If this equation is violated and assertions are enabled, an {@link AssertionError} will
    * be thrown.
    * @param reqOff the requested offset
    * @param reqLen the requested length
@@ -145,8 +145,8 @@ public final class UnsafeUtil {
 
   /**
    * Check the requested offset and length against the allocated size.
-   * If reqOff + reqLen &gt; allocSize or any of the parameters are negative an exception will
-   * be thrown.
+   * The invariants equation is: {@code 0 <= reqOff <= reqLen <= reqOff + reqLen <= allocSize}.
+   * If this equation is violated an {@link IllegalArgumentException} will be thrown.
    * @param reqOff the requested offset
    * @param reqLen the requested length
    * @param allocSize the allocated size.

--- a/src/main/java/com/yahoo/memory/Utf8.java
+++ b/src/main/java/com/yahoo/memory/Utf8.java
@@ -35,8 +35,7 @@ final class Utf8 {
   static final void getCharsFromUtf8(final long offsetBytes, final int utf8LengthBytes,
       final Appendable dst, final ResourceState state)
           throws IOException, Utf8CodingException {
-    assert state.isValid();
-
+    state.checkValid();
     checkBounds(offsetBytes, utf8LengthBytes, state.getCapacity());
     final long cumBaseOffset = state.getCumBaseOffset();
     final long address = cumBaseOffset + offsetBytes;
@@ -251,7 +250,7 @@ final class Utf8 {
   //Encode
   static long putCharsToUtf8(final long offsetBytes, final CharSequence src,
         final ResourceState state) {
-    assert state.isValid();
+    state.checkValid();
     final Object unsafeObj = state.getUnsafeObject();
     final long cumBaseOffset = state.getCumBaseOffset();
 

--- a/src/main/java/com/yahoo/memory/WritableBuffer.java
+++ b/src/main/java/com/yahoo/memory/WritableBuffer.java
@@ -49,7 +49,7 @@ public abstract class WritableBuffer extends Buffer {
   //ALLOCATE DIRECT XXX
   //Use WritableMemory to allocate direct memory
 
-  //REGIONS/DUPLICATES XXX
+  //DUPLICATES & REGIONS XXX
   /**
    * Returns a writable duplicate view of this Buffer with the same but independent values of
    * start, position, end and capacity.
@@ -59,8 +59,11 @@ public abstract class WritableBuffer extends Buffer {
   public abstract WritableBuffer writableDuplicate();
 
   /**
-   * Returns a writable region of this WritableBuffer
-   * @return a writable region of this WritableBuffer
+   * Returns a writable region of this WritableBuffer defined by the current position and end.
+   * This is equivalent to {@code writableRegion(getPosition(), getEnd() - getPosition());}.
+   * The new independent start and position will be zero and the end and capacity will be
+   * {@code getEnd() - getPosition()}.
+   * @return a writable region of this WritableBuffer defined by the current position and end.
    */
   public abstract WritableBuffer writableRegion();
 
@@ -399,9 +402,6 @@ public abstract class WritableBuffer extends Buffer {
    */
   public abstract void putShortArray(short[] srcArray,
           final int srcOffset, final int length);
-
-  //Atomic Methods XXX
-  //Use WritableMemory for atomic methods
 
   //OTHER WRITE METHODS XXX
   /**

--- a/src/main/java/com/yahoo/memory/WritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableBufferImpl.java
@@ -381,7 +381,7 @@ class WritableBufferImpl extends WritableBuffer {
 
   @Override
   public void checkLimits(final long offsetBytes, final long length) {
-    assertValid();
+    checkValid();
     checkInvariants(getStart(), offsetBytes + length, getEnd(), getCapacity());
   }
 

--- a/src/main/java/com/yahoo/memory/WritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableBufferImpl.java
@@ -374,7 +374,7 @@ class WritableBufferImpl extends WritableBuffer {
   }
 
   @Override
-  public void checkBounds(long offsetBytes, long length) {
+  public void checkBounds(final long offsetBytes, final long length) {
     checkValid();
     UnsafeUtil.checkBounds(offsetBytes, length, capacity);
   }

--- a/src/main/java/com/yahoo/memory/WritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableBufferImpl.java
@@ -120,7 +120,9 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public WritableMemory asWritableMemory() {
     state.checkValid();
-    return (originMemory != null) ? originMemory : new WritableMemoryImpl(state);
+    if (originMemory != null) { return originMemory; }
+    originMemory = new WritableMemoryImpl(state);
+    return originMemory;
   }
 
   //PRIMITIVE getXXX() and getXXXArray() XXX

--- a/src/main/java/com/yahoo/memory/WritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableBufferImpl.java
@@ -488,7 +488,6 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void putByte(final byte value) {
     final long pos = getPosition();
-    assertBounds(pos, ARRAY_BYTE_INDEX_SCALE);
     incrementPosition(pos, ARRAY_BYTE_INDEX_SCALE);
     unsafe.putByte(unsafeObj, cumBaseOffset + pos, value);
   }

--- a/src/main/java/com/yahoo/memory/WritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableBufferImpl.java
@@ -21,8 +21,6 @@ import static com.yahoo.memory.UnsafeUtil.ARRAY_LONG_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_LONG_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_SHORT_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_SHORT_INDEX_SCALE;
-import static com.yahoo.memory.UnsafeUtil.BOOLEAN_SHIFT;
-import static com.yahoo.memory.UnsafeUtil.BYTE_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.CHAR_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.DOUBLE_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.FLOAT_SHIFT;
@@ -142,14 +140,14 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void getBooleanArray(final boolean[] dstArray, final int dstOffset, final int length) {
     final long pos = getPosition();
-    final long copyBytes = length << BOOLEAN_SHIFT;
+    final long copyBytes = length;
     checkBounds(pos, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
     unsafe.copyMemory(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
-            ARRAY_BOOLEAN_BASE_OFFSET + (dstOffset << BOOLEAN_SHIFT),
+            ARRAY_BOOLEAN_BASE_OFFSET + dstOffset,
             copyBytes);
     incrementPosition(copyBytes);
   }
@@ -174,14 +172,14 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void getByteArray(final byte[] dstArray, final int dstOffset, final int length) {
     final long pos = getPosition();
-    final long copyBytes = length << BYTE_SHIFT;
+    final long copyBytes = length;
     checkBounds(pos, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
     unsafe.copyMemory(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
-            ARRAY_BYTE_BASE_OFFSET + (dstOffset << BYTE_SHIFT),
+            ARRAY_BYTE_BASE_OFFSET + dstOffset,
             copyBytes);
     incrementPosition(copyBytes);
   }
@@ -206,14 +204,14 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void getCharArray(final char[] dstArray, final int dstOffset, final int length) {
     final long pos = getPosition();
-    final long copyBytes = length << CHAR_SHIFT;
+    final long copyBytes = ((long) length) << CHAR_SHIFT;
     checkBounds(pos, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
     unsafe.copyMemory(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
-            ARRAY_CHAR_BASE_OFFSET + (dstOffset << CHAR_SHIFT),
+            ARRAY_CHAR_BASE_OFFSET + (((long) dstOffset) << CHAR_SHIFT),
             copyBytes);
     incrementPosition(copyBytes);
   }
@@ -238,14 +236,14 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void getDoubleArray(final double[] dstArray, final int dstOffset, final int length) {
     final long pos = getPosition();
-    final long copyBytes = length << DOUBLE_SHIFT;
+    final long copyBytes = ((long) length) << DOUBLE_SHIFT;
     checkBounds(pos, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
     unsafe.copyMemory(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
-            ARRAY_DOUBLE_BASE_OFFSET + (dstOffset << DOUBLE_SHIFT),
+            ARRAY_DOUBLE_BASE_OFFSET + (((long) dstOffset) << DOUBLE_SHIFT),
             copyBytes);
     incrementPosition(copyBytes);
   }
@@ -270,14 +268,14 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void getFloatArray(final float[] dstArray, final int dstOffset, final int length) {
     final long pos = getPosition();
-    final long copyBytes = length << FLOAT_SHIFT;
+    final long copyBytes = ((long) length) << FLOAT_SHIFT;
     checkBounds(pos, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
     unsafe.copyMemory(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
-            ARRAY_FLOAT_BASE_OFFSET + (dstOffset << FLOAT_SHIFT),
+            ARRAY_FLOAT_BASE_OFFSET + (((long) dstOffset) << FLOAT_SHIFT),
             copyBytes);
     incrementPosition(copyBytes);
   }
@@ -302,14 +300,14 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void getIntArray(final int[] dstArray, final int dstOffset, final int length) {
     final long pos = getPosition();
-    final long copyBytes = length << INT_SHIFT;
+    final long copyBytes = ((long) length) << INT_SHIFT;
     checkBounds(pos, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
     unsafe.copyMemory(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
-            ARRAY_INT_BASE_OFFSET + (dstOffset << INT_SHIFT),
+            ARRAY_INT_BASE_OFFSET + (((long) dstOffset) << INT_SHIFT),
             copyBytes);
     incrementPosition(copyBytes);
   }
@@ -334,14 +332,14 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void getLongArray(final long[] dstArray, final int dstOffset, final int length) {
     final long pos = getPosition();
-    final long copyBytes = length << LONG_SHIFT;
+    final long copyBytes = ((long) length) << LONG_SHIFT;
     checkBounds(pos, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
     unsafe.copyMemory(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
-            ARRAY_LONG_BASE_OFFSET + (dstOffset << LONG_SHIFT),
+            ARRAY_LONG_BASE_OFFSET + (((long) dstOffset) << LONG_SHIFT),
             copyBytes);
     incrementPosition(copyBytes);
   }
@@ -366,14 +364,14 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void getShortArray(final short[] dstArray, final int dstOffset, final int length) {
     final long pos = getPosition();
-    final long copyBytes = length << SHORT_SHIFT;
+    final long copyBytes = ((long) length) << SHORT_SHIFT;
     checkBounds(pos, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
     unsafe.copyMemory(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
-            ARRAY_SHORT_BASE_OFFSET + (dstOffset << SHORT_SHIFT),
+            ARRAY_SHORT_BASE_OFFSET + (((long) dstOffset) << SHORT_SHIFT),
             copyBytes);
     incrementPosition(copyBytes);
   }
@@ -507,12 +505,12 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void putBooleanArray(final boolean[] srcArray, final int srcOffset, final int length) {
     final long pos = getPosition();
-    final long copyBytes = length << BOOLEAN_SHIFT;
+    final long copyBytes = length;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
     checkBounds(pos, copyBytes);
     unsafe.copyMemory(
             srcArray,
-            ARRAY_BOOLEAN_BASE_OFFSET + (srcOffset << BOOLEAN_SHIFT),
+            ARRAY_BOOLEAN_BASE_OFFSET + srcOffset,
             unsafeObj,
             cumBaseOffset + pos,
             copyBytes
@@ -539,12 +537,12 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void putByteArray(final byte[] srcArray, final int srcOffset, final int length) {
     final long pos = getPosition();
-    final long copyBytes = length << BYTE_SHIFT;
+    final long copyBytes = length;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
     checkBounds(pos, copyBytes);
     unsafe.copyMemory(
             srcArray,
-            ARRAY_BYTE_BASE_OFFSET + (srcOffset << BYTE_SHIFT),
+            ARRAY_BYTE_BASE_OFFSET + srcOffset,
             unsafeObj,
             cumBaseOffset + pos,
             copyBytes
@@ -571,12 +569,12 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void putCharArray(final char[] srcArray, final int srcOffset, final int length) {
     final long pos = getPosition();
-    final long copyBytes = length << CHAR_SHIFT;
+    final long copyBytes = ((long) length) << CHAR_SHIFT;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
     checkBounds(pos, copyBytes);
     unsafe.copyMemory(
             srcArray,
-            ARRAY_CHAR_BASE_OFFSET + (srcOffset << CHAR_SHIFT),
+            ARRAY_CHAR_BASE_OFFSET + (((long) srcOffset) << CHAR_SHIFT),
             unsafeObj,
             cumBaseOffset + pos,
             copyBytes
@@ -603,12 +601,12 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void putDoubleArray(final double[] srcArray, final int srcOffset, final int length) {
     final long pos = getPosition();
-    final long copyBytes = length << DOUBLE_SHIFT;
+    final long copyBytes = ((long) length) << DOUBLE_SHIFT;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
     checkBounds(pos, copyBytes);
     unsafe.copyMemory(
             srcArray,
-            ARRAY_DOUBLE_BASE_OFFSET + (srcOffset << DOUBLE_SHIFT),
+            ARRAY_DOUBLE_BASE_OFFSET + (((long) srcOffset) << DOUBLE_SHIFT),
             unsafeObj,
             cumBaseOffset + pos,
             copyBytes
@@ -635,12 +633,12 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void putFloatArray(final float[] srcArray, final int srcOffset, final int length) {
     final long pos = getPosition();
-    final long copyBytes = length << FLOAT_SHIFT;
+    final long copyBytes = ((long) length) << FLOAT_SHIFT;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
     checkBounds(pos, copyBytes);
     unsafe.copyMemory(
             srcArray,
-            ARRAY_FLOAT_BASE_OFFSET + (srcOffset << FLOAT_SHIFT),
+            ARRAY_FLOAT_BASE_OFFSET + (((long) srcOffset) << FLOAT_SHIFT),
             unsafeObj,
             cumBaseOffset + pos,
             copyBytes
@@ -667,12 +665,12 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void putIntArray(final int[] srcArray, final int srcOffset, final int length) {
     final long pos = getPosition();
-    final long copyBytes = length << INT_SHIFT;
+    final long copyBytes = ((long) length) << INT_SHIFT;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
     checkBounds(pos, copyBytes);
     unsafe.copyMemory(
             srcArray,
-            ARRAY_INT_BASE_OFFSET + (srcOffset << INT_SHIFT),
+            ARRAY_INT_BASE_OFFSET + (((long) srcOffset) << INT_SHIFT),
             unsafeObj,
             cumBaseOffset + pos,
             copyBytes
@@ -699,12 +697,12 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void putLongArray(final long[] srcArray, final int srcOffset, final int length) {
     final long pos = getPosition();
-    final long copyBytes = length << LONG_SHIFT;
+    final long copyBytes = ((long) length) << LONG_SHIFT;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
     checkBounds(pos, copyBytes);
     unsafe.copyMemory(
             srcArray,
-            ARRAY_LONG_BASE_OFFSET + (srcOffset << LONG_SHIFT),
+            ARRAY_LONG_BASE_OFFSET + (((long) srcOffset) << LONG_SHIFT),
             unsafeObj,
             cumBaseOffset + pos,
             copyBytes
@@ -731,12 +729,12 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void putShortArray(final short[] srcArray, final int srcOffset, final int length) {
     final long pos = getPosition();
-    final long copyBytes = length << SHORT_SHIFT;
+    final long copyBytes = ((long) length) << SHORT_SHIFT;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
     checkBounds(pos, copyBytes);
     unsafe.copyMemory(
             srcArray,
-            ARRAY_SHORT_BASE_OFFSET + (srcOffset << SHORT_SHIFT),
+            ARRAY_SHORT_BASE_OFFSET + (((long) srcOffset) << SHORT_SHIFT),
             unsafeObj,
             cumBaseOffset + pos,
             copyBytes

--- a/src/main/java/com/yahoo/memory/WritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableBufferImpl.java
@@ -152,7 +152,7 @@ class WritableBufferImpl extends WritableBuffer {
 
   @Override
   public byte getByte(final long offsetBytes) {
-    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE);
+    assertBounds(offsetBytes, ARRAY_BYTE_INDEX_SCALE);
     return unsafe.getByte(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
@@ -180,7 +180,7 @@ class WritableBufferImpl extends WritableBuffer {
 
   @Override
   public char getChar(final long offsetBytes) {
-    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE);
+    assertBounds(offsetBytes, ARRAY_CHAR_INDEX_SCALE);
     return unsafe.getChar(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
@@ -208,7 +208,7 @@ class WritableBufferImpl extends WritableBuffer {
 
   @Override
   public double getDouble(final long offsetBytes) {
-    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE);
+    assertBounds(offsetBytes, ARRAY_DOUBLE_INDEX_SCALE);
     return unsafe.getDouble(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
@@ -236,7 +236,7 @@ class WritableBufferImpl extends WritableBuffer {
 
   @Override
   public float getFloat(final long offsetBytes) {
-    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE);
+    assertBounds(offsetBytes, ARRAY_FLOAT_INDEX_SCALE);
     return unsafe.getFloat(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
@@ -264,7 +264,7 @@ class WritableBufferImpl extends WritableBuffer {
 
   @Override
   public int getInt(final long offsetBytes) {
-    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE);
+    assertBounds(offsetBytes, ARRAY_INT_INDEX_SCALE);
     return unsafe.getInt(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
@@ -292,7 +292,7 @@ class WritableBufferImpl extends WritableBuffer {
 
   @Override
   public long getLong(final long offsetBytes) {
-    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE);
+    assertBounds(offsetBytes, ARRAY_LONG_INDEX_SCALE);
     return unsafe.getLong(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
@@ -320,7 +320,7 @@ class WritableBufferImpl extends WritableBuffer {
 
   @Override
   public short getShort(final long offsetBytes) {
-    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE);
+    assertBounds(offsetBytes, ARRAY_SHORT_INDEX_SCALE);
     return unsafe.getShort(unsafeObj, cumBaseOffset + offsetBytes);
   }
 

--- a/src/main/java/com/yahoo/memory/WritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableBufferImpl.java
@@ -118,7 +118,7 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public boolean getBoolean() {
     final long pos = getPosition();
-    incrementPosition(pos, ARRAY_BOOLEAN_INDEX_SCALE);
+    incrementPositionAndAssert(pos, ARRAY_BOOLEAN_INDEX_SCALE);
     return unsafe.getBoolean(unsafeObj, cumBaseOffset + pos);
   }
 
@@ -132,9 +132,8 @@ class WritableBufferImpl extends WritableBuffer {
   public void getBooleanArray(final boolean[] dstArray, final int dstOffset, final int length) {
     final long pos = getPosition();
     final long copyBytes = length;
-    checkLimits(pos, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
-    incrementPosition(pos, copyBytes);
+    incrementPositionAndCheck(pos, copyBytes);
     unsafe.copyMemory(
             unsafeObj,
             cumBaseOffset + pos,
@@ -146,7 +145,7 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public byte getByte() {
     final long pos = getPosition();
-    incrementPosition(pos, ARRAY_BYTE_INDEX_SCALE);
+    incrementPositionAndAssert(pos, ARRAY_BYTE_INDEX_SCALE);
     return unsafe.getByte(unsafeObj, cumBaseOffset + pos);
   }
 
@@ -160,9 +159,8 @@ class WritableBufferImpl extends WritableBuffer {
   public void getByteArray(final byte[] dstArray, final int dstOffset, final int length) {
     final long pos = getPosition();
     final long copyBytes = length;
-    checkLimits(pos, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
-    incrementPosition(pos, copyBytes);
+    incrementPositionAndCheck(pos, copyBytes);
     unsafe.copyMemory(
             unsafeObj,
             cumBaseOffset + pos,
@@ -174,7 +172,7 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public char getChar() {
     final long pos = getPosition();
-    incrementPosition(pos, ARRAY_CHAR_INDEX_SCALE);
+    incrementPositionAndAssert(pos, ARRAY_CHAR_INDEX_SCALE);
     return unsafe.getChar(unsafeObj, cumBaseOffset + pos);
   }
 
@@ -188,9 +186,8 @@ class WritableBufferImpl extends WritableBuffer {
   public void getCharArray(final char[] dstArray, final int dstOffset, final int length) {
     final long pos = getPosition();
     final long copyBytes = ((long) length) << CHAR_SHIFT;
-    checkLimits(pos, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
-    incrementPosition(pos, copyBytes);
+    incrementPositionAndCheck(pos, copyBytes);
     unsafe.copyMemory(
             unsafeObj,
             cumBaseOffset + pos,
@@ -202,7 +199,7 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public double getDouble() {
     final long pos = getPosition();
-    incrementPosition(pos, ARRAY_DOUBLE_INDEX_SCALE);
+    incrementPositionAndAssert(pos, ARRAY_DOUBLE_INDEX_SCALE);
     return unsafe.getDouble(unsafeObj, cumBaseOffset + pos);
   }
 
@@ -216,9 +213,8 @@ class WritableBufferImpl extends WritableBuffer {
   public void getDoubleArray(final double[] dstArray, final int dstOffset, final int length) {
     final long pos = getPosition();
     final long copyBytes = ((long) length) << DOUBLE_SHIFT;
-    checkLimits(pos, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
-    incrementPosition(pos, copyBytes);
+    incrementPositionAndCheck(pos, copyBytes);
     unsafe.copyMemory(
             unsafeObj,
             cumBaseOffset + pos,
@@ -230,7 +226,7 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public float getFloat() {
     final long pos = getPosition();
-    incrementPosition(pos, ARRAY_FLOAT_INDEX_SCALE);
+    incrementPositionAndAssert(pos, ARRAY_FLOAT_INDEX_SCALE);
     return unsafe.getFloat(unsafeObj, cumBaseOffset + pos);
   }
 
@@ -244,9 +240,8 @@ class WritableBufferImpl extends WritableBuffer {
   public void getFloatArray(final float[] dstArray, final int dstOffset, final int length) {
     final long pos = getPosition();
     final long copyBytes = ((long) length) << FLOAT_SHIFT;
-    checkLimits(pos, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
-    incrementPosition(pos, copyBytes);
+    incrementPositionAndCheck(pos, copyBytes);
     unsafe.copyMemory(
             unsafeObj,
             cumBaseOffset + pos,
@@ -258,7 +253,7 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public int getInt() {
     final long pos = getPosition();
-    incrementPosition(pos, ARRAY_INT_INDEX_SCALE);
+    incrementPositionAndAssert(pos, ARRAY_INT_INDEX_SCALE);
     return unsafe.getInt(unsafeObj, cumBaseOffset + pos);
   }
 
@@ -272,9 +267,8 @@ class WritableBufferImpl extends WritableBuffer {
   public void getIntArray(final int[] dstArray, final int dstOffset, final int length) {
     final long pos = getPosition();
     final long copyBytes = ((long) length) << INT_SHIFT;
-    checkLimits(pos, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
-    incrementPosition(pos, copyBytes);
+    incrementPositionAndCheck(pos, copyBytes);
     unsafe.copyMemory(
             unsafeObj,
             cumBaseOffset + pos,
@@ -286,7 +280,7 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public long getLong() {
     final long pos = getPosition();
-    incrementPosition(pos, ARRAY_LONG_INDEX_SCALE);
+    incrementPositionAndAssert(pos, ARRAY_LONG_INDEX_SCALE);
     return unsafe.getLong(unsafeObj, cumBaseOffset + pos);
   }
 
@@ -300,9 +294,8 @@ class WritableBufferImpl extends WritableBuffer {
   public void getLongArray(final long[] dstArray, final int dstOffset, final int length) {
     final long pos = getPosition();
     final long copyBytes = ((long) length) << LONG_SHIFT;
-    checkLimits(pos, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
-    incrementPosition(pos, copyBytes);
+    incrementPositionAndCheck(pos, copyBytes);
     unsafe.copyMemory(
             unsafeObj,
             cumBaseOffset + pos,
@@ -314,7 +307,7 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public short getShort() {
     final long pos = getPosition();
-    incrementPosition(pos, ARRAY_SHORT_INDEX_SCALE);
+    incrementPositionAndAssert(pos, ARRAY_SHORT_INDEX_SCALE);
     return unsafe.getShort(unsafeObj, cumBaseOffset + pos);
   }
 
@@ -328,9 +321,8 @@ class WritableBufferImpl extends WritableBuffer {
   public void getShortArray(final short[] dstArray, final int dstOffset, final int length) {
     final long pos = getPosition();
     final long copyBytes = ((long) length) << SHORT_SHIFT;
-    checkLimits(pos, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
-    incrementPosition(pos, copyBytes);
+    incrementPositionAndCheck(pos, copyBytes);
     unsafe.copyMemory(
             unsafeObj,
             cumBaseOffset + pos,
@@ -377,12 +369,6 @@ class WritableBufferImpl extends WritableBuffer {
   public void checkBounds(final long offsetBytes, final long length) {
     checkValid();
     UnsafeUtil.checkBounds(offsetBytes, length, capacity);
-  }
-
-  @Override
-  public void checkLimits(final long offsetBytes, final long length) {
-    checkValid();
-    checkInvariants(getStart(), offsetBytes + length, getEnd(), getCapacity());
   }
 
   private void assertBounds(final long offsetBytes, final long length) {
@@ -460,7 +446,7 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void putBoolean(final boolean value) {
     final long pos = getPosition();
-    incrementPosition(pos, ARRAY_BOOLEAN_INDEX_SCALE);
+    incrementPositionAndAssert(pos, ARRAY_BOOLEAN_INDEX_SCALE);
     unsafe.putBoolean(unsafeObj, cumBaseOffset + pos, value);
   }
 
@@ -475,8 +461,7 @@ class WritableBufferImpl extends WritableBuffer {
     final long pos = getPosition();
     final long copyBytes = length;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
-    checkLimits(pos, copyBytes);
-    incrementPosition(pos, copyBytes);
+    incrementPositionAndCheck(pos, copyBytes);
     unsafe.copyMemory(
             srcArray,
             ARRAY_BOOLEAN_BASE_OFFSET + srcOffset,
@@ -488,7 +473,7 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void putByte(final byte value) {
     final long pos = getPosition();
-    incrementPosition(pos, ARRAY_BYTE_INDEX_SCALE);
+    incrementPositionAndAssert(pos, ARRAY_BYTE_INDEX_SCALE);
     unsafe.putByte(unsafeObj, cumBaseOffset + pos, value);
   }
 
@@ -503,8 +488,7 @@ class WritableBufferImpl extends WritableBuffer {
     final long pos = getPosition();
     final long copyBytes = length;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
-    checkLimits(pos, copyBytes);
-    incrementPosition(pos, copyBytes);
+    incrementPositionAndCheck(pos, copyBytes);
     unsafe.copyMemory(
             srcArray,
             ARRAY_BYTE_BASE_OFFSET + srcOffset,
@@ -516,7 +500,7 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void putChar(final char value) {
     final long pos = getPosition();
-    incrementPosition(pos, ARRAY_CHAR_INDEX_SCALE);
+    incrementPositionAndAssert(pos, ARRAY_CHAR_INDEX_SCALE);
     unsafe.putChar(unsafeObj, cumBaseOffset + pos, value);
   }
 
@@ -531,8 +515,7 @@ class WritableBufferImpl extends WritableBuffer {
     final long pos = getPosition();
     final long copyBytes = ((long) length) << CHAR_SHIFT;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
-    checkLimits(pos, copyBytes);
-    incrementPosition(pos, copyBytes);
+    incrementPositionAndCheck(pos, copyBytes);
     unsafe.copyMemory(
             srcArray,
             ARRAY_CHAR_BASE_OFFSET + (((long) srcOffset) << CHAR_SHIFT),
@@ -544,7 +527,7 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void putDouble(final double value) {
     final long pos = getPosition();
-    incrementPosition(pos, ARRAY_DOUBLE_INDEX_SCALE);
+    incrementPositionAndAssert(pos, ARRAY_DOUBLE_INDEX_SCALE);
     unsafe.putDouble(unsafeObj, cumBaseOffset + pos, value);
   }
 
@@ -559,8 +542,7 @@ class WritableBufferImpl extends WritableBuffer {
     final long pos = getPosition();
     final long copyBytes = ((long) length) << DOUBLE_SHIFT;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
-    checkLimits(pos, copyBytes);
-    incrementPosition(pos, copyBytes);
+    incrementPositionAndCheck(pos, copyBytes);
     unsafe.copyMemory(
             srcArray,
             ARRAY_DOUBLE_BASE_OFFSET + (((long) srcOffset) << DOUBLE_SHIFT),
@@ -572,7 +554,7 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void putFloat(final float value) {
     final long pos = getPosition();
-    incrementPosition(pos, ARRAY_FLOAT_INDEX_SCALE);
+    incrementPositionAndAssert(pos, ARRAY_FLOAT_INDEX_SCALE);
     unsafe.putFloat(unsafeObj, cumBaseOffset + pos, value);
   }
 
@@ -587,8 +569,7 @@ class WritableBufferImpl extends WritableBuffer {
     final long pos = getPosition();
     final long copyBytes = ((long) length) << FLOAT_SHIFT;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
-    checkLimits(pos, copyBytes);
-    incrementPosition(pos, copyBytes);
+    incrementPositionAndCheck(pos, copyBytes);
     unsafe.copyMemory(
             srcArray,
             ARRAY_FLOAT_BASE_OFFSET + (((long) srcOffset) << FLOAT_SHIFT),
@@ -600,7 +581,7 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void putInt(final int value) {
     final long pos = getPosition();
-    incrementPosition(pos, ARRAY_INT_INDEX_SCALE);
+    incrementPositionAndAssert(pos, ARRAY_INT_INDEX_SCALE);
     unsafe.putInt(unsafeObj, cumBaseOffset + pos, value);
   }
 
@@ -615,8 +596,7 @@ class WritableBufferImpl extends WritableBuffer {
     final long pos = getPosition();
     final long copyBytes = ((long) length) << INT_SHIFT;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
-    checkLimits(pos, copyBytes);
-    incrementPosition(pos, copyBytes);
+    incrementPositionAndCheck(pos, copyBytes);
     unsafe.copyMemory(
             srcArray,
             ARRAY_INT_BASE_OFFSET + (((long) srcOffset) << INT_SHIFT),
@@ -628,7 +608,7 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void putLong(final long value) {
     final long pos = getPosition();
-    incrementPosition(pos, ARRAY_LONG_INDEX_SCALE);
+    incrementPositionAndAssert(pos, ARRAY_LONG_INDEX_SCALE);
     unsafe.putLong(unsafeObj, cumBaseOffset + pos, value);
   }
 
@@ -643,8 +623,7 @@ class WritableBufferImpl extends WritableBuffer {
     final long pos = getPosition();
     final long copyBytes = ((long) length) << LONG_SHIFT;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
-    checkLimits(pos, copyBytes);
-    incrementPosition(pos, copyBytes);
+    incrementPositionAndCheck(pos, copyBytes);
     unsafe.copyMemory(
             srcArray,
             ARRAY_LONG_BASE_OFFSET + (((long) srcOffset) << LONG_SHIFT),
@@ -656,7 +635,7 @@ class WritableBufferImpl extends WritableBuffer {
   @Override
   public void putShort(final short value) {
     final long pos = getPosition();
-    incrementPosition(pos, ARRAY_SHORT_INDEX_SCALE);
+    incrementPositionAndAssert(pos, ARRAY_SHORT_INDEX_SCALE);
     unsafe.putShort(unsafeObj, cumBaseOffset + pos, value);
   }
 
@@ -671,8 +650,7 @@ class WritableBufferImpl extends WritableBuffer {
     final long pos = getPosition();
     final long copyBytes = ((long) length) << SHORT_SHIFT;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
-    checkLimits(pos, copyBytes);
-    incrementPosition(pos, copyBytes);
+    incrementPositionAndCheck(pos, copyBytes);
     unsafe.copyMemory(
             srcArray,
             ARRAY_SHORT_BASE_OFFSET + (((long) srcOffset) << SHORT_SHIFT),
@@ -706,7 +684,8 @@ class WritableBufferImpl extends WritableBuffer {
   public void fill(final byte value) {
     final long pos = getPosition();
     final long len = getEnd() - pos;
-    checkLimits(pos, len);
+    checkValid();
+    checkInvariants(getStart(), pos + len, getEnd(), getCapacity());
     unsafe.setMemory(unsafeObj, cumBaseOffset + pos, len, value);
   }
 }

--- a/src/main/java/com/yahoo/memory/WritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableBufferImpl.java
@@ -54,6 +54,7 @@ import java.nio.ByteOrder;
  * @author Lee Rhodes
  */
 class WritableBufferImpl extends WritableBuffer {
+  final ResourceState state;
   final Object unsafeObj; //Array objects are held here.
   final long unsafeObjHeader; //Heap ByteBuffer includes the slice() offset here.
   final long cumBaseOffset; //Holds the cumulative offset to the start of data.
@@ -69,6 +70,7 @@ class WritableBufferImpl extends WritableBuffer {
 
   WritableBufferImpl(final ResourceState state) {
     super(state);
+    this.state = state;
     unsafeObj = state.getUnsafeObject();
     unsafeObjHeader = state.getUnsafeObjectHeader();
     cumBaseOffset = state.getCumBaseOffset();
@@ -371,7 +373,7 @@ class WritableBufferImpl extends WritableBuffer {
   public int compareTo(final long thisOffsetBytes, final long thisLengthBytes, final Buffer that,
           final long thatOffsetBytes, final long thatLengthBytes) {
     state.checkValid();
-    that.state.checkValid();
+    that.getResourceState().checkValid();
     checkBounds(thisOffsetBytes, thisLengthBytes, capacity);
     checkBounds(thatOffsetBytes, thatLengthBytes, that.capacity);
     final long thisAdd = getCumulativeOffset() + thisOffsetBytes;
@@ -746,4 +748,9 @@ class WritableBufferImpl extends WritableBuffer {
     unsafe.setMemory(unsafeObj, cumBaseOffset + pos, len, value);
   }
 
+  @Override
+  final ResourceState getResourceState() {
+    state.assertValid();
+    return state;
+  }
 }

--- a/src/main/java/com/yahoo/memory/WritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableBufferImpl.java
@@ -28,7 +28,6 @@ import static com.yahoo.memory.UnsafeUtil.INT_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.LONG_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.LS;
 import static com.yahoo.memory.UnsafeUtil.SHORT_SHIFT;
-import static com.yahoo.memory.UnsafeUtil.assertBounds;
 import static com.yahoo.memory.UnsafeUtil.unsafe;
 
 import java.nio.ByteBuffer;
@@ -40,10 +39,8 @@ import java.nio.ByteOrder;
  * @author Lee Rhodes
  */
 class WritableBufferImpl extends WritableBuffer {
-  final ResourceState state;
   final Object unsafeObj; //Array objects are held here.
   final long unsafeObjHeader; //Heap ByteBuffer includes the slice() offset here.
-  final long capacity;
   final long cumBaseOffset; //Holds the cumulative offset to the start of data.
   //Static variable for cases where byteBuf/array sizes are zero
   final static WritableBufferImpl ZERO_SIZE_BUFFER;
@@ -56,10 +53,8 @@ class WritableBufferImpl extends WritableBuffer {
 
   WritableBufferImpl(final ResourceState state) {
     super(state);
-    this.state = state;
     unsafeObj = state.getUnsafeObject();
     unsafeObjHeader = state.getUnsafeObjectHeader();
-    capacity = state.getCapacity();
     cumBaseOffset = state.getCumBaseOffset();
   }
 
@@ -109,31 +104,27 @@ class WritableBufferImpl extends WritableBuffer {
   //MEMORY XXX
   @Override
   public Memory asMemory() {
-    assertValid();
+    checkValid();
     return new WritableMemoryImpl(state);
   }
 
   @Override
   public WritableMemory asWritableMemory() {
-    assertValid();
+    checkValid();
     return new WritableMemoryImpl(state);
   }
 
   //PRIMITIVE getXXX() and getXXXArray() XXX
   @Override
   public boolean getBoolean() {
-    assertValid();
     final long pos = getPosition();
-    assertBounds(pos, ARRAY_BOOLEAN_INDEX_SCALE, capacity);
-    final boolean ret = unsafe.getBoolean(unsafeObj, cumBaseOffset + pos);
-    incrementPosition(ARRAY_BOOLEAN_INDEX_SCALE);
-    return ret;
+    incrementPosition(pos, ARRAY_BOOLEAN_INDEX_SCALE);
+    return unsafe.getBoolean(unsafeObj, cumBaseOffset + pos);
   }
 
   @Override
   public boolean getBoolean(final long offsetBytes) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE);
     return unsafe.getBoolean(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
@@ -141,31 +132,27 @@ class WritableBufferImpl extends WritableBuffer {
   public void getBooleanArray(final boolean[] dstArray, final int dstOffset, final int length) {
     final long pos = getPosition();
     final long copyBytes = length;
-    checkBounds(pos, copyBytes);
+    checkLimits(pos, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
+    incrementPosition(pos, copyBytes);
     unsafe.copyMemory(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
             ARRAY_BOOLEAN_BASE_OFFSET + dstOffset,
             copyBytes);
-    incrementPosition(copyBytes);
   }
 
   @Override
   public byte getByte() {
-    assertValid();
     final long pos = getPosition();
-    assertBounds(pos, ARRAY_BYTE_INDEX_SCALE, capacity);
-    final byte ret = unsafe.getByte(unsafeObj, cumBaseOffset + pos);
-    incrementPosition(ARRAY_BYTE_INDEX_SCALE);
-    return ret;
+    incrementPosition(pos, ARRAY_BYTE_INDEX_SCALE);
+    return unsafe.getByte(unsafeObj, cumBaseOffset + pos);
   }
 
   @Override
   public byte getByte(final long offsetBytes) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE);
     return unsafe.getByte(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
@@ -173,31 +160,27 @@ class WritableBufferImpl extends WritableBuffer {
   public void getByteArray(final byte[] dstArray, final int dstOffset, final int length) {
     final long pos = getPosition();
     final long copyBytes = length;
-    checkBounds(pos, copyBytes);
+    checkLimits(pos, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
+    incrementPosition(pos, copyBytes);
     unsafe.copyMemory(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
             ARRAY_BYTE_BASE_OFFSET + dstOffset,
             copyBytes);
-    incrementPosition(copyBytes);
   }
 
   @Override
   public char getChar() {
-    assertValid();
     final long pos = getPosition();
-    assertBounds(pos, ARRAY_CHAR_INDEX_SCALE, capacity);
-    final char ret = unsafe.getChar(unsafeObj, cumBaseOffset + pos);
-    incrementPosition(ARRAY_CHAR_INDEX_SCALE);
-    return ret;
+    incrementPosition(pos, ARRAY_CHAR_INDEX_SCALE);
+    return unsafe.getChar(unsafeObj, cumBaseOffset + pos);
   }
 
   @Override
   public char getChar(final long offsetBytes) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE);
     return unsafe.getChar(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
@@ -205,31 +188,27 @@ class WritableBufferImpl extends WritableBuffer {
   public void getCharArray(final char[] dstArray, final int dstOffset, final int length) {
     final long pos = getPosition();
     final long copyBytes = ((long) length) << CHAR_SHIFT;
-    checkBounds(pos, copyBytes);
+    checkLimits(pos, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
+    incrementPosition(pos, copyBytes);
     unsafe.copyMemory(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
             ARRAY_CHAR_BASE_OFFSET + (((long) dstOffset) << CHAR_SHIFT),
             copyBytes);
-    incrementPosition(copyBytes);
   }
 
   @Override
   public double getDouble() {
-    assertValid();
     final long pos = getPosition();
-    assertBounds(pos, ARRAY_DOUBLE_INDEX_SCALE, capacity);
-    final double ret = unsafe.getDouble(unsafeObj, cumBaseOffset + pos);
-    incrementPosition(ARRAY_DOUBLE_INDEX_SCALE);
-    return ret;
+    incrementPosition(pos, ARRAY_DOUBLE_INDEX_SCALE);
+    return unsafe.getDouble(unsafeObj, cumBaseOffset + pos);
   }
 
   @Override
   public double getDouble(final long offsetBytes) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE);
     return unsafe.getDouble(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
@@ -237,31 +216,27 @@ class WritableBufferImpl extends WritableBuffer {
   public void getDoubleArray(final double[] dstArray, final int dstOffset, final int length) {
     final long pos = getPosition();
     final long copyBytes = ((long) length) << DOUBLE_SHIFT;
-    checkBounds(pos, copyBytes);
+    checkLimits(pos, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
+    incrementPosition(pos, copyBytes);
     unsafe.copyMemory(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
             ARRAY_DOUBLE_BASE_OFFSET + (((long) dstOffset) << DOUBLE_SHIFT),
             copyBytes);
-    incrementPosition(copyBytes);
   }
 
   @Override
   public float getFloat() {
-    assertValid();
     final long pos = getPosition();
-    assertBounds(pos, ARRAY_FLOAT_INDEX_SCALE, capacity);
-    final float ret = unsafe.getFloat(unsafeObj, cumBaseOffset + pos);
-    incrementPosition(ARRAY_FLOAT_INDEX_SCALE);
-    return ret;
+    incrementPosition(pos, ARRAY_FLOAT_INDEX_SCALE);
+    return unsafe.getFloat(unsafeObj, cumBaseOffset + pos);
   }
 
   @Override
   public float getFloat(final long offsetBytes) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE);
     return unsafe.getFloat(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
@@ -269,31 +244,27 @@ class WritableBufferImpl extends WritableBuffer {
   public void getFloatArray(final float[] dstArray, final int dstOffset, final int length) {
     final long pos = getPosition();
     final long copyBytes = ((long) length) << FLOAT_SHIFT;
-    checkBounds(pos, copyBytes);
+    checkLimits(pos, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
+    incrementPosition(pos, copyBytes);
     unsafe.copyMemory(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
             ARRAY_FLOAT_BASE_OFFSET + (((long) dstOffset) << FLOAT_SHIFT),
             copyBytes);
-    incrementPosition(copyBytes);
   }
 
   @Override
   public int getInt() {
-    assertValid();
     final long pos = getPosition();
-    assertBounds(pos, ARRAY_INT_INDEX_SCALE, capacity);
-    final int ret = unsafe.getInt(unsafeObj, cumBaseOffset + pos);
-    incrementPosition(ARRAY_INT_INDEX_SCALE);
-    return ret;
+    incrementPosition(pos, ARRAY_INT_INDEX_SCALE);
+    return unsafe.getInt(unsafeObj, cumBaseOffset + pos);
   }
 
   @Override
   public int getInt(final long offsetBytes) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE);
     return unsafe.getInt(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
@@ -301,31 +272,27 @@ class WritableBufferImpl extends WritableBuffer {
   public void getIntArray(final int[] dstArray, final int dstOffset, final int length) {
     final long pos = getPosition();
     final long copyBytes = ((long) length) << INT_SHIFT;
-    checkBounds(pos, copyBytes);
+    checkLimits(pos, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
+    incrementPosition(pos, copyBytes);
     unsafe.copyMemory(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
             ARRAY_INT_BASE_OFFSET + (((long) dstOffset) << INT_SHIFT),
             copyBytes);
-    incrementPosition(copyBytes);
   }
 
   @Override
   public long getLong() {
-    assertValid();
     final long pos = getPosition();
-    assertBounds(pos, ARRAY_LONG_INDEX_SCALE, capacity);
-    final long ret = unsafe.getLong(unsafeObj, cumBaseOffset + pos);
-    incrementPosition(ARRAY_LONG_INDEX_SCALE);
-    return ret;
+    incrementPosition(pos, ARRAY_LONG_INDEX_SCALE);
+    return unsafe.getLong(unsafeObj, cumBaseOffset + pos);
   }
 
   @Override
   public long getLong(final long offsetBytes) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE);
     return unsafe.getLong(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
@@ -333,31 +300,27 @@ class WritableBufferImpl extends WritableBuffer {
   public void getLongArray(final long[] dstArray, final int dstOffset, final int length) {
     final long pos = getPosition();
     final long copyBytes = ((long) length) << LONG_SHIFT;
-    checkBounds(pos, copyBytes);
+    checkLimits(pos, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
+    incrementPosition(pos, copyBytes);
     unsafe.copyMemory(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
             ARRAY_LONG_BASE_OFFSET + (((long) dstOffset) << LONG_SHIFT),
             copyBytes);
-    incrementPosition(copyBytes);
   }
 
   @Override
   public short getShort() {
-    assertValid();
     final long pos = getPosition();
-    assertBounds(pos, ARRAY_SHORT_INDEX_SCALE, capacity);
-    final short ret = unsafe.getShort(unsafeObj, cumBaseOffset + pos);
-    incrementPosition(ARRAY_SHORT_INDEX_SCALE);
-    return ret;
+    incrementPosition(pos, ARRAY_SHORT_INDEX_SCALE);
+    return unsafe.getShort(unsafeObj, cumBaseOffset + pos);
   }
 
   @Override
   public short getShort(final long offsetBytes) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE);
     return unsafe.getShort(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
@@ -365,24 +328,23 @@ class WritableBufferImpl extends WritableBuffer {
   public void getShortArray(final short[] dstArray, final int dstOffset, final int length) {
     final long pos = getPosition();
     final long copyBytes = ((long) length) << SHORT_SHIFT;
-    checkBounds(pos, copyBytes);
+    checkLimits(pos, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
+    incrementPosition(pos, copyBytes);
     unsafe.copyMemory(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
             ARRAY_SHORT_BASE_OFFSET + (((long) dstOffset) << SHORT_SHIFT),
             copyBytes);
-    incrementPosition(copyBytes);
   }
 
   //OTHER PRIMITIVE READ METHODS: copyTo, compareTo XXX
   @Override
   public int compareTo(final long thisOffsetBytes, final long thisLengthBytes, final Buffer that,
           final long thatOffsetBytes, final long thatLengthBytes) {
-    ((WritableBufferImpl)that).assertValid();
     checkBounds(thisOffsetBytes, thisLengthBytes);
-    UnsafeUtil.checkBounds(thatOffsetBytes, thatLengthBytes, that.getCapacity());
+    that.checkBounds(thatOffsetBytes, thatLengthBytes);
     final long thisAdd = getCumulativeOffset() + thisOffsetBytes;
     final long thatAdd = that.getCumulativeOffset() + thatOffsetBytes;
     final Object thisObj = (isDirect()) ? null : unsafeObj;
@@ -394,9 +356,7 @@ class WritableBufferImpl extends WritableBuffer {
       if (thisByte < thatByte) { return -1; }
       if (thisByte > thatByte) { return  1; }
     }
-    if (thisLengthBytes < thatLengthBytes) { return -1; }
-    if (thisLengthBytes > thatLengthBytes) { return  1; }
-    return 0;
+    return Long.compare(thisLengthBytes, thatLengthBytes);
   }
 
   //OTHER READ METHODS XXX
@@ -414,9 +374,20 @@ class WritableBufferImpl extends WritableBuffer {
   }
 
   @Override
-  public void checkBounds(final long offsetBytes, final long length) {
-    assertValid();
+  public void checkBounds(long offsetBytes, long length) {
+    checkValid();
     UnsafeUtil.checkBounds(offsetBytes, length, capacity);
+  }
+
+  @Override
+  public void checkLimits(final long offsetBytes, final long length) {
+    assertValid();
+    checkInvariants(getStart(), offsetBytes + length, getEnd(), getCapacity());
+  }
+
+  private void assertBounds(final long offsetBytes, final long length) {
+    assertValid();
+    UnsafeUtil.assertBounds(offsetBytes, length, capacity);
   }
 
   @Override
@@ -488,17 +459,14 @@ class WritableBufferImpl extends WritableBuffer {
   //PRIMITIVE putXXX() and putXXXArray() XXX
   @Override
   public void putBoolean(final boolean value) {
-    assertValid();
     final long pos = getPosition();
-    assertBounds(pos, ARRAY_BOOLEAN_INDEX_SCALE, capacity);
+    incrementPosition(pos, ARRAY_BOOLEAN_INDEX_SCALE);
     unsafe.putBoolean(unsafeObj, cumBaseOffset + pos, value);
-    incrementPosition(ARRAY_BOOLEAN_INDEX_SCALE);
   }
 
   @Override
   public void putBoolean(final long offsetBytes, final boolean value) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE);
     unsafe.putBoolean(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
@@ -507,30 +475,27 @@ class WritableBufferImpl extends WritableBuffer {
     final long pos = getPosition();
     final long copyBytes = length;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
-    checkBounds(pos, copyBytes);
+    checkLimits(pos, copyBytes);
+    incrementPosition(pos, copyBytes);
     unsafe.copyMemory(
             srcArray,
             ARRAY_BOOLEAN_BASE_OFFSET + srcOffset,
             unsafeObj,
             cumBaseOffset + pos,
-            copyBytes
-            );
-    incrementPosition(copyBytes);
+            copyBytes);
   }
 
   @Override
   public void putByte(final byte value) {
-    assertValid();
     final long pos = getPosition();
-    assertBounds(pos, ARRAY_BYTE_INDEX_SCALE, capacity);
+    assertBounds(pos, ARRAY_BYTE_INDEX_SCALE);
+    incrementPosition(pos, ARRAY_BYTE_INDEX_SCALE);
     unsafe.putByte(unsafeObj, cumBaseOffset + pos, value);
-    incrementPosition(ARRAY_BYTE_INDEX_SCALE);
   }
 
   @Override
   public void putByte(final long offsetBytes, final byte value) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_BYTE_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_BYTE_INDEX_SCALE);
     unsafe.putByte(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
@@ -539,30 +504,26 @@ class WritableBufferImpl extends WritableBuffer {
     final long pos = getPosition();
     final long copyBytes = length;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
-    checkBounds(pos, copyBytes);
+    checkLimits(pos, copyBytes);
+    incrementPosition(pos, copyBytes);
     unsafe.copyMemory(
             srcArray,
             ARRAY_BYTE_BASE_OFFSET + srcOffset,
             unsafeObj,
             cumBaseOffset + pos,
-            copyBytes
-            );
-    incrementPosition(copyBytes);
+            copyBytes);
   }
 
   @Override
   public void putChar(final char value) {
-    assertValid();
     final long pos = getPosition();
-    assertBounds(pos, ARRAY_CHAR_INDEX_SCALE, capacity);
+    incrementPosition(pos, ARRAY_CHAR_INDEX_SCALE);
     unsafe.putChar(unsafeObj, cumBaseOffset + pos, value);
-    incrementPosition(ARRAY_CHAR_INDEX_SCALE);
   }
 
   @Override
   public void putChar(final long offsetBytes, final char value) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_CHAR_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_CHAR_INDEX_SCALE);
     unsafe.putChar(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
@@ -571,30 +532,26 @@ class WritableBufferImpl extends WritableBuffer {
     final long pos = getPosition();
     final long copyBytes = ((long) length) << CHAR_SHIFT;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
-    checkBounds(pos, copyBytes);
+    checkLimits(pos, copyBytes);
+    incrementPosition(pos, copyBytes);
     unsafe.copyMemory(
             srcArray,
             ARRAY_CHAR_BASE_OFFSET + (((long) srcOffset) << CHAR_SHIFT),
             unsafeObj,
             cumBaseOffset + pos,
-            copyBytes
-            );
-    incrementPosition(copyBytes);
+            copyBytes);
   }
 
   @Override
   public void putDouble(final double value) {
-    assertValid();
     final long pos = getPosition();
-    assertBounds(pos, ARRAY_DOUBLE_INDEX_SCALE, capacity);
+    incrementPosition(pos, ARRAY_DOUBLE_INDEX_SCALE);
     unsafe.putDouble(unsafeObj, cumBaseOffset + pos, value);
-    incrementPosition(ARRAY_DOUBLE_INDEX_SCALE);
   }
 
   @Override
   public void putDouble(final long offsetBytes, final double value) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_DOUBLE_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_DOUBLE_INDEX_SCALE);
     unsafe.putDouble(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
@@ -603,30 +560,26 @@ class WritableBufferImpl extends WritableBuffer {
     final long pos = getPosition();
     final long copyBytes = ((long) length) << DOUBLE_SHIFT;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
-    checkBounds(pos, copyBytes);
+    checkLimits(pos, copyBytes);
+    incrementPosition(pos, copyBytes);
     unsafe.copyMemory(
             srcArray,
             ARRAY_DOUBLE_BASE_OFFSET + (((long) srcOffset) << DOUBLE_SHIFT),
             unsafeObj,
             cumBaseOffset + pos,
-            copyBytes
-            );
-    incrementPosition(copyBytes);
+            copyBytes);
   }
 
   @Override
   public void putFloat(final float value) {
-    assertValid();
     final long pos = getPosition();
-    assertBounds(pos, ARRAY_FLOAT_INDEX_SCALE, capacity);
+    incrementPosition(pos, ARRAY_FLOAT_INDEX_SCALE);
     unsafe.putFloat(unsafeObj, cumBaseOffset + pos, value);
-    incrementPosition(ARRAY_FLOAT_INDEX_SCALE);
   }
 
   @Override
   public void putFloat(final long offsetBytes, final float value) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_FLOAT_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_FLOAT_INDEX_SCALE);
     unsafe.putFloat(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
@@ -635,30 +588,26 @@ class WritableBufferImpl extends WritableBuffer {
     final long pos = getPosition();
     final long copyBytes = ((long) length) << FLOAT_SHIFT;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
-    checkBounds(pos, copyBytes);
+    checkLimits(pos, copyBytes);
+    incrementPosition(pos, copyBytes);
     unsafe.copyMemory(
             srcArray,
             ARRAY_FLOAT_BASE_OFFSET + (((long) srcOffset) << FLOAT_SHIFT),
             unsafeObj,
             cumBaseOffset + pos,
-            copyBytes
-            );
-    incrementPosition(copyBytes);
+            copyBytes);
   }
 
   @Override
   public void putInt(final int value) {
-    assertValid();
     final long pos = getPosition();
-    assertBounds(pos, ARRAY_INT_INDEX_SCALE, capacity);
+    incrementPosition(pos, ARRAY_INT_INDEX_SCALE);
     unsafe.putInt(unsafeObj, cumBaseOffset + pos, value);
-    incrementPosition(ARRAY_INT_INDEX_SCALE);
   }
 
   @Override
   public void putInt(final long offsetBytes, final int value) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_INT_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_INT_INDEX_SCALE);
     unsafe.putInt(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
@@ -667,30 +616,26 @@ class WritableBufferImpl extends WritableBuffer {
     final long pos = getPosition();
     final long copyBytes = ((long) length) << INT_SHIFT;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
-    checkBounds(pos, copyBytes);
+    checkLimits(pos, copyBytes);
+    incrementPosition(pos, copyBytes);
     unsafe.copyMemory(
             srcArray,
             ARRAY_INT_BASE_OFFSET + (((long) srcOffset) << INT_SHIFT),
             unsafeObj,
             cumBaseOffset + pos,
-            copyBytes
-            );
-    incrementPosition(copyBytes);
+            copyBytes);
   }
 
   @Override
   public void putLong(final long value) {
-    assertValid();
     final long pos = getPosition();
-    assertBounds(pos, ARRAY_LONG_INDEX_SCALE, capacity);
+    incrementPosition(pos, ARRAY_LONG_INDEX_SCALE);
     unsafe.putLong(unsafeObj, cumBaseOffset + pos, value);
-    incrementPosition(ARRAY_LONG_INDEX_SCALE);
   }
 
   @Override
   public void putLong(final long offsetBytes, final long value) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_LONG_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_LONG_INDEX_SCALE);
     unsafe.putLong(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
@@ -699,30 +644,26 @@ class WritableBufferImpl extends WritableBuffer {
     final long pos = getPosition();
     final long copyBytes = ((long) length) << LONG_SHIFT;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
-    checkBounds(pos, copyBytes);
+    checkLimits(pos, copyBytes);
+    incrementPosition(pos, copyBytes);
     unsafe.copyMemory(
             srcArray,
             ARRAY_LONG_BASE_OFFSET + (((long) srcOffset) << LONG_SHIFT),
             unsafeObj,
             cumBaseOffset + pos,
-            copyBytes
-            );
-    incrementPosition(copyBytes);
+            copyBytes);
   }
 
   @Override
   public void putShort(final short value) {
-    assertValid();
     final long pos = getPosition();
-    assertBounds(pos, ARRAY_SHORT_INDEX_SCALE, capacity);
+    incrementPosition(pos, ARRAY_SHORT_INDEX_SCALE);
     unsafe.putShort(unsafeObj, cumBaseOffset + pos, value);
-    incrementPosition(ARRAY_SHORT_INDEX_SCALE);
   }
 
   @Override
   public void putShort(final long offsetBytes, final short value) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_SHORT_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_SHORT_INDEX_SCALE);
     unsafe.putShort(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
@@ -731,15 +672,14 @@ class WritableBufferImpl extends WritableBuffer {
     final long pos = getPosition();
     final long copyBytes = ((long) length) << SHORT_SHIFT;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
-    checkBounds(pos, copyBytes);
+    checkLimits(pos, copyBytes);
+    incrementPosition(pos, copyBytes);
     unsafe.copyMemory(
             srcArray,
             ARRAY_SHORT_BASE_OFFSET + (((long) srcOffset) << SHORT_SHIFT),
             unsafeObj,
             cumBaseOffset + pos,
-            copyBytes
-            );
-    incrementPosition(copyBytes);
+            copyBytes);
   }
 
   //Atomic Write Methods XXX
@@ -767,17 +707,7 @@ class WritableBufferImpl extends WritableBuffer {
   public void fill(final byte value) {
     final long pos = getPosition();
     final long len = getEnd() - pos;
-    checkBounds(pos, len);
+    checkLimits(pos, len);
     unsafe.setMemory(unsafeObj, cumBaseOffset + pos, len, value);
-  }
-
-  //RESTRICTED READ AND WRITE XXX
-  private final void assertValid() { //applies to both readable and writable
-    assert state.isValid() : "Memory not valid.";
-  }
-
-  @Override
-  ResourceState getResourceState() {
-    return state;
   }
 }

--- a/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
@@ -31,7 +31,6 @@ import static com.yahoo.memory.UnsafeUtil.LONG_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.LS;
 import static com.yahoo.memory.UnsafeUtil.SHORT_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.UNSAFE_COPY_THRESHOLD;
-import static com.yahoo.memory.UnsafeUtil.assertBounds;
 import static com.yahoo.memory.UnsafeUtil.checkOverlap;
 import static com.yahoo.memory.UnsafeUtil.unsafe;
 
@@ -104,8 +103,7 @@ class WritableMemoryImpl extends WritableMemory {
   ///PRIMITIVE getXXX() and getXXXArray() XXX
   @Override
   public boolean getBoolean(final long offsetBytes) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE);
     return unsafe.getBoolean(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
@@ -125,8 +123,7 @@ class WritableMemoryImpl extends WritableMemory {
 
   @Override
   public byte getByte(final long offsetBytes) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_BYTE_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_BYTE_INDEX_SCALE);
     return unsafe.getByte(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
@@ -146,8 +143,7 @@ class WritableMemoryImpl extends WritableMemory {
 
   @Override
   public char getChar(final long offsetBytes) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_CHAR_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_CHAR_INDEX_SCALE);
     return unsafe.getChar(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
@@ -173,8 +169,7 @@ class WritableMemoryImpl extends WritableMemory {
 
   @Override
   public double getDouble(final long offsetBytes) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_DOUBLE_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_DOUBLE_INDEX_SCALE);
     return unsafe.getDouble(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
@@ -194,8 +189,7 @@ class WritableMemoryImpl extends WritableMemory {
 
   @Override
   public float getFloat(final long offsetBytes) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_FLOAT_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_FLOAT_INDEX_SCALE);
     return unsafe.getFloat(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
@@ -215,8 +209,7 @@ class WritableMemoryImpl extends WritableMemory {
 
   @Override
   public int getInt(final long offsetBytes) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_INT_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_INT_INDEX_SCALE);
     return unsafe.getInt(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
@@ -236,8 +229,7 @@ class WritableMemoryImpl extends WritableMemory {
 
   @Override
   public long getLong(final long offsetBytes) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_LONG_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_LONG_INDEX_SCALE);
     return unsafe.getLong(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
@@ -257,8 +249,7 @@ class WritableMemoryImpl extends WritableMemory {
 
   @Override
   public short getShort(final long offsetBytes) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_SHORT_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_SHORT_INDEX_SCALE);
     return unsafe.getShort(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
@@ -340,6 +331,11 @@ class WritableMemoryImpl extends WritableMemory {
     UnsafeUtil.checkBounds(offsetBytes, length, capacity);
   }
 
+  private void assertBounds(final long offsetBytes, final long length) {
+    assertValid();
+    UnsafeUtil.assertBounds(offsetBytes, length, capacity);
+  }
+
   @Override
   public long getRegionOffset(final long offsetBytes) {
     assertValid();
@@ -409,8 +405,7 @@ class WritableMemoryImpl extends WritableMemory {
   //PRIMITIVE putXXX() and putXXXArray() implementations XXX
   @Override
   public void putBoolean(final long offsetBytes, final boolean value) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE);
     unsafe.putBoolean(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
@@ -431,8 +426,7 @@ class WritableMemoryImpl extends WritableMemory {
 
   @Override
   public void putByte(final long offsetBytes, final byte value) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_BYTE_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_BYTE_INDEX_SCALE);
     unsafe.putByte(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
@@ -453,8 +447,7 @@ class WritableMemoryImpl extends WritableMemory {
 
   @Override
   public void putChar(final long offsetBytes, final char value) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_CHAR_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_CHAR_INDEX_SCALE);
     unsafe.putChar(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
@@ -480,8 +473,7 @@ class WritableMemoryImpl extends WritableMemory {
 
   @Override
   public void putDouble(final long offsetBytes, final double value) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_DOUBLE_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_DOUBLE_INDEX_SCALE);
     unsafe.putDouble(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
@@ -502,8 +494,7 @@ class WritableMemoryImpl extends WritableMemory {
 
   @Override
   public void putFloat(final long offsetBytes, final float value) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_FLOAT_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_FLOAT_INDEX_SCALE);
     unsafe.putFloat(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
@@ -524,8 +515,7 @@ class WritableMemoryImpl extends WritableMemory {
 
   @Override
   public void putInt(final long offsetBytes, final int value) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_INT_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_INT_INDEX_SCALE);
     unsafe.putInt(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
@@ -546,8 +536,7 @@ class WritableMemoryImpl extends WritableMemory {
 
   @Override
   public void putLong(final long offsetBytes, final long value) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_LONG_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_LONG_INDEX_SCALE);
     unsafe.putLong(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
@@ -568,8 +557,7 @@ class WritableMemoryImpl extends WritableMemory {
 
   @Override
   public void putShort(final long offsetBytes, final short value) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_SHORT_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_SHORT_INDEX_SCALE);
     unsafe.putShort(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
@@ -591,24 +579,21 @@ class WritableMemoryImpl extends WritableMemory {
   //Atomic Write Methods XXX
   @Override
   public long getAndAddLong(final long offsetBytes, final long delta) { //JDK 8+
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_LONG_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_LONG_INDEX_SCALE);
     final long add = cumBaseOffset + offsetBytes;
     return UnsafeUtil.compatibilityMethods.getAndAddLong(unsafeObj, add, delta) + delta;
   }
 
   @Override
   public long getAndSetLong(final long offsetBytes, final long newValue) { //JDK 8+
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_LONG_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_LONG_INDEX_SCALE);
     final long add = cumBaseOffset + offsetBytes;
     return UnsafeUtil.compatibilityMethods.getAndSetLong(unsafeObj, add, newValue);
   }
 
   @Override
   public boolean compareAndSwapLong(final long offsetBytes, final long expect, final long update) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_LONG_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_LONG_INDEX_SCALE);
     return unsafe.compareAndSwapLong(unsafeObj, cumBaseOffset + offsetBytes, expect, update);
   }
 
@@ -637,8 +622,7 @@ class WritableMemoryImpl extends WritableMemory {
 
   @Override
   public void clearBits(final long offsetBytes, final byte bitMask) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_BYTE_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_BYTE_INDEX_SCALE);
     final long cumBaseOff = cumBaseOffset + offsetBytes;
     int value = unsafe.getByte(unsafeObj, cumBaseOff) & 0XFF;
     value &= ~bitMask;
@@ -658,8 +642,7 @@ class WritableMemoryImpl extends WritableMemory {
 
   @Override
   public void setBits(final long offsetBytes, final byte bitMask) {
-    assertValid();
-    assertBounds(offsetBytes, ARRAY_BYTE_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_BYTE_INDEX_SCALE);
     final long myOffset = cumBaseOffset + offsetBytes;
     final byte value = unsafe.getByte(unsafeObj, myOffset);
     unsafe.putByte(unsafeObj, myOffset, (byte)(value | bitMask));

--- a/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
@@ -21,8 +21,6 @@ import static com.yahoo.memory.UnsafeUtil.ARRAY_LONG_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_LONG_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_SHORT_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_SHORT_INDEX_SCALE;
-import static com.yahoo.memory.UnsafeUtil.BOOLEAN_SHIFT;
-import static com.yahoo.memory.UnsafeUtil.BYTE_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.CHAR_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.DOUBLE_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.FLOAT_SHIFT;
@@ -110,14 +108,14 @@ class WritableMemoryImpl extends WritableMemory {
   @Override
   public void getBooleanArray(final long offsetBytes, final boolean[] dstArray, final int dstOffset,
       final int length) {
-    final long copyBytes = length << BOOLEAN_SHIFT;
+    final long copyBytes = length;
     checkBounds(offsetBytes, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
     unsafe.copyMemory(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
-        ARRAY_BOOLEAN_BASE_OFFSET + (dstOffset << BOOLEAN_SHIFT),
+        ARRAY_BOOLEAN_BASE_OFFSET + dstOffset,
         copyBytes);
   }
 
@@ -130,14 +128,14 @@ class WritableMemoryImpl extends WritableMemory {
   @Override
   public void getByteArray(final long offsetBytes, final byte[] dstArray, final int dstOffset,
       final int length) {
-    final long copyBytes = length << BYTE_SHIFT;
+    final long copyBytes = length;
     checkBounds(offsetBytes, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
     unsafe.copyMemory(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
-        ARRAY_BYTE_BASE_OFFSET + (dstOffset << BYTE_SHIFT),
+        ARRAY_BYTE_BASE_OFFSET + dstOffset,
         copyBytes);
   }
 
@@ -150,14 +148,14 @@ class WritableMemoryImpl extends WritableMemory {
   @Override
   public void getCharArray(final long offsetBytes, final char[] dstArray, final int dstOffset,
       final int length) {
-    final long copyBytes = length << CHAR_SHIFT;
+    final long copyBytes = ((long) length) << CHAR_SHIFT;
     checkBounds(offsetBytes, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
     unsafe.copyMemory(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
-        ARRAY_CHAR_BASE_OFFSET + (dstOffset << CHAR_SHIFT),
+        ARRAY_CHAR_BASE_OFFSET + (((long) dstOffset) << CHAR_SHIFT),
         copyBytes);
   }
 
@@ -176,14 +174,14 @@ class WritableMemoryImpl extends WritableMemory {
   @Override
   public void getDoubleArray(final long offsetBytes, final double[] dstArray, final int dstOffset,
       final int length) {
-    final long copyBytes = length << DOUBLE_SHIFT;
+    final long copyBytes = ((long) length) << DOUBLE_SHIFT;
     checkBounds(offsetBytes, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
     unsafe.copyMemory(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
-        ARRAY_DOUBLE_BASE_OFFSET + (dstOffset << DOUBLE_SHIFT),
+        ARRAY_DOUBLE_BASE_OFFSET + (((long) dstOffset) << DOUBLE_SHIFT),
         copyBytes);
   }
 
@@ -196,14 +194,14 @@ class WritableMemoryImpl extends WritableMemory {
   @Override
   public void getFloatArray(final long offsetBytes, final float[] dstArray, final int dstOffset,
       final int length) {
-    final long copyBytes = length << FLOAT_SHIFT;
+    final long copyBytes = ((long) length) << FLOAT_SHIFT;
     checkBounds(offsetBytes, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
     unsafe.copyMemory(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
-        ARRAY_FLOAT_BASE_OFFSET + (dstOffset << FLOAT_SHIFT),
+        ARRAY_FLOAT_BASE_OFFSET + (((long) dstOffset) << FLOAT_SHIFT),
         copyBytes);
   }
 
@@ -216,14 +214,14 @@ class WritableMemoryImpl extends WritableMemory {
   @Override
   public void getIntArray(final long offsetBytes, final int[] dstArray, final int dstOffset,
       final int length) {
-    final long copyBytes = length << INT_SHIFT;
+    final long copyBytes = ((long) length) << INT_SHIFT;
     checkBounds(offsetBytes, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
     unsafe.copyMemory(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
-        ARRAY_INT_BASE_OFFSET + (dstOffset << INT_SHIFT),
+        ARRAY_INT_BASE_OFFSET + (((long) dstOffset) << INT_SHIFT),
         copyBytes);
   }
 
@@ -236,14 +234,14 @@ class WritableMemoryImpl extends WritableMemory {
   @Override
   public void getLongArray(final long offsetBytes, final long[] dstArray, final int dstOffset,
       final int length) {
-    final long copyBytes = length << LONG_SHIFT;
+    final long copyBytes = ((long) length) << LONG_SHIFT;
     checkBounds(offsetBytes, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
     unsafe.copyMemory(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
-        ARRAY_LONG_BASE_OFFSET + (dstOffset << LONG_SHIFT),
+        ARRAY_LONG_BASE_OFFSET + (((long) dstOffset) << LONG_SHIFT),
         copyBytes);
   }
 
@@ -256,14 +254,14 @@ class WritableMemoryImpl extends WritableMemory {
   @Override
   public void getShortArray(final long offsetBytes, final short[] dstArray, final int dstOffset,
       final int length) {
-    final long copyBytes = length << SHORT_SHIFT;
+    final long copyBytes = ((long) length) << SHORT_SHIFT;
     checkBounds(offsetBytes, copyBytes);
     UnsafeUtil.checkBounds(dstOffset, length, dstArray.length);
     unsafe.copyMemory(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
-        ARRAY_SHORT_BASE_OFFSET + (dstOffset << SHORT_SHIFT),
+        ARRAY_SHORT_BASE_OFFSET + (((long) dstOffset) << SHORT_SHIFT),
         copyBytes);
   }
 
@@ -412,12 +410,12 @@ class WritableMemoryImpl extends WritableMemory {
   @Override
   public void putBooleanArray(final long offsetBytes, final boolean[] srcArray, final int srcOffset,
       final int length) {
-    final long copyBytes = length << BOOLEAN_SHIFT;
+    final long copyBytes = length;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
     checkBounds(offsetBytes, copyBytes);
     unsafe.copyMemory(
         srcArray,
-        ARRAY_BOOLEAN_BASE_OFFSET + (srcOffset << BOOLEAN_SHIFT),
+        ARRAY_BOOLEAN_BASE_OFFSET + srcOffset,
         unsafeObj,
         cumBaseOffset + offsetBytes,
         copyBytes
@@ -433,12 +431,12 @@ class WritableMemoryImpl extends WritableMemory {
   @Override
   public void putByteArray(final long offsetBytes, final byte[] srcArray, final int srcOffset,
       final int length) {
-    final long copyBytes = length << BYTE_SHIFT;
+    final long copyBytes = length;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
     checkBounds(offsetBytes, copyBytes);
     unsafe.copyMemory(
         srcArray,
-        ARRAY_BYTE_BASE_OFFSET + (srcOffset << BYTE_SHIFT),
+        ARRAY_BYTE_BASE_OFFSET + srcOffset,
         unsafeObj,
         cumBaseOffset + offsetBytes,
         copyBytes
@@ -454,12 +452,12 @@ class WritableMemoryImpl extends WritableMemory {
   @Override
   public void putCharArray(final long offsetBytes, final char[] srcArray, final int srcOffset,
       final int length) {
-    final long copyBytes = length << CHAR_SHIFT;
+    final long copyBytes = ((long) length) << CHAR_SHIFT;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
     checkBounds(offsetBytes, copyBytes);
     unsafe.copyMemory(
         srcArray,
-        ARRAY_CHAR_BASE_OFFSET + (srcOffset << CHAR_SHIFT),
+        ARRAY_CHAR_BASE_OFFSET + (((long) srcOffset) << CHAR_SHIFT),
         unsafeObj,
         cumBaseOffset + offsetBytes,
         copyBytes
@@ -480,12 +478,12 @@ class WritableMemoryImpl extends WritableMemory {
   @Override
   public void putDoubleArray(final long offsetBytes, final double[] srcArray, final int srcOffset,
       final int length) {
-    final long copyBytes = length << DOUBLE_SHIFT;
+    final long copyBytes = ((long) length) << DOUBLE_SHIFT;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
     checkBounds(offsetBytes, copyBytes);
     unsafe.copyMemory(
         srcArray,
-        ARRAY_DOUBLE_BASE_OFFSET + (srcOffset << DOUBLE_SHIFT),
+        ARRAY_DOUBLE_BASE_OFFSET + (((long) srcOffset) << DOUBLE_SHIFT),
         unsafeObj,
         cumBaseOffset + offsetBytes,
         copyBytes
@@ -501,12 +499,12 @@ class WritableMemoryImpl extends WritableMemory {
   @Override
   public void putFloatArray(final long offsetBytes, final float[] srcArray, final int srcOffset,
       final int length) {
-    final long copyBytes = length << FLOAT_SHIFT;
+    final long copyBytes = ((long) length) << FLOAT_SHIFT;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
     checkBounds(offsetBytes, copyBytes);
     unsafe.copyMemory(
         srcArray,
-        ARRAY_FLOAT_BASE_OFFSET + (srcOffset << FLOAT_SHIFT),
+        ARRAY_FLOAT_BASE_OFFSET + (((long) srcOffset) << FLOAT_SHIFT),
         unsafeObj,
         cumBaseOffset + offsetBytes,
         copyBytes
@@ -522,12 +520,12 @@ class WritableMemoryImpl extends WritableMemory {
   @Override
   public void putIntArray(final long offsetBytes, final int[] srcArray, final int srcOffset,
       final int length) {
-    final long copyBytes = length << INT_SHIFT;
+    final long copyBytes = ((long) length) << INT_SHIFT;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
     checkBounds(offsetBytes, copyBytes);
     unsafe.copyMemory(
         srcArray,
-        ARRAY_INT_BASE_OFFSET + (srcOffset << INT_SHIFT),
+        ARRAY_INT_BASE_OFFSET + (((long) srcOffset) << INT_SHIFT),
         unsafeObj,
         cumBaseOffset + offsetBytes,
         copyBytes
@@ -543,12 +541,12 @@ class WritableMemoryImpl extends WritableMemory {
   @Override
   public void putLongArray(final long offsetBytes, final long[] srcArray, final int srcOffset,
       final int length) {
-    final long copyBytes = length << LONG_SHIFT;
+    final long copyBytes = ((long) length) << LONG_SHIFT;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
     checkBounds(offsetBytes, copyBytes);
     unsafe.copyMemory(
         srcArray,
-        ARRAY_LONG_BASE_OFFSET + (srcOffset << LONG_SHIFT),
+        ARRAY_LONG_BASE_OFFSET + (((long) srcOffset) << LONG_SHIFT),
         unsafeObj,
         cumBaseOffset + offsetBytes,
         copyBytes
@@ -564,12 +562,12 @@ class WritableMemoryImpl extends WritableMemory {
   @Override
   public void putShortArray(final long offsetBytes, final short[] srcArray, final int srcOffset,
       final int length) {
-    final long copyBytes = length << SHORT_SHIFT;
+    final long copyBytes = ((long) length) << SHORT_SHIFT;
     UnsafeUtil.checkBounds(srcOffset, length, srcArray.length);
     checkBounds(offsetBytes, copyBytes);
     unsafe.copyMemory(
         srcArray,
-        ARRAY_SHORT_BASE_OFFSET + (srcOffset << SHORT_SHIFT),
+        ARRAY_SHORT_BASE_OFFSET + (((long) srcOffset) << SHORT_SHIFT),
         unsafeObj,
         cumBaseOffset + offsetBytes,
         copyBytes

--- a/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
@@ -304,6 +304,8 @@ class WritableMemoryImpl extends WritableMemory {
   public int compareTo(final long thisOffsetBytes, final long thisLengthBytes, final Memory that,
       final long thatOffsetBytes, final long thatLengthBytes) {
     state.checkValid();
+    checkBounds(thisOffsetBytes, thisLengthBytes, capacity);
+    checkBounds(thatOffsetBytes, thatLengthBytes, that.getCapacity());
     if (isSameResource(that)) {
       if (thisOffsetBytes == thatOffsetBytes) {
         return 0;
@@ -311,8 +313,6 @@ class WritableMemoryImpl extends WritableMemory {
     } else {
       that.getResourceState().checkValid();
     }
-    checkBounds(thisOffsetBytes, thisLengthBytes, capacity);
-    checkBounds(thatOffsetBytes, thatLengthBytes, that.getCapacity());
     final long thisAdd = getCumulativeOffset(thisOffsetBytes);
     final long thatAdd = that.getCumulativeOffset(thatOffsetBytes);
     final Object thisObj = (isDirect()) ? null : unsafeObj;
@@ -331,6 +331,8 @@ class WritableMemoryImpl extends WritableMemory {
   public void copyTo(final long srcOffsetBytes, final WritableMemory destination,
       final long dstOffsetBytes, final long lengthBytes) {
     state.checkValid();
+    checkBounds(srcOffsetBytes, lengthBytes, capacity);
+    checkBounds(dstOffsetBytes, lengthBytes, destination.getCapacity());
     if (isSameResource(destination)) {
       if (srcOffsetBytes == dstOffsetBytes) {
         return;
@@ -338,9 +340,6 @@ class WritableMemoryImpl extends WritableMemory {
     } else {
       destination.getResourceState().checkValid();
     }
-    checkBounds(srcOffsetBytes, lengthBytes, capacity);
-    checkBounds(dstOffsetBytes, lengthBytes, destination.getCapacity());
-
     final long srcAdd = getCumulativeOffset(srcOffsetBytes);
     final long dstAdd = destination.getCumulativeOffset(dstOffsetBytes);
     final Object srcParent = (isDirect()) ? null : unsafeObj;

--- a/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
@@ -608,7 +608,7 @@ class WritableMemoryImpl extends WritableMemory {
   @Override
   public boolean compareAndSwapLong(final long offsetBytes, final long expect, final long update) {
     assertValid();
-    assertBounds(offsetBytes, ARRAY_INT_INDEX_SCALE, capacity);
+    assertBounds(offsetBytes, ARRAY_LONG_INDEX_SCALE, capacity);
     return unsafe.compareAndSwapLong(unsafeObj, cumBaseOffset + offsetBytes, expect, update);
   }
 

--- a/src/test/java/com/yahoo/memory/ArrayOverflowTest.java
+++ b/src/test/java/com/yahoo/memory/ArrayOverflowTest.java
@@ -7,8 +7,10 @@ package com.yahoo.memory;
 
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
+@Ignore("Test causes OutOfMemoryError in Travis CI, run only locally")
 public class ArrayOverflowTest {
 
   private WritableDirectHandle h;

--- a/src/test/java/com/yahoo/memory/ArrayOverflowTest.java
+++ b/src/test/java/com/yahoo/memory/ArrayOverflowTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017, Yahoo! Inc. Licensed under the terms of the
+ * Apache License 2.0. See LICENSE file at the project root for terms.
+ */
+
+package com.yahoo.memory;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class ArrayOverflowTest {
+
+  private WritableDirectHandle h;
+  private WritableMemory memory;
+
+  @BeforeClass
+  public void allocate() {
+    h = WritableMemory.allocateDirect(Integer.MAX_VALUE + 100L);
+    memory = h.get();
+  }
+
+  @AfterClass
+  public void close() {
+    h.close();
+  }
+
+  @Test
+  public void testCharArray() {
+    int size = (int) (memory.getCapacity() / 2);
+    char[] array = new char[size];
+    memory.getCharArray(0, array, 0, size);
+    memory.asBuffer().getCharArray(array, 0, size);
+    memory.putCharArray(0, array, 0, size);
+    memory.asWritableBuffer().putCharArray(array, 0, size);
+  }
+
+  @Test
+  public void testShortArray() {
+    int size = (int) (memory.getCapacity() / 2);
+    short[] array = new short[size];
+    memory.getShortArray(0, array, 0, size);
+    memory.asBuffer().getShortArray(array, 0, size);
+    memory.putShortArray(0, array, 0, size);
+    memory.asWritableBuffer().putShortArray(array, 0, size);
+  }
+
+  @Test
+  public void testIntArray() {
+    int size = (int) (memory.getCapacity() / 4);
+    int[] array = new int[size];
+    memory.getIntArray(0, array, 0, size);
+    memory.asBuffer().getIntArray(array, 0, size);
+    memory.putIntArray(0, array, 0, size);
+    memory.asWritableBuffer().putIntArray(array, 0, size);
+  }
+
+  @Test
+  public void testFloatArray() {
+    int size = (int) (memory.getCapacity() / 4);
+    float[] array = new float[size];
+    memory.getFloatArray(0, array, 0, size);
+    memory.asBuffer().getFloatArray(array, 0, size);
+    memory.putFloatArray(0, array, 0, size);
+    memory.asWritableBuffer().putFloatArray(array, 0, size);
+  }
+
+  @Test
+  public void testLongArray() {
+    int size = (int) (memory.getCapacity() / 8);
+    long[] array = new long[size];
+    memory.getLongArray(0, array, 0, size);
+    memory.asBuffer().getLongArray(array, 0, size);
+    memory.putLongArray(0, array, 0, size);
+    memory.asWritableBuffer().putLongArray(array, 0, size);
+  }
+
+  @Test
+  public void testDoubleArray() {
+    int size = (int) (memory.getCapacity() / 8);
+    double[] array = new double[size];
+    memory.getDoubleArray(0, array, 0, size);
+    memory.asBuffer().getDoubleArray(array, 0, size);
+    memory.putDoubleArray(0, array, 0, size);
+    memory.asWritableBuffer().putDoubleArray(array, 0, size);
+  }
+}

--- a/src/test/java/com/yahoo/memory/BaseBufferTest.java
+++ b/src/test/java/com/yahoo/memory/BaseBufferTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018, Yahoo! Inc. Licensed under the terms of the
+ * Apache License 2.0. See LICENSE file at the project root for terms.
+ */
+
+package com.yahoo.memory;
+
+import static org.testng.Assert.fail;
+
+import org.testng.annotations.Test;
+
+/**
+ * @author Lee Rhodes
+ */
+public class BaseBufferTest {
+
+  @Test
+  public void checkLimits() {
+    Buffer buf = Buffer.wrap(new byte[100]);
+    buf.setStartPositionEnd(40, 45, 50);
+    buf.setStartPositionEnd(0, 0, 100);
+    try {
+      buf.setStartPositionEnd(0, 0, 101);
+      fail();
+    } catch (AssertionError e) {
+      //ok
+    }
+  }
+
+  @Test
+  public void checkLimitsAndCheck() {
+    Buffer buf = Buffer.wrap(new byte[100]);
+    buf.setStartPositionEndAndCheck(40, 45, 50);
+    buf.setStartPositionEndAndCheck(0, 0, 100);
+    try {
+      buf.setStartPositionEndAndCheck(0, 0, 101);
+      fail();
+    } catch (IllegalArgumentException e) {
+      //ok
+    }
+    buf.setPositionAndCheck(100);
+    try {
+      buf.setPositionAndCheck(101);
+      fail();
+    } catch (IllegalArgumentException e) {
+      //ok
+    }
+    buf.setPosition(99);
+    buf.incrementPositionAndCheck(1L);
+    try {
+      buf.incrementPositionAndCheck(1L);
+      fail();
+    } catch (IllegalArgumentException e) {
+      //ok
+    }
+  }
+
+  @Test
+  public void checkCheckValid() {
+    WritableMemory wmem;
+    Buffer buf;
+    try (WritableDirectHandle hand = WritableMemory.allocateDirect(100)) {
+      wmem = hand.get();
+      buf = wmem.asBuffer();
+    }
+    try {
+      @SuppressWarnings("unused")
+      Memory mem = buf.asMemory();
+      fail();
+    } catch (IllegalStateException e) {
+      //ok
+    }
+  }
+}

--- a/src/test/java/com/yahoo/memory/BaseBufferTest.java
+++ b/src/test/java/com/yahoo/memory/BaseBufferTest.java
@@ -30,25 +30,25 @@ public class BaseBufferTest {
   @Test
   public void checkLimitsAndCheck() {
     Buffer buf = Buffer.wrap(new byte[100]);
-    buf.setStartPositionEndAndCheck(40, 45, 50);
-    buf.setStartPositionEndAndCheck(0, 0, 100);
+    buf.setAndCheckStartPositionEnd(40, 45, 50);
+    buf.setAndCheckStartPositionEnd(0, 0, 100);
     try {
-      buf.setStartPositionEndAndCheck(0, 0, 101);
+      buf.setAndCheckStartPositionEnd(0, 0, 101);
       fail();
     } catch (IllegalArgumentException e) {
       //ok
     }
-    buf.setPositionAndCheck(100);
+    buf.setAndCheckPosition(100);
     try {
-      buf.setPositionAndCheck(101);
+      buf.setAndCheckPosition(101);
       fail();
     } catch (IllegalArgumentException e) {
       //ok
     }
     buf.setPosition(99);
-    buf.incrementPositionAndCheck(1L);
+    buf.incrementAndCheckPosition(1L);
     try {
-      buf.incrementPositionAndCheck(1L);
+      buf.incrementAndCheckPosition(1L);
       fail();
     } catch (IllegalArgumentException e) {
       //ok

--- a/src/test/java/com/yahoo/memory/BufferBoundaryCheckTest.java
+++ b/src/test/java/com/yahoo/memory/BufferBoundaryCheckTest.java
@@ -7,15 +7,15 @@ package com.yahoo.memory;
 
 import org.testng.annotations.Test;
 
-public class MemoryBoundaryCheckTest {
+public class BufferBoundaryCheckTest {
 
-  private final WritableBuffer writableBuffer = WritableMemory.allocate(8).asWritableBuffer();
+  private final WritableMemory writableMemory = WritableMemory.allocate(8);
 
   @Test
   public void testGetBoolean() {
-    writableBuffer.getBoolean(7);
+    writableMemory.getBoolean(7);
     try {
-      writableBuffer.getBoolean(8);
+      writableMemory.getBoolean(8);
       throw new RuntimeException("Expected AssertionError");
     } catch (final AssertionError expected) {
       // ignore
@@ -24,9 +24,9 @@ public class MemoryBoundaryCheckTest {
 
   @Test
   public void testPutBoolean() {
-    writableBuffer.putBoolean(7, true);
+    writableMemory.putBoolean(7, true);
     try {
-      writableBuffer.putBoolean(8, true);
+      writableMemory.putBoolean(8, true);
       throw new RuntimeException("Expected AssertionError");
     } catch (final AssertionError expected) {
       // ignore
@@ -35,9 +35,9 @@ public class MemoryBoundaryCheckTest {
 
   @Test
   public void testGetByte() {
-    writableBuffer.getByte(7);
+    writableMemory.getByte(7);
     try {
-      writableBuffer.getByte(8);
+      writableMemory.getByte(8);
       throw new RuntimeException("Expected AssertionError");
     } catch (final AssertionError expected) {
       // ignore
@@ -46,9 +46,9 @@ public class MemoryBoundaryCheckTest {
 
   @Test
   public void testPutByte() {
-    writableBuffer.putByte(7, (byte) 1);
+    writableMemory.putByte(7, (byte) 1);
     try {
-      writableBuffer.putByte(8, (byte) 1);
+      writableMemory.putByte(8, (byte) 1);
       throw new RuntimeException("Expected AssertionError");
     } catch (final AssertionError expected) {
       // ignore
@@ -57,9 +57,9 @@ public class MemoryBoundaryCheckTest {
 
   @Test
   public void testGetChar() {
-    writableBuffer.getChar(6);
+    writableMemory.getChar(6);
     try {
-      writableBuffer.getChar(7);
+      writableMemory.getChar(7);
       throw new RuntimeException("Expected AssertionError");
     } catch (final AssertionError expected) {
       // ignore
@@ -68,9 +68,9 @@ public class MemoryBoundaryCheckTest {
 
   @Test
   public void testPutChar() {
-    writableBuffer.putChar(6, 'a');
+    writableMemory.putChar(6, 'a');
     try {
-      writableBuffer.putChar(7, 'a');
+      writableMemory.putChar(7, 'a');
       throw new RuntimeException("Expected AssertionError");
     } catch (final AssertionError expected) {
       // ignore
@@ -79,9 +79,9 @@ public class MemoryBoundaryCheckTest {
 
   @Test
   public void testGetShort() {
-    writableBuffer.getShort(6);
+    writableMemory.getShort(6);
     try {
-      writableBuffer.getShort(7);
+      writableMemory.getShort(7);
       throw new RuntimeException("Expected AssertionError");
     } catch (final AssertionError expected) {
       // ignore
@@ -90,9 +90,9 @@ public class MemoryBoundaryCheckTest {
 
   @Test
   public void testPutShort() {
-    writableBuffer.putShort(6, (short) 1);
+    writableMemory.putShort(6, (short) 1);
     try {
-      writableBuffer.putShort(7, (short) 1);
+      writableMemory.putShort(7, (short) 1);
       throw new RuntimeException("Expected AssertionError");
     } catch (final AssertionError expected) {
       // ignore
@@ -101,9 +101,9 @@ public class MemoryBoundaryCheckTest {
 
   @Test
   public void testGetInt() {
-    writableBuffer.getInt(4);
+    writableMemory.getInt(4);
     try {
-      writableBuffer.getInt(5);
+      writableMemory.getInt(5);
       throw new RuntimeException("Expected AssertionError");
     } catch (final AssertionError expected) {
       // ignore
@@ -112,9 +112,9 @@ public class MemoryBoundaryCheckTest {
 
   @Test
   public void testPutInt() {
-    writableBuffer.putInt(4, 1);
+    writableMemory.putInt(4, 1);
     try {
-      writableBuffer.putInt(5, 1);
+      writableMemory.putInt(5, 1);
       throw new RuntimeException("Expected AssertionError");
     } catch (final AssertionError expected) {
       // ignore
@@ -123,9 +123,9 @@ public class MemoryBoundaryCheckTest {
 
   @Test
   public void testGetFloat() {
-    writableBuffer.getFloat(4);
+    writableMemory.getFloat(4);
     try {
-      writableBuffer.getFloat(5);
+      writableMemory.getFloat(5);
       throw new RuntimeException("Expected AssertionError");
     } catch (final AssertionError expected) {
       // ignore
@@ -134,9 +134,9 @@ public class MemoryBoundaryCheckTest {
 
   @Test
   public void testPutFloat() {
-    writableBuffer.putFloat(4, 1f);
+    writableMemory.putFloat(4, 1f);
     try {
-      writableBuffer.putFloat(5, 1f);
+      writableMemory.putFloat(5, 1f);
       throw new RuntimeException("Expected AssertionError");
     } catch (final AssertionError expected) {
       // ignore
@@ -145,9 +145,9 @@ public class MemoryBoundaryCheckTest {
 
   @Test
   public void testGetLong() {
-    writableBuffer.getLong(0);
+    writableMemory.getLong(0);
     try {
-      writableBuffer.getLong(1);
+      writableMemory.getLong(1);
       throw new RuntimeException("Expected AssertionError");
     } catch (final AssertionError expected) {
       // ignore
@@ -156,9 +156,9 @@ public class MemoryBoundaryCheckTest {
 
   @Test
   public void testPutLong() {
-    writableBuffer.putLong(0, 1L);
+    writableMemory.putLong(0, 1L);
     try {
-      writableBuffer.putLong(1, 1L);
+      writableMemory.putLong(1, 1L);
       throw new RuntimeException("Expected AssertionError");
     } catch (final AssertionError expected) {
       // ignore
@@ -167,9 +167,9 @@ public class MemoryBoundaryCheckTest {
 
   @Test
   public void testGetDouble() {
-    writableBuffer.getDouble(0);
+    writableMemory.getDouble(0);
     try {
-      writableBuffer.getDouble(1);
+      writableMemory.getDouble(1);
       throw new RuntimeException("Expected AssertionError");
     } catch (final AssertionError expected) {
       // ignore
@@ -178,9 +178,42 @@ public class MemoryBoundaryCheckTest {
 
   @Test
   public void testPutDouble() {
-    writableBuffer.putDouble(0, 1d);
+    writableMemory.putDouble(0, 1d);
     try {
-      writableBuffer.putDouble(1, 1d);
+      writableMemory.putDouble(1, 1d);
+      throw new RuntimeException("Expected AssertionError");
+    } catch (final AssertionError expected) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testGetAndAddLong() {
+    writableMemory.getAndAddLong(0, 1L);
+    try {
+      writableMemory.getAndAddLong(1, 1L);
+      throw new RuntimeException("Expected AssertionError");
+    } catch (final AssertionError expected) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testGetAndSetLong() {
+    writableMemory.getAndSetLong(0, 1L);
+    try {
+      writableMemory.getAndSetLong(1, 1L);
+      throw new RuntimeException("Expected AssertionError");
+    } catch (final AssertionError expected) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testCompareAndSwapLong() {
+    writableMemory.compareAndSwapLong(0, 0L, 1L);
+    try {
+      writableMemory.compareAndSwapLong(1, 0L, 1L);
       throw new RuntimeException("Expected AssertionError");
     } catch (final AssertionError expected) {
       // ignore

--- a/src/test/java/com/yahoo/memory/BufferInvariantsTest.java
+++ b/src/test/java/com/yahoo/memory/BufferInvariantsTest.java
@@ -14,22 +14,8 @@ import org.testng.annotations.Test;
 
 /**
  * @author Lee Rhodes
- *
  */
 public class BufferInvariantsTest {
-
-  @Test
-  public void checkLimits() {
-    Buffer buf = Buffer.wrap(new byte[100]);
-    buf.setStartPositionEnd(40, 45, 50);
-    buf.setStartPositionEnd(0, 0, 100);
-    try {
-      buf.setStartPositionEnd(0, 0, 101);
-      fail();
-    } catch (AssertionError e) {
-      //ok
-    }
-  }
 
   @Test
   public void testRegion() {

--- a/src/test/java/com/yahoo/memory/CopyMemoryOverlapTest.java
+++ b/src/test/java/com/yahoo/memory/CopyMemoryOverlapTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2018, Yahoo! Inc. Licensed under the terms of the
+ * Apache License 2.0. See LICENSE file at the project root for terms.
+ */
+
+package com.yahoo.memory;
+
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+/**
+ * @author Lee Rhodes
+ */
+public class CopyMemoryOverlapTest {
+
+  @Test
+  public void checkOverlapUsingMemory() {
+    long copyLongs = 1 << 20;
+    double overlap = 0.5;
+    long start_mS = System.currentTimeMillis();
+
+    copyUsingDirectMemory(copyLongs, overlap, true);
+    long end1_mS = System.currentTimeMillis();
+
+    copyUsingDirectMemory(copyLongs, overlap, false);
+    long end2_mS = System.currentTimeMillis();
+
+    println("CopyUp Time Sec: " + ((end1_mS - start_mS)/1000.0));
+    println("CopyDn Time Sec: " + ((end2_mS - end1_mS)/1000.0));
+  }
+
+  @Test
+  public void checkOverlapUsingRegions() {
+    long copyLongs = 1 << 20;
+    double overlap = 0.5;
+    long start_mS = System.currentTimeMillis();
+
+    copyUsingDirectRegions(copyLongs, overlap, true);
+    long end1_mS = System.currentTimeMillis();
+
+    copyUsingDirectRegions(copyLongs, overlap, false);
+    long end2_mS = System.currentTimeMillis();
+
+    println("CopyUp Time Sec: " + ((end1_mS - start_mS)/1000.0));
+    println("CopyDn Time Sec: " + ((end2_mS - end1_mS)/1000.0));
+  }
+
+  private static final void copyUsingDirectMemory(long copyLongs, double overlap, boolean copyUp) {
+    println("Copy Using Direct Memory");
+    long overlapLongs = (long) (overlap * copyLongs);
+    long backingLongs = (2 * copyLongs) - overlapLongs;
+
+    long fromOffsetLongs;
+    long toOffsetLongs;
+    //long deltaLongs;
+
+    if (copyUp) {
+      fromOffsetLongs = 0;
+      toOffsetLongs = copyLongs - overlapLongs;
+      //deltaLongs = toOffsetLongs - fromOffsetLongs;
+    } else {
+      fromOffsetLongs = copyLongs - overlapLongs;
+      toOffsetLongs = 0;
+      //deltaLongs = toOffsetLongs - fromOffsetLongs;
+    }
+
+    long backingBytes = backingLongs << 3;
+    long copyBytes = copyLongs << 3;
+    long fromOffsetBytes = fromOffsetLongs << 3;
+    long toOffsetBytes = toOffsetLongs << 3;
+    //long deltaBytes = deltaLongs << 3;
+    println("Copy longs   : " + copyLongs    + "\t bytes: " + copyBytes);
+    println("Overlap      : " + (overlap * 100.0) + "%");
+    println("CopyUp       : " + copyUp);
+    println("Backing longs: " + backingLongs + "\t bytes: " + backingBytes);
+
+    try (WritableDirectHandle backHandle = WritableMemory.allocateDirect(backingBytes)) {
+      WritableMemory backingMem = backHandle.get();
+      fill(backingMem); //fill mem with 0 thru copyLongs -1
+      //listMem(backingMem, "Original");
+      backingMem.copyTo(fromOffsetBytes, backingMem, toOffsetBytes, copyBytes);
+      //listMem(backingMem, "After");
+      checkMemLongs(backingMem, fromOffsetLongs, toOffsetLongs, copyLongs);
+    }
+    println("");
+  }
+
+  private static final void copyUsingDirectRegions(long copyLongs, double overlap, boolean copyUp) {
+    println("Copy Using Direct Memory");
+    long overlapLongs = (long) (overlap * copyLongs);
+    long backingLongs = (2 * copyLongs) - overlapLongs;
+
+    long fromOffsetLongs;
+    long toOffsetLongs;
+    //long deltaLongs;
+
+    if (copyUp) {
+      fromOffsetLongs = 0;
+      toOffsetLongs = copyLongs - overlapLongs;
+      //deltaLongs = toOffsetLongs - fromOffsetLongs;
+    } else {
+      fromOffsetLongs = copyLongs - overlapLongs;
+      toOffsetLongs = 0;
+      //deltaLongs = toOffsetLongs - fromOffsetLongs;
+    }
+
+    long backingBytes = backingLongs << 3;
+    long copyBytes = copyLongs << 3;
+    long fromOffsetBytes = fromOffsetLongs << 3;
+    long toOffsetBytes = toOffsetLongs << 3;
+    //long deltaBytes = deltaLongs << 3;
+    println("Copy longs   : " + copyLongs    + "\t bytes: " + copyBytes);
+    println("Overlap      : " + (overlap * 100.0) + "%");
+    println("CopyUp       : " + copyUp);
+    println("Backing longs: " + backingLongs + "\t bytes: " + backingBytes);
+
+    try (WritableDirectHandle backHandle = WritableMemory.allocateDirect(backingBytes)) {
+      WritableMemory backingMem = backHandle.get();
+      fill(backingMem); //fill mem with 0 thru copyLongs -1
+      //listMem(backingMem, "Original");
+      WritableMemory reg1 = backingMem.writableRegion(fromOffsetBytes, copyBytes);
+      WritableMemory reg2 = backingMem.writableRegion(toOffsetBytes, copyBytes);
+
+      reg1.copyTo(0, reg2, 0, copyBytes);
+      //listMem(backingMem, "After");
+      checkMemLongs(reg2, fromOffsetLongs, 0, copyLongs);
+    }
+    println("");
+  }
+
+  private static final void fill(WritableMemory wmem) {
+    long longs = wmem.getCapacity() >>> 3;
+    for (long i = 0; i < longs; i++) { wmem.putLong(i << 3, i); } //fill with 0 .. (longs - 1)
+    //checkMemLongs(wmem, 0L, 0L, longs);
+  }
+
+  private static final void checkMemLongs(Memory mem, long fromOffsetLongs, long toOffsetLongs, long copyLongs) {
+    for (long i = 0; i < copyLongs; i++) {
+      long memVal = mem.getLong((toOffsetLongs + i) << 3);
+      assertEquals(memVal, fromOffsetLongs + i);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  private static final void listMem(Memory mem, String comment) {
+    println(comment);
+    println("Idx\tValue");
+    long longs = mem.getCapacity() >>> 3;
+    for (long i = 0; i < longs; i++) {
+      println(i + "\t" + mem.getLong(i << 3));
+    }
+  }
+
+  @Test
+  public void printlnTest() {
+    println("PRINTING: "+this.getClass().getName());
+  }
+
+  /**
+   * @param s value to print
+   */
+  static void println(String s) {
+    //System.out.println(s); //disable here
+  }
+}

--- a/src/test/java/com/yahoo/memory/MemoryBoundaryCheckTest.java
+++ b/src/test/java/com/yahoo/memory/MemoryBoundaryCheckTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2017, Yahoo! Inc. Licensed under the terms of the
+ * Apache License 2.0. See LICENSE file at the project root for terms.
+ */
+
+package com.yahoo.memory;
+
+import org.testng.annotations.Test;
+
+public class MemoryBoundaryCheckTest {
+
+  private final WritableMemory writableMemory = WritableMemory.allocate(8);
+
+  @Test
+  public void testGetBoolean() {
+    writableMemory.getBoolean(7);
+    try {
+      writableMemory.getBoolean(8);
+      throw new RuntimeException("Expected AssertionError");
+    } catch (final AssertionError expected) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testPutBoolean() {
+    writableMemory.putBoolean(7, true);
+    try {
+      writableMemory.putBoolean(8, true);
+      throw new RuntimeException("Expected AssertionError");
+    } catch (final AssertionError expected) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testGetByte() {
+    writableMemory.getByte(7);
+    try {
+      writableMemory.getByte(8);
+      throw new RuntimeException("Expected AssertionError");
+    } catch (final AssertionError expected) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testPutByte() {
+    writableMemory.putByte(7, (byte) 1);
+    try {
+      writableMemory.putByte(8, (byte) 1);
+      throw new RuntimeException("Expected AssertionError");
+    } catch (final AssertionError expected) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testGetChar() {
+    writableMemory.getChar(6);
+    try {
+      writableMemory.getChar(7);
+      throw new RuntimeException("Expected AssertionError");
+    } catch (final AssertionError expected) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testPutChar() {
+    writableMemory.putChar(6, 'a');
+    try {
+      writableMemory.putChar(7, 'a');
+      throw new RuntimeException("Expected AssertionError");
+    } catch (final AssertionError expected) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testGetShort() {
+    writableMemory.getShort(6);
+    try {
+      writableMemory.getShort(7);
+      throw new RuntimeException("Expected AssertionError");
+    } catch (final AssertionError expected) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testPutShort() {
+    writableMemory.putShort(6, (short) 1);
+    try {
+      writableMemory.putShort(7, (short) 1);
+      throw new RuntimeException("Expected AssertionError");
+    } catch (final AssertionError expected) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testGetInt() {
+    writableMemory.getInt(4);
+    try {
+      writableMemory.getInt(5);
+      throw new RuntimeException("Expected AssertionError");
+    } catch (final AssertionError expected) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testPutInt() {
+    writableMemory.putInt(4, 1);
+    try {
+      writableMemory.putInt(5, 1);
+      throw new RuntimeException("Expected AssertionError");
+    } catch (final AssertionError expected) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testGetFloat() {
+    writableMemory.getFloat(4);
+    try {
+      writableMemory.getFloat(5);
+      throw new RuntimeException("Expected AssertionError");
+    } catch (final AssertionError expected) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testPutFloat() {
+    writableMemory.putFloat(4, 1f);
+    try {
+      writableMemory.putFloat(5, 1f);
+      throw new RuntimeException("Expected AssertionError");
+    } catch (final AssertionError expected) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testGetLong() {
+    writableMemory.getLong(0);
+    try {
+      writableMemory.getLong(1);
+      throw new RuntimeException("Expected AssertionError");
+    } catch (final AssertionError expected) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testPutLong() {
+    writableMemory.putLong(0, 1L);
+    try {
+      writableMemory.putLong(1, 1L);
+      throw new RuntimeException("Expected AssertionError");
+    } catch (final AssertionError expected) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testGetDouble() {
+    writableMemory.getDouble(0);
+    try {
+      writableMemory.getDouble(1);
+      throw new RuntimeException("Expected AssertionError");
+    } catch (final AssertionError expected) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testPutDouble() {
+    writableMemory.putDouble(0, 1d);
+    try {
+      writableMemory.putDouble(1, 1d);
+      throw new RuntimeException("Expected AssertionError");
+    } catch (final AssertionError expected) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testGetAndAddLong() {
+    writableMemory.getAndAddLong(0, 1L);
+    try {
+      writableMemory.getAndAddLong(1, 1L);
+      throw new RuntimeException("Expected AssertionError");
+    } catch (final AssertionError expected) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testGetAndSetLong() {
+    writableMemory.getAndSetLong(0, 1L);
+    try {
+      writableMemory.getAndSetLong(1, 1L);
+      throw new RuntimeException("Expected AssertionError");
+    } catch (final AssertionError expected) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testCompareAndSwapLong() {
+    writableMemory.compareAndSwapLong(0, 0L, 1L);
+    try {
+      writableMemory.compareAndSwapLong(1, 0L, 1L);
+      throw new RuntimeException("Expected AssertionError");
+    } catch (final AssertionError expected) {
+      // ignore
+    }
+  }
+}

--- a/src/test/java/com/yahoo/memory/Utf8Test.java
+++ b/src/test/java/com/yahoo/memory/Utf8Test.java
@@ -315,6 +315,12 @@ public class Utf8Test {
     checkStrings(cbStr, rcpStr);
   }
 
+  @Test
+  public void checkRandomValidCodePoints2() {
+    //checks the non-deterministic constructor
+    @SuppressWarnings("unused")
+    RandomCodePoints rcp = new RandomCodePoints(false);
+  }
 
   @Test
   public void printlnTest() {

--- a/src/test/java/com/yahoo/memory/WritableMemoryImplTest.java
+++ b/src/test/java/com/yahoo/memory/WritableMemoryImplTest.java
@@ -248,26 +248,6 @@ public class WritableMemoryImplTest {
   }
 
   @Test
-  public void checkCopyWithinNativeOverlap() {
-    int memCapacity = 64;
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
-      WritableMemory mem = wrh.get();
-      mem.clear();
-      //println(mem.toHexString("Clear 64", 0, memCapacity));
-
-      for (int i=0; i < (memCapacity/2); i++) {
-        mem.putByte(i, (byte) i);
-      }
-      //println(mem.toHexString("Set 1st 32 to ints ", 0, memCapacity));
-
-      mem.copyTo(0, mem, memCapacity/4, memCapacity/2);
-      fail("Did Not Catch Assertion Error: Region Overlap");
-    } catch (AssertionError e) {
-      //pass
-    }
-  }
-
-  @Test
   public void checkCopyWithinNativeSrcBound() {
     int memCapacity = 64;
     try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {


### PR DESCRIPTION
I decided to remove the chunking.  I could not make it fail on my laptop with copies over 8GB.  When I have some time, I will try it on one of our back-end systems with gobs of ram.  But if the JVM can tolerate it, I see no reason to complicate our code.  I added a `CopyMemoryOverlapTest` that will be easy to reconfigure for very large copy tests if we want to do that.

Also, the C++ code with the chunking I referred to was from JDK6 and I couldn't find it in JDK8.  I presume the JVM native code has improved quite a lot since then.  