### PR TITLE
Assorted changes 7

### DIFF
--- a/src/main/java/com/yahoo/memory/BaseWritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/BaseWritableBufferImpl.java
@@ -10,11 +10,13 @@ import static com.yahoo.memory.UnsafeUtil.ARRAY_BOOLEAN_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_BOOLEAN_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_BYTE_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_BYTE_INDEX_SCALE;
+import static com.yahoo.memory.UnsafeUtil.LS;
 import static com.yahoo.memory.UnsafeUtil.assertBounds;
 import static com.yahoo.memory.UnsafeUtil.checkBounds;
 import static com.yahoo.memory.UnsafeUtil.unsafe;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /*
  * Developer notes: The heavier methods, such as put/get arrays, duplicate, region, clear, fill,
@@ -194,6 +196,31 @@ abstract class BaseWritableBufferImpl extends WritableBuffer {
   @Override
   public boolean isValid() {
     return state.isValid();
+  }
+
+  @Override
+  public ByteOrder getResourceOrder() {
+    state.assertValid();
+    return state.order();
+  }
+
+  @Override
+  public boolean swapBytes() {
+    return state.isSwapBytes();
+  }
+
+  @Override
+  public String toHexString(final String header, final long offsetBytes, final int lengthBytes) {
+    state.checkValid();
+    final String klass = this.getClass().getSimpleName();
+    final String s1 = String.format("(..., %d, %d)", offsetBytes, lengthBytes);
+    final long hcode = hashCode() & 0XFFFFFFFFL;
+    final String call = ".toHexString" + s1 + ", hashCode: " + hcode;
+    final StringBuilder sb = new StringBuilder();
+    sb.append("### ").append(klass).append(" SUMMARY ###").append(LS);
+    sb.append("Header Comment      : ").append(header).append(LS);
+    sb.append("Call Parameters     : ").append(call);
+    return Memory.toHex(sb.toString(), offsetBytes, lengthBytes, state);
   }
 
   //PRIMITIVE putXXX() and putXXXArray() XXX

--- a/src/main/java/com/yahoo/memory/BaseWritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/BaseWritableBufferImpl.java
@@ -5,6 +5,7 @@
 
 package com.yahoo.memory;
 
+import static com.yahoo.memory.BaseWritableMemoryImpl.copyMemoryCheckingNonOverlapping;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_BOOLEAN_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_BOOLEAN_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_BYTE_BASE_OFFSET;
@@ -68,7 +69,7 @@ abstract class BaseWritableBufferImpl extends WritableBuffer {
     final long pos = getPosition();
     final long copyBytes = lengthBooleans;
     incrementAndCheckPosition(pos, copyBytes);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
@@ -98,7 +99,7 @@ abstract class BaseWritableBufferImpl extends WritableBuffer {
     final long pos = getPosition();
     final long copyBytes = lengthBytes;
     incrementAndCheckPosition(pos, copyBytes);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
@@ -219,7 +220,7 @@ abstract class BaseWritableBufferImpl extends WritableBuffer {
     final long pos = getPosition();
     final long copyBytes = lengthBooleans;
     incrementAndCheckPosition(pos, copyBytes);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
             srcArray,
             ARRAY_BOOLEAN_BASE_OFFSET + srcOffset,
             unsafeObj,
@@ -249,7 +250,7 @@ abstract class BaseWritableBufferImpl extends WritableBuffer {
     final long pos = getPosition();
     final long copyBytes = lengthBytes;
     incrementAndCheckPosition(pos, copyBytes);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
             srcArray,
             ARRAY_BYTE_BASE_OFFSET + srcOffset,
             unsafeObj,

--- a/src/main/java/com/yahoo/memory/BaseWritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/BaseWritableBufferImpl.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2017, Yahoo! Inc. Licensed under the terms of the
+ * Apache License 2.0. See LICENSE file at the project root for terms.
+ */
+
+package com.yahoo.memory;
+
+import static com.yahoo.memory.UnsafeUtil.ARRAY_BOOLEAN_BASE_OFFSET;
+import static com.yahoo.memory.UnsafeUtil.ARRAY_BOOLEAN_INDEX_SCALE;
+import static com.yahoo.memory.UnsafeUtil.ARRAY_BYTE_BASE_OFFSET;
+import static com.yahoo.memory.UnsafeUtil.ARRAY_BYTE_INDEX_SCALE;
+import static com.yahoo.memory.UnsafeUtil.assertBounds;
+import static com.yahoo.memory.UnsafeUtil.checkBounds;
+import static com.yahoo.memory.UnsafeUtil.unsafe;
+
+import java.nio.ByteBuffer;
+
+/*
+ * Developer notes: The heavier methods, such as put/get arrays, duplicate, region, clear, fill,
+ * compareTo, etc., use hard checks (checkValid() and checkBounds()), which execute at runtime
+ * and throw exceptions if violated. The cost of the runtime checks are minor compared to
+ * the rest of the work these methods are doing.
+ *
+ * <p>The light weight methods, such as put/get primitives, use asserts (assertValid() and
+ * assertBounds()), which only execute when asserts are enabled and JIT will remove them
+ * entirely from production runtime code. The offset versions of the light weight methods
+ * will simplify to a single unsafe call, which is further simplified by JIT to an intrinsic
+ * that is often a single CPU instruction.
+ */
+
+/**
+ * Common base of native-ordered and non-native-ordered {@link WritableBuffer} implementations.
+ * Contains methods which are agnostic to the byte order.
+ */
+abstract class BaseWritableBufferImpl extends WritableBuffer {
+  final ResourceState state;
+  final Object unsafeObj; //Array objects are held here.
+  final long cumBaseOffset; //Holds the cumulative offset to the start of data.
+
+  BaseWritableBufferImpl(final ResourceState state) {
+    super(state);
+    this.state = state;
+    unsafeObj = state.getUnsafeObject();
+    cumBaseOffset = state.getCumBaseOffset();
+  }
+
+  //PRIMITIVE getXXX() and getXXXArray() XXX
+  @Override
+  public boolean getBoolean() {
+    state.assertValid();
+    final long pos = getPosition();
+    incrementAndAssertPosition(pos, ARRAY_BOOLEAN_INDEX_SCALE);
+    return unsafe.getBoolean(unsafeObj, cumBaseOffset + pos);
+  }
+
+  @Override
+  public boolean getBoolean(final long offsetBytes) {
+    state.assertValid();
+    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE, capacity);
+    return unsafe.getBoolean(unsafeObj, cumBaseOffset + offsetBytes);
+  }
+
+  @Override
+  public void getBooleanArray(final boolean[] dstArray, final int dstOffset,
+      final int lengthBooleans) {
+    state.checkValid();
+    checkBounds(dstOffset, lengthBooleans, dstArray.length);
+    final long pos = getPosition();
+    final long copyBytes = lengthBooleans;
+    incrementAndCheckPosition(pos, copyBytes);
+    unsafe.copyMemory(
+            unsafeObj,
+            cumBaseOffset + pos,
+            dstArray,
+            ARRAY_BOOLEAN_BASE_OFFSET + dstOffset,
+            copyBytes);
+  }
+
+  @Override
+  public byte getByte() {
+    state.assertValid();
+    final long pos = getPosition();
+    incrementAndAssertPosition(pos, ARRAY_BYTE_INDEX_SCALE);
+    return unsafe.getByte(unsafeObj, cumBaseOffset + pos);
+  }
+
+  @Override
+  public byte getByte(final long offsetBytes) {
+    state.assertValid();
+    assertBounds(offsetBytes, ARRAY_BYTE_INDEX_SCALE, capacity);
+    return unsafe.getByte(unsafeObj, cumBaseOffset + offsetBytes);
+  }
+
+  @Override
+  public void getByteArray(final byte[] dstArray, final int dstOffset, final int lengthBytes) {
+    state.checkValid();
+    checkBounds(dstOffset, lengthBytes, dstArray.length);
+    final long pos = getPosition();
+    final long copyBytes = lengthBytes;
+    incrementAndCheckPosition(pos, copyBytes);
+    unsafe.copyMemory(
+            unsafeObj,
+            cumBaseOffset + pos,
+            dstArray,
+            ARRAY_BYTE_BASE_OFFSET + dstOffset,
+            copyBytes);
+  }
+
+  //OTHER PRIMITIVE READ METHODS: copyTo, compareTo XXX
+  @Override
+  public int compareTo(final long thisOffsetBytes, final long thisLengthBytes, final Buffer that,
+          final long thatOffsetBytes, final long thatLengthBytes) {
+    state.checkValid();
+    that.getResourceState().checkValid();
+    checkBounds(thisOffsetBytes, thisLengthBytes, capacity);
+    checkBounds(thatOffsetBytes, thatLengthBytes, that.capacity);
+    final long thisAdd = getCumulativeOffset() + thisOffsetBytes;
+    final long thatAdd = that.getCumulativeOffset() + thatOffsetBytes;
+    final Object thisObj = (isDirect()) ? null : unsafeObj;
+    final Object thatObj = (that.isDirect()) ? null : ((WritableBuffer)that).getArray();
+    final long lenBytes = Math.min(thisLengthBytes, thatLengthBytes);
+    for (long i = 0; i < lenBytes; i++) {
+      final int thisByte = unsafe.getByte(thisObj, thisAdd + i);
+      final int thatByte = unsafe.getByte(thatObj, thatAdd + i);
+      if (thisByte < thatByte) { return -1; }
+      if (thisByte > thatByte) { return  1; }
+    }
+    return Long.compare(thisLengthBytes, thatLengthBytes);
+  }
+
+  /*
+   * Develper notes: There is no copyTo for Buffers because of the ambiguity of what to do with
+   * the positional values. Switch to Memory view to do copyTo.
+   */
+
+  //OTHER READ METHODS XXX
+  @Override
+  public void checkValidAndBounds(final long offsetBytes, final long lengthBytes) {
+    state.checkValid();
+    checkBounds(offsetBytes, lengthBytes, capacity);
+  }
+
+  @Override
+  public long getCapacity() {
+    state.assertValid();
+    return capacity;
+  }
+
+  @Override
+  public long getCumulativeOffset() {
+    state.assertValid();
+    return cumBaseOffset;
+  }
+
+  @Override
+  public long getRegionOffset() {
+    state.assertValid();
+    return state.getRegionOffset();
+  }
+
+  @Override
+  public boolean hasArray() {
+    state.assertValid();
+    return (unsafeObj != null);
+  }
+
+  @Override
+  public boolean hasByteBuffer() {
+    state.assertValid();
+    return state.getByteBuffer() != null;
+  }
+
+  @Override
+  public boolean isDirect() {
+    state.assertValid();
+    return state.isDirect();
+  }
+
+  @Override
+  public boolean isResourceReadOnly() {
+    state.assertValid();
+    return state.isResourceReadOnly();
+  }
+
+  @Override
+  public boolean isSameResource(final Buffer that) {
+    if (that == null) { return false; }
+    state.assertValid();
+    that.getResourceState().checkValid();
+    return state.isSameResource(that.getResourceState());
+  }
+
+  @Override
+  public boolean isValid() {
+    return state.isValid();
+  }
+
+  //PRIMITIVE putXXX() and putXXXArray() XXX
+  @Override
+  public void putBoolean(final boolean value) {
+    state.assertValid();
+    final long pos = getPosition();
+    incrementAndAssertPosition(pos, ARRAY_BOOLEAN_INDEX_SCALE);
+    unsafe.putBoolean(unsafeObj, cumBaseOffset + pos, value);
+  }
+
+  @Override
+  public void putBoolean(final long offsetBytes, final boolean value) {
+    state.assertValid();
+    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE, capacity);
+    unsafe.putBoolean(unsafeObj, cumBaseOffset + offsetBytes, value);
+  }
+
+  @Override
+  public void putBooleanArray(final boolean[] srcArray, final int srcOffset,
+      final int lengthBooleans) {
+    state.checkValid();
+    checkBounds(srcOffset, lengthBooleans, srcArray.length);
+    final long pos = getPosition();
+    final long copyBytes = lengthBooleans;
+    incrementAndCheckPosition(pos, copyBytes);
+    unsafe.copyMemory(
+            srcArray,
+            ARRAY_BOOLEAN_BASE_OFFSET + srcOffset,
+            unsafeObj,
+            cumBaseOffset + pos,
+            copyBytes);
+  }
+
+  @Override
+  public void putByte(final byte value) {
+    state.assertValid();
+    final long pos = getPosition();
+    incrementAndAssertPosition(pos, ARRAY_BYTE_INDEX_SCALE);
+    unsafe.putByte(unsafeObj, cumBaseOffset + pos, value);
+  }
+
+  @Override
+  public void putByte(final long offsetBytes, final byte value) {
+    state.assertValid();
+    assertBounds(offsetBytes, ARRAY_BYTE_INDEX_SCALE, capacity);
+    unsafe.putByte(unsafeObj, cumBaseOffset + offsetBytes, value);
+  }
+
+  @Override
+  public void putByteArray(final byte[] srcArray, final int srcOffset, final int lengthBytes) {
+    state.checkValid();
+    checkBounds(srcOffset, lengthBytes, srcArray.length);
+    final long pos = getPosition();
+    final long copyBytes = lengthBytes;
+    incrementAndCheckPosition(pos, copyBytes);
+    unsafe.copyMemory(
+            srcArray,
+            ARRAY_BYTE_BASE_OFFSET + srcOffset,
+            unsafeObj,
+            cumBaseOffset + pos,
+            copyBytes);
+  }
+
+  //OTHER XXX
+  @Override
+  public Object getArray() {
+    state.assertValid();
+    return unsafeObj;
+  }
+
+  @Override
+  public ByteBuffer getByteBuffer() {
+    state.assertValid();
+    return state.getByteBuffer();
+  }
+
+  @Override
+  public void clear() {
+    fill((byte)0);
+  }
+
+  @Override
+  public void fill(final byte value) {
+    state.checkValid();
+    final long pos = getPosition();
+    final long len = getEnd() - pos;
+    checkInvariants(getStart(), pos + len, getEnd(), getCapacity());
+    unsafe.setMemory(unsafeObj, cumBaseOffset + pos, len, value);
+  }
+
+  @Override
+  final ResourceState getResourceState() {
+    state.assertValid();
+    return state;
+  }
+}

--- a/src/main/java/com/yahoo/memory/BaseWritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/BaseWritableBufferImpl.java
@@ -111,16 +111,17 @@ abstract class BaseWritableBufferImpl extends WritableBuffer {
 
   //OTHER PRIMITIVE READ METHODS: copyTo, compareTo XXX
   @Override
-  public int compareTo(final long thisOffsetBytes, final long thisLengthBytes, final Buffer that,
+  public int compareTo(final long thisOffsetBytes, final long thisLengthBytes, final Buffer thatBuf,
           final long thatOffsetBytes, final long thatLengthBytes) {
     state.checkValid();
-    that.getResourceState().checkValid();
     checkBounds(thisOffsetBytes, thisLengthBytes, capacity);
+    final BaseWritableBufferImpl that = (BaseWritableBufferImpl) thatBuf;
+    that.state.checkValid();
     checkBounds(thatOffsetBytes, thatLengthBytes, that.capacity);
     final long thisAdd = getCumulativeOffset() + thisOffsetBytes;
     final long thatAdd = that.getCumulativeOffset() + thatOffsetBytes;
-    final Object thisObj = (isDirect()) ? null : unsafeObj;
-    final Object thatObj = (that.isDirect()) ? null : ((WritableBuffer)that).getArray();
+    @SuppressWarnings("UnnecessaryLocalVariable") final Object thisObj = this.unsafeObj;
+    @SuppressWarnings("UnnecessaryLocalVariable") final Object thatObj = that.unsafeObj;
     final long lenBytes = Math.min(thisLengthBytes, thatLengthBytes);
     for (long i = 0; i < lenBytes; i++) {
       final int thisByte = unsafe.getByte(thisObj, thisAdd + i);

--- a/src/main/java/com/yahoo/memory/BaseWritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/BaseWritableBufferImpl.java
@@ -5,7 +5,7 @@
 
 package com.yahoo.memory;
 
-import static com.yahoo.memory.BaseWritableMemoryImpl.copyMemoryCheckingNonOverlapping;
+import static com.yahoo.memory.BaseWritableMemoryImpl.copyMemoryCheckingDifferentObject;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_BOOLEAN_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_BOOLEAN_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_BYTE_BASE_OFFSET;
@@ -71,7 +71,7 @@ abstract class BaseWritableBufferImpl extends WritableBuffer {
     final long pos = getPosition();
     final long copyBytes = lengthBooleans;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
@@ -101,7 +101,7 @@ abstract class BaseWritableBufferImpl extends WritableBuffer {
     final long pos = getPosition();
     final long copyBytes = lengthBytes;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
@@ -248,7 +248,7 @@ abstract class BaseWritableBufferImpl extends WritableBuffer {
     final long pos = getPosition();
     final long copyBytes = lengthBooleans;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
             srcArray,
             ARRAY_BOOLEAN_BASE_OFFSET + srcOffset,
             unsafeObj,
@@ -278,7 +278,7 @@ abstract class BaseWritableBufferImpl extends WritableBuffer {
     final long pos = getPosition();
     final long copyBytes = lengthBytes;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
             srcArray,
             ARRAY_BYTE_BASE_OFFSET + srcOffset,
             unsafeObj,

--- a/src/main/java/com/yahoo/memory/BaseWritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/BaseWritableBufferImpl.java
@@ -120,8 +120,8 @@ abstract class BaseWritableBufferImpl extends WritableBuffer {
     checkBounds(thatOffsetBytes, thatLengthBytes, that.capacity);
     final long thisAdd = getCumulativeOffset() + thisOffsetBytes;
     final long thatAdd = that.getCumulativeOffset() + thatOffsetBytes;
-    @SuppressWarnings("UnnecessaryLocalVariable") final Object thisObj = this.unsafeObj;
-    @SuppressWarnings("UnnecessaryLocalVariable") final Object thatObj = that.unsafeObj;
+    final Object thisObj = this.unsafeObj;
+    final Object thatObj = that.unsafeObj;
     final long lenBytes = Math.min(thisLengthBytes, thatLengthBytes);
     for (long i = 0; i < lenBytes; i++) {
       final int thisByte = unsafe.getByte(thisObj, thisAdd + i);

--- a/src/main/java/com/yahoo/memory/BaseWritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/BaseWritableMemoryImpl.java
@@ -74,7 +74,7 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
     final long copyBytes = lengthBooleans;
     checkBounds(offsetBytes, copyBytes, capacity);
     checkBounds(dstOffset, lengthBooleans, dstArray.length);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
@@ -96,7 +96,7 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
     final long copyBytes = lengthBytes;
     checkBounds(offsetBytes, copyBytes, capacity);
     checkBounds(dstOffset, lengthBytes, dstArray.length);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
@@ -170,15 +170,13 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
     unsafe.copyMemory(srcUnsafeObj, srcAdd, dstUnsafeObj, dstAdd, lengthBytes);
   }
 
-  static void copyMemoryCheckingNonOverlapping(final Object srcUnsafeObj, final long srcAdd,
-      final Object dstUnsafeObj, final long dstAdd, final long lengthBytes) {
-    if ((srcUnsafeObj != dstUnsafeObj) || ((srcAdd + lengthBytes) <= dstAdd)
-        || ((dstAdd + lengthBytes) <= srcAdd)) {
+  static void copyMemoryCheckingDifferentObject(final Object srcUnsafeObj, final long srcAdd,
+        final Object dstUnsafeObj, final long dstAdd, final long lengthBytes) {
+    if (srcUnsafeObj != dstUnsafeObj) {
       copyNonOverlappingMemory(srcUnsafeObj, srcAdd, dstUnsafeObj, dstAdd, lengthBytes);
     } else {
-      throw new IllegalArgumentException("Not expecting memory blocks to overlap: obj="
-          + srcUnsafeObj + ", srcAddress=" + srcAdd + ", dstAddress=" + dstAdd
-          + ", lengthBytes=" + lengthBytes);
+      throw new IllegalArgumentException("Not expecting to copy to/from array which is the " +
+          "underlying object of the memory at the same time");
     }
   }
 
@@ -297,7 +295,7 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
     final long copyBytes = lengthBooleans;
     checkBounds(srcOffset, lengthBooleans, srcArray.length);
     checkBounds(offsetBytes, copyBytes, capacity);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
         srcArray,
         ARRAY_BOOLEAN_BASE_OFFSET + srcOffset,
         unsafeObj,
@@ -320,7 +318,7 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
     final long copyBytes = lengthBytes;
     checkBounds(srcOffset, lengthBytes, srcArray.length);
     checkBounds(offsetBytes, copyBytes, capacity);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
         srcArray,
         ARRAY_BYTE_BASE_OFFSET + srcOffset,
         unsafeObj,

--- a/src/main/java/com/yahoo/memory/BaseWritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/BaseWritableMemoryImpl.java
@@ -9,11 +9,13 @@ import static com.yahoo.memory.UnsafeUtil.ARRAY_BOOLEAN_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_BOOLEAN_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_BYTE_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_BYTE_INDEX_SCALE;
+import static com.yahoo.memory.UnsafeUtil.LS;
 import static com.yahoo.memory.UnsafeUtil.assertBounds;
 import static com.yahoo.memory.UnsafeUtil.checkBounds;
 import static com.yahoo.memory.UnsafeUtil.unsafe;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /*
  * Developer notes: The heavier methods, such as put/get arrays, duplicate, region, clear, fill,
@@ -251,6 +253,32 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
   @Override
   public boolean isValid() {
     return state.isValid();
+  }
+
+  @Override
+  public ByteOrder getResourceOrder() {
+    state.assertValid();
+    return state.order();
+  }
+
+  @Override
+  public boolean swapBytes() {
+    state.assertValid();
+    return state.isSwapBytes();
+  }
+
+  @Override
+  public String toHexString(final String header, final long offsetBytes, final int lengthBytes) {
+    state.checkValid();
+    final String klass = this.getClass().getSimpleName();
+    final String s1 = String.format("(..., %d, %d)", offsetBytes, lengthBytes);
+    final long hcode = hashCode() & 0XFFFFFFFFL;
+    final String call = ".toHexString" + s1 + ", hashCode: " + hcode;
+    final StringBuilder sb = new StringBuilder();
+    sb.append("### ").append(klass).append(" SUMMARY ###").append(LS);
+    sb.append("Header Comment      : ").append(header).append(LS);
+    sb.append("Call Parameters     : ").append(call);
+    return Memory.toHex(sb.toString(), offsetBytes, lengthBytes, state);
   }
 
   //PRIMITIVE putXXX() and putXXXArray() implementations XXX

--- a/src/main/java/com/yahoo/memory/BaseWritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/BaseWritableMemoryImpl.java
@@ -115,9 +115,9 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
     checkBounds(thatOffsetBytes, thatLengthBytes, that.capacity);
     final long thisAdd = getCumulativeOffset(thisOffsetBytes);
     final long thatAdd = that.getCumulativeOffset(thatOffsetBytes);
-    final Object thisObj = this.unsafeObj;
+    final Object thisObj = unsafeObj;
     final Object thatObj = that.unsafeObj;
-    if (thisObj != thatObj || thisAdd != thatAdd) {
+    if ((thisObj != thatObj) || (thisAdd != thatAdd)) {
       final long lenBytes = Math.min(thisLengthBytes, thatLengthBytes);
       for (long i = 0; i < lenBytes; i++) {
         final int thisByte = unsafe.getByte(thisObj, thisAdd + i);
@@ -175,8 +175,8 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
     if (srcUnsafeObj != dstUnsafeObj) {
       copyNonOverlappingMemory(srcUnsafeObj, srcAdd, dstUnsafeObj, dstAdd, lengthBytes);
     } else {
-      throw new IllegalArgumentException("Not expecting to copy to/from array which is the " +
-          "underlying object of the memory at the same time");
+      throw new IllegalArgumentException("Not expecting to copy to/from array which is the "
+          + "underlying object of the memory at the same time");
     }
   }
 

--- a/src/main/java/com/yahoo/memory/BaseWritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/BaseWritableMemoryImpl.java
@@ -34,8 +34,9 @@ import java.nio.ByteBuffer;
  * Contains methods which are agnostic to the byte order.
  */
 abstract class BaseWritableMemoryImpl extends WritableMemory {
+
   /**
-   * Don't use {@link sun.misc.Unsafe#copyMemory to copy blocks of memory larger than this
+   * Don't use {@link sun.misc.Unsafe#copyMemory} to copy blocks of memory larger than this
    * threshold, because internally it doesn't have safepoint polls, that may cause long
    * "Time To Safe Point" pauses in the application. This has been fixed in JDK 9 (see
    * https://bugs.openjdk.java.net/browse/JDK-8149596 and
@@ -132,7 +133,7 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
   @Override
   public void copyTo(final long srcOffsetBytes, final WritableMemory destination,
       final long dstOffsetBytes, final long lengthBytes) {
-    BaseWritableMemoryImpl dst = (BaseWritableMemoryImpl) destination;
+    final BaseWritableMemoryImpl dst = (BaseWritableMemoryImpl) destination;
     state.checkValid();
     checkBounds(srcOffsetBytes, lengthBytes, capacity);
     dst.state.checkValid();
@@ -153,7 +154,7 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
 
   private static void copyMemorySlowPath(final Object srcUnsafeObj, final long srcAdd,
       final Object dstUnsafeObj, final long dstAdd, final long lengthBytes) {
-    if (srcAdd + lengthBytes <= dstAdd || dstAdd + lengthBytes <= srcAdd) {
+    if (((srcAdd + lengthBytes) <= dstAdd) || ((dstAdd + lengthBytes) <= srcAdd)) {
       copyNonOverlappingMemory(srcUnsafeObj, srcAdd, dstUnsafeObj, dstAdd, lengthBytes);
       return;
     }
@@ -168,21 +169,21 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
 
   static void copyMemoryCheckingNonOverlapping(final Object srcUnsafeObj, final long srcAdd,
       final Object dstUnsafeObj, final long dstAdd, final long lengthBytes) {
-    if (srcUnsafeObj != dstUnsafeObj || srcAdd + lengthBytes <= dstAdd ||
-        dstAdd + lengthBytes <= srcAdd) {
+    if ((srcUnsafeObj != dstUnsafeObj) || ((srcAdd + lengthBytes) <= dstAdd)
+        || ((dstAdd + lengthBytes) <= srcAdd)) {
       copyNonOverlappingMemory(srcUnsafeObj, srcAdd, dstUnsafeObj, dstAdd, lengthBytes);
     } else {
-      throw new IllegalArgumentException("Not expecting memory blocks to overlap: obj=" +
-          srcUnsafeObj + ", srcAddress=" + srcAdd + ", dstAddress=" + dstAdd + ", lengthBytes=" +
-          lengthBytes);
+      throw new IllegalArgumentException("Not expecting memory blocks to overlap: obj="
+          + srcUnsafeObj + ", srcAddress=" + srcAdd + ", dstAddress=" + dstAdd
+          + ", lengthBytes=" + lengthBytes);
     }
   }
 
-  /** @see #UNSAFE_COPY_MEMORY_THRESHOLD */
+  /* @see #UNSAFE_COPY_MEMORY_THRESHOLD */
   private static void copyNonOverlappingMemory(final Object srcUnsafeObj, long srcAdd,
       final Object dstUnsafeObj, long dstAdd, long lengthBytes) {
     while (lengthBytes > 0) {
-      long copy = Math.min(lengthBytes, UNSAFE_COPY_MEMORY_THRESHOLD);
+      final long copy = Math.min(lengthBytes, UNSAFE_COPY_MEMORY_THRESHOLD);
       unsafe.copyMemory(srcUnsafeObj, srcAdd, dstUnsafeObj, dstAdd, copy);
       lengthBytes -= copy;
       srcAdd += copy;

--- a/src/main/java/com/yahoo/memory/BaseWritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/BaseWritableMemoryImpl.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2017, Yahoo! Inc. Licensed under the terms of the
+ * Apache License 2.0. See LICENSE file at the project root for terms.
+ */
+
+package com.yahoo.memory;
+
+import static com.yahoo.memory.UnsafeUtil.ARRAY_BOOLEAN_BASE_OFFSET;
+import static com.yahoo.memory.UnsafeUtil.ARRAY_BOOLEAN_INDEX_SCALE;
+import static com.yahoo.memory.UnsafeUtil.ARRAY_BYTE_BASE_OFFSET;
+import static com.yahoo.memory.UnsafeUtil.ARRAY_BYTE_INDEX_SCALE;
+import static com.yahoo.memory.UnsafeUtil.assertBounds;
+import static com.yahoo.memory.UnsafeUtil.checkBounds;
+import static com.yahoo.memory.UnsafeUtil.unsafe;
+
+import java.nio.ByteBuffer;
+
+/*
+ * Developer notes: The heavier methods, such as put/get arrays, duplicate, region, clear, fill,
+ * compareTo, etc., use hard checks (checkValid() and checkBounds()), which execute at runtime
+ * and throw exceptions if violated. The cost of the runtime checks are minor compared to
+ * the rest of the work these methods are doing.
+ *
+ * <p>The light weight methods, such as put/get primitives, use asserts (assertValid() and
+ * assertBounds()), which only execute when asserts are enabled and JIT will remove them
+ * entirely from production runtime code. The light weight methods
+ * will simplify to a single unsafe call, which is further simplified by JIT to an intrinsic
+ * that is often a single CPU instruction.
+ */
+
+
+/**
+ * Common base of native-ordered and non-native-ordered {@link WritableMemory} implementations.
+ * Contains methods which are agnostic to the byte order.
+ */
+abstract class BaseWritableMemoryImpl extends WritableMemory {
+  final ResourceState state;
+  final Object unsafeObj; //Array objects are held here.
+  final long capacity;
+  final long cumBaseOffset; //Holds the cumulative offset to the start of data.
+
+  BaseWritableMemoryImpl(final ResourceState state) {
+    unsafeObj = state.getUnsafeObject();
+    this.state = state;
+    capacity = state.getCapacity();
+    cumBaseOffset = state.getCumBaseOffset();
+  }
+
+  ///PRIMITIVE getXXX() and getXXXArray() XXX
+  @Override
+  public boolean getBoolean(final long offsetBytes) {
+    state.assertValid();
+    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE, capacity);
+    return unsafe.getBoolean(unsafeObj, cumBaseOffset + offsetBytes);
+  }
+
+  @Override
+  public void getBooleanArray(final long offsetBytes, final boolean[] dstArray,
+      final int dstOffset, final int lengthBooleans) {
+    state.checkValid();
+    final long copyBytes = lengthBooleans;
+    checkBounds(offsetBytes, copyBytes, capacity);
+    checkBounds(dstOffset, lengthBooleans, dstArray.length);
+    unsafe.copyMemory(
+        unsafeObj,
+        cumBaseOffset + offsetBytes,
+        dstArray,
+        ARRAY_BOOLEAN_BASE_OFFSET + dstOffset,
+        copyBytes);
+  }
+
+  @Override
+  public byte getByte(final long offsetBytes) {
+    state.assertValid();
+    assertBounds(offsetBytes, ARRAY_BYTE_INDEX_SCALE, capacity);
+    return unsafe.getByte(unsafeObj, cumBaseOffset + offsetBytes);
+  }
+
+  @Override
+  public void getByteArray(final long offsetBytes, final byte[] dstArray, final int dstOffset,
+      final int lengthBytes) {
+    state.checkValid();
+    final long copyBytes = lengthBytes;
+    checkBounds(offsetBytes, copyBytes, capacity);
+    checkBounds(dstOffset, lengthBytes, dstArray.length);
+    unsafe.copyMemory(
+        unsafeObj,
+        cumBaseOffset + offsetBytes,
+        dstArray,
+        ARRAY_BYTE_BASE_OFFSET + dstOffset,
+        copyBytes);
+  }
+
+  //OTHER PRIMITIVE READ METHODS: compareTo, copyTo XXX
+  @Override
+  public int compareTo(final long thisOffsetBytes, final long thisLengthBytes, final Memory that,
+      final long thatOffsetBytes, final long thatLengthBytes) {
+    state.checkValid();
+    checkBounds(thisOffsetBytes, thisLengthBytes, capacity);
+    checkBounds(thatOffsetBytes, thatLengthBytes, that.getCapacity());
+    if (isSameResource(that)) {
+      if (thisOffsetBytes == thatOffsetBytes) {
+        return 0;
+      }
+    } else {
+      that.getResourceState().checkValid();
+    }
+    final long thisAdd = getCumulativeOffset(thisOffsetBytes);
+    final long thatAdd = that.getCumulativeOffset(thatOffsetBytes);
+    final Object thisObj = (isDirect()) ? null : unsafeObj;
+    final Object thatObj = (that.isDirect()) ? null : ((WritableMemory)that).getArray();
+    final long lenBytes = Math.min(thisLengthBytes, thatLengthBytes);
+    for (long i = 0; i < lenBytes; i++) {
+      final int thisByte = unsafe.getByte(thisObj, thisAdd + i);
+      final int thatByte = unsafe.getByte(thatObj, thatAdd + i);
+      if (thisByte < thatByte) { return -1; }
+      if (thisByte > thatByte) { return  1; }
+    }
+    return Long.compare(thisLengthBytes, thatLengthBytes);
+  }
+
+  @Override
+  public void copyTo(final long srcOffsetBytes, final WritableMemory destination,
+      final long dstOffsetBytes, final long lengthBytes) {
+    state.checkValid();
+    checkBounds(srcOffsetBytes, lengthBytes, capacity);
+    checkBounds(dstOffsetBytes, lengthBytes, destination.getCapacity());
+    if (isSameResource(destination)) {
+      if (srcOffsetBytes == dstOffsetBytes) {
+        return;
+      }
+    } else {
+      destination.getResourceState().checkValid();
+    }
+    final long srcAdd = getCumulativeOffset(srcOffsetBytes);
+    final long dstAdd = destination.getCumulativeOffset(dstOffsetBytes);
+    final Object srcParent = (isDirect()) ? null : unsafeObj;
+    final Object dstParent = (destination.isDirect()) ? null : destination.getArray();
+    final long lenBytes = lengthBytes;
+    unsafe.copyMemory(srcParent, srcAdd, dstParent, dstAdd, lenBytes);
+  }
+
+  //OTHER READ METHODS XXX
+  @Override
+  public void checkValidAndBounds(final long offsetBytes, final long lengthBytes) {
+    state.checkValid();
+    checkBounds(offsetBytes, lengthBytes, capacity);
+  }
+
+  @Override
+  public long getCapacity() {
+    state.assertValid();
+    return capacity;
+  }
+
+  @Override
+  public long getCumulativeOffset(final long offsetBytes) {
+    state.assertValid();
+    return cumBaseOffset + offsetBytes;
+  }
+
+  @Override
+  public long getRegionOffset(final long offsetBytes) {
+    state.assertValid();
+    return state.getRegionOffset() + offsetBytes;
+  }
+
+  @Override
+  public boolean hasArray() {
+    state.assertValid();
+    return unsafeObj != null;
+  }
+
+  @Override
+  public boolean hasByteBuffer() {
+    state.assertValid();
+    return state.getByteBuffer() != null;
+  }
+
+  @Override
+  public boolean isDirect() {
+    state.assertValid();
+    return state.isDirect();
+  }
+
+  @Override
+  public boolean isResourceReadOnly() {
+    state.assertValid();
+    return state.isResourceReadOnly();
+  }
+
+  @Override
+  public boolean isSameResource(final Memory that) {
+    if (that == null) { return false; }
+    state.checkValid();
+    that.getResourceState().checkValid();
+    return state.isSameResource(that.getResourceState());
+  }
+
+  @Override
+  public boolean isValid() {
+    return state.isValid();
+  }
+
+  //PRIMITIVE putXXX() and putXXXArray() implementations XXX
+  @Override
+  public void putBoolean(final long offsetBytes, final boolean value) {
+    state.assertValid();
+    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE, capacity);
+    unsafe.putBoolean(unsafeObj, cumBaseOffset + offsetBytes, value);
+  }
+
+  @Override
+  public void putBooleanArray(final long offsetBytes, final boolean[] srcArray, final int srcOffset,
+      final int lengthBooleans) {
+    state.checkValid();
+    final long copyBytes = lengthBooleans;
+    checkBounds(srcOffset, lengthBooleans, srcArray.length);
+    checkBounds(offsetBytes, copyBytes, capacity);
+    unsafe.copyMemory(
+        srcArray,
+        ARRAY_BOOLEAN_BASE_OFFSET + srcOffset,
+        unsafeObj,
+        cumBaseOffset + offsetBytes,
+        copyBytes
+    );
+  }
+
+  @Override
+  public void putByte(final long offsetBytes, final byte value) {
+    state.assertValid();
+    assertBounds(offsetBytes, ARRAY_BYTE_INDEX_SCALE, capacity);
+    unsafe.putByte(unsafeObj, cumBaseOffset + offsetBytes, value);
+  }
+
+  @Override
+  public void putByteArray(final long offsetBytes, final byte[] srcArray, final int srcOffset,
+      final int lengthBytes) {
+    state.checkValid();
+    final long copyBytes = lengthBytes;
+    checkBounds(srcOffset, lengthBytes, srcArray.length);
+    checkBounds(offsetBytes, copyBytes, capacity);
+    unsafe.copyMemory(
+        srcArray,
+        ARRAY_BYTE_BASE_OFFSET + srcOffset,
+        unsafeObj,
+        cumBaseOffset + offsetBytes,
+        copyBytes
+    );
+  }
+
+  //OTHER WRITE METHODS XXX
+  @Override
+  public Object getArray() {
+    state.assertValid();
+    return unsafeObj;
+  }
+
+  @Override
+  public ByteBuffer getByteBuffer() {
+    state.assertValid();
+    return state.getByteBuffer();
+  }
+
+  @Override
+  public void clear() {
+    fill(0, capacity, (byte) 0);
+  }
+
+  @Override
+  public void clear(final long offsetBytes, final long lengthBytes) {
+    fill(offsetBytes, lengthBytes, (byte) 0);
+  }
+
+  @Override
+  public void clearBits(final long offsetBytes, final byte bitMask) {
+    state.assertValid();
+    assertBounds(offsetBytes, ARRAY_BYTE_INDEX_SCALE, capacity);
+    final long cumBaseOff = cumBaseOffset + offsetBytes;
+    int value = unsafe.getByte(unsafeObj, cumBaseOff) & 0XFF;
+    value &= ~bitMask;
+    unsafe.putByte(unsafeObj, cumBaseOff, (byte)value);
+  }
+
+  @Override
+  public void fill(final byte value) {
+    fill(0, capacity, value);
+  }
+
+  @Override
+  public void fill(final long offsetBytes, final long lengthBytes, final byte value) {
+    state.checkValid();
+    checkBounds(offsetBytes, lengthBytes, capacity);
+    unsafe.setMemory(unsafeObj, cumBaseOffset + offsetBytes, lengthBytes, value);
+  }
+
+  @Override
+  public void setBits(final long offsetBytes, final byte bitMask) {
+    state.assertValid();
+    assertBounds(offsetBytes, ARRAY_BYTE_INDEX_SCALE, capacity);
+    final long myOffset = cumBaseOffset + offsetBytes;
+    final byte value = unsafe.getByte(unsafeObj, myOffset);
+    unsafe.putByte(unsafeObj, myOffset, (byte)(value | bitMask));
+  }
+
+  //OTHER XXX
+  @Override
+  public MemoryRequestServer getMemoryRequestServer() { //only applicable to writable
+    state.assertValid();
+    return state.getMemoryRequestServer();
+  }
+
+  @Override
+  public void setMemoryRequest(final MemoryRequestServer memReqSvr) {
+    state.assertValid();
+    state.setMemoryRequestServer(memReqSvr);
+  }
+
+  @Override
+  public WritableDirectHandle getHandle() {
+    state.assertValid();
+    return state.getHandle();
+  }
+
+  @Override
+  public void setHandle(final WritableDirectHandle handle) {
+    state.assertValid();
+    state.setHandle(handle);
+  }
+
+  //RESTRICTED XXX
+  @Override
+  ResourceState getResourceState() {
+    return state;
+  }
+}

--- a/src/main/java/com/yahoo/memory/BaseWritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/BaseWritableMemoryImpl.java
@@ -104,7 +104,7 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
         copyBytes);
   }
 
-  //OTHER PRIMITIVE READ METHODS: compareTo, copyTo XXX
+  //OTHER PRIMITIVE READ METHODS: compareTo, copyTo, equals XXX
   @Override
   public int compareTo(final long thisOffsetBytes, final long thisLengthBytes,
       final Memory thatMem, final long thatOffsetBytes, final long thatLengthBytes) {
@@ -117,6 +117,18 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
       final long dstOffsetBytes, final long lengthBytes) {
     CompareAndCopy.copy(state, srcOffsetBytes, destination.getResourceState(),
         dstOffsetBytes, lengthBytes);
+  }
+
+  @Override
+  public boolean equalTo(final Memory that) {
+    return CompareAndCopy.equals(state, that.getResourceState());
+  }
+
+  @Override
+  public boolean equalTo(final long thisOffsetBytes, final Memory that,
+      final long thatOffsetBytes, final long lengthBytes) {
+    return CompareAndCopy.equals(state, thisOffsetBytes, that.getResourceState(),
+        thatOffsetBytes, lengthBytes);
   }
 
   //OTHER READ METHODS XXX

--- a/src/main/java/com/yahoo/memory/Buffer.java
+++ b/src/main/java/com/yahoo/memory/Buffer.java
@@ -264,7 +264,8 @@ public abstract class Buffer extends BaseBuffer {
   /**
    * Compares the bytes of this Buffer to <i>that</i> Buffer.
    * This uses absolute offsets not the start, position and end.
-   * Returns <i>(this &lt; that) ? -1 : (this &gt; that) ? 1 : 0;</i>.
+   * Returns <i>(this &lt; that) ? (some negative value) : (this &gt; that) ? (some positive value)
+   * : 0;</i>.
    * If all bytes are equal up to the shorter of the two lengths, the shorter length is
    * considered to be less than the other.
    * @param thisOffsetBytes the starting offset for <i>this Buffer</i>
@@ -272,7 +273,8 @@ public abstract class Buffer extends BaseBuffer {
    * @param that the other Buffer to compare with
    * @param thatOffsetBytes the starting offset for <i>that Buffer</i>
    * @param thatLengthBytes the length of the region to compare from <i>that Buffer</i>
-   * @return <i>(this &lt; that) ? -1 : (this &gt; that) ? 1 : 0;</i>
+   * @return <i>(this &lt; that) ? (some negative value) : (this &gt; that) ? (some positive value)
+   * : 0;</i>
    */
   public abstract int compareTo(long thisOffsetBytes, long thisLengthBytes, Buffer that,
           long thatOffsetBytes, long thatLengthBytes);

--- a/src/main/java/com/yahoo/memory/CompareAndCopy.java
+++ b/src/main/java/com/yahoo/memory/CompareAndCopy.java
@@ -97,7 +97,7 @@ final class CompareAndCopy {
    */
   private static void copyMemoryOverlapAddressCheck(final Object srcUnsafeObj, final long srcAdd,
       final Object dstUnsafeObj, final long dstAdd, final long lengthBytes) {
-    if ((((srcAdd + lengthBytes) - dstAdd) <= 0) || (((dstAdd + lengthBytes) - srcAdd) <= 0)) {
+    if (((srcAdd + lengthBytes) <= dstAdd) || ((dstAdd + lengthBytes) <= srcAdd)) {
       copyNonOverlappingMemoryWithChunking(srcUnsafeObj, srcAdd, dstUnsafeObj, dstAdd,
           lengthBytes);
       return;

--- a/src/main/java/com/yahoo/memory/CompareAndCopy.java
+++ b/src/main/java/com/yahoo/memory/CompareAndCopy.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2018, Yahoo! Inc. Licensed under the terms of the
+ * Apache License 2.0. See LICENSE file at the project root for terms.
+ */
+
+package com.yahoo.memory;
+
+import static com.yahoo.memory.UnsafeUtil.checkBounds;
+import static com.yahoo.memory.UnsafeUtil.unsafe;
+
+/**
+ * @author Lee Rhodes
+ */
+final class CompareAndCopy {
+
+  /**
+   * Don't use {@link sun.misc.Unsafe#copyMemory} to copy blocks of memory larger than this
+   * threshold, because internally it doesn't have safepoint polls, that may cause long
+   * "Time To Safe Point" pauses in the application. This has been fixed in JDK 9 (see
+   * https://bugs.openjdk.java.net/browse/JDK-8149596 and
+   * https://bugs.openjdk.java.net/browse/JDK-8141491), but not in JDK 8, so the Memory library
+   * should keep having this boilerplate as long as it supports Java 8.
+   */
+  static final long UNSAFE_COPY_MEMORY_THRESHOLD = 1024 * 1024;
+
+  static int compare(
+      final ResourceState thisState, final long thisOffsetBytes, final long thisLengthBytes,
+      final ResourceState thatState, final long thatOffsetBytes, final long thatLengthBytes) {
+    thisState.checkValid();
+    checkBounds(thisOffsetBytes, thisLengthBytes, thisState.getCapacity());
+    thatState.checkValid();
+    checkBounds(thatOffsetBytes, thatLengthBytes, thatState.getCapacity());
+    final long thisAdd = thisState.getCumBaseOffset() + thisOffsetBytes;
+    final long thatAdd = thatState.getCumBaseOffset() + thatOffsetBytes;
+    final Object thisObj = thisState.getUnsafeObject();
+    final Object thatObj = thatState.getUnsafeObject();
+    if ((thisObj != thatObj) || (thisAdd != thatAdd)) {
+      final long lenBytes = Math.min(thisLengthBytes, thatLengthBytes);
+      for (long i = 0; i < lenBytes; i++) {
+        final int thisByte = unsafe.getByte(thisObj, thisAdd + i);
+        final int thatByte = unsafe.getByte(thatObj, thatAdd + i);
+        if (thisByte < thatByte) { return -1; }
+        if (thisByte > thatByte) { return  1; }
+      }
+    }
+    return Long.compare(thisLengthBytes, thatLengthBytes);
+  }
+
+  static void copy(final ResourceState srcState, final long srcOffsetBytes,
+      final ResourceState dstState, final long dstOffsetBytes, final long lengthBytes) {
+    srcState.checkValid();
+    checkBounds(srcOffsetBytes, lengthBytes, srcState.getCapacity());
+    dstState.checkValid();
+    checkBounds(dstOffsetBytes, lengthBytes, dstState.getCapacity());
+    final long srcAdd = srcState.getCumBaseOffset() + srcOffsetBytes;
+    final long dstAdd = dstState.getCumBaseOffset() + dstOffsetBytes;
+    copyMemory(srcState.getUnsafeObject(), srcAdd, dstState.getUnsafeObject(), dstAdd,
+        lengthBytes);
+  }
+
+  //Used by all of the get/put array methods in Buffer and Memory classes
+  static final void copyMemoryCheckingDifferentObject(final Object srcUnsafeObj,
+      final long srcAdd, final Object dstUnsafeObj, final long dstAdd, final long lengthBytes) {
+    if (srcUnsafeObj != dstUnsafeObj) {
+      copyNonOverlappingMemoryWithChunking(srcUnsafeObj, srcAdd, dstUnsafeObj, dstAdd,
+          lengthBytes);
+    } else {
+      throw new IllegalArgumentException("Not expecting to copy to/from array which is the "
+          + "underlying object of the memory at the same time");
+    }
+  }
+
+  //only valid and bounds checks have been performed at this point
+  private static void copyMemory(final Object srcUnsafeObj, final long srcAdd,
+      final Object dstUnsafeObj, final long dstAdd, final long lengthBytes) {
+    if (srcUnsafeObj != dstUnsafeObj) {
+      //either srcArray != dstArray OR one of them is off-heap
+      copyNonOverlappingMemoryWithChunking(srcUnsafeObj, srcAdd, dstUnsafeObj, dstAdd,
+          lengthBytes);
+    } else { //either srcArray == dstArray OR both src and dst are off-heap
+      copyMemoryOverlapAddressCheck(srcUnsafeObj, srcAdd, dstUnsafeObj, dstAdd, lengthBytes);
+    }
+  }
+
+  /**
+   * At this point either srcArray == dstArray OR both src and dst are off-heap.
+   * Performs overlapping address check. If addresses do not overlap, proceed to
+   * {@link #copyNonOverlappingMemoryWithChunking(Object, long, Object, long, long)}; otherwise
+   * fall back on <i>Unsafe.copyMemory(...)</i> tolerating potentially long
+   * Time to Safe Point pauses.
+   * If srcAdd == dstAdd an exception will be thrown.
+   * @param srcUnsafeObj The source array object, it may be null.
+   * @param srcAdd The cumulative source offset
+   * @param dstUnsafeObj The destination array object, it may be null
+   * @param dstAdd The cumulative destination offset
+   * @param lengthBytes The length to be copied in bytes
+   */
+  private static void copyMemoryOverlapAddressCheck(final Object srcUnsafeObj, final long srcAdd,
+      final Object dstUnsafeObj, final long dstAdd, final long lengthBytes) {
+    if (((srcAdd + lengthBytes) <= dstAdd) || ((dstAdd + lengthBytes) <= srcAdd)) {
+      copyNonOverlappingMemoryWithChunking(srcUnsafeObj, srcAdd, dstUnsafeObj, dstAdd,
+          lengthBytes);
+      return;
+    }
+    if (srcAdd == dstAdd) {
+      throw new IllegalArgumentException(
+          "Attempt to copy a block of memory exactly in-place, should be a bug");
+    }
+    // If regions do overlap, fall back to unsafe.copyMemory, tolerating potentially long
+    // Time to Safe Point pauses.
+    unsafe.copyMemory(srcUnsafeObj, srcAdd, dstUnsafeObj, dstAdd, lengthBytes);
+  }
+
+  /**
+   * This copies only non-overlapping memory in chunks to avoid safepoint delays.
+   * Java 9 may not require the chunking.
+   * @param srcUnsafeObj The source array object, it may be null.
+   * @param srcAdd The cumulative source offset
+   * @param dstUnsafeObj The destination array object, it may be null
+   * @param dstAdd The cumulative destination offset
+   * @param lengthBytes The length to be copied in bytes
+   * @see #UNSAFE_COPY_MEMORY_THRESHOLD
+   */
+  private static void copyNonOverlappingMemoryWithChunking(final Object srcUnsafeObj,
+      long srcAdd, final Object dstUnsafeObj, long dstAdd, long lengthBytes) {
+    while (lengthBytes > 0) {
+      final long copy = Math.min(lengthBytes, UNSAFE_COPY_MEMORY_THRESHOLD);
+      unsafe.copyMemory(srcUnsafeObj, srcAdd, dstUnsafeObj, dstAdd, copy);
+      lengthBytes -= copy;
+      srcAdd += copy;
+      dstAdd += copy;
+    }
+  }
+}

--- a/src/main/java/com/yahoo/memory/CompareAndCopy.java
+++ b/src/main/java/com/yahoo/memory/CompareAndCopy.java
@@ -97,7 +97,7 @@ final class CompareAndCopy {
    */
   private static void copyMemoryOverlapAddressCheck(final Object srcUnsafeObj, final long srcAdd,
       final Object dstUnsafeObj, final long dstAdd, final long lengthBytes) {
-    if (((srcAdd + lengthBytes) <= dstAdd) || ((dstAdd + lengthBytes) <= srcAdd)) {
+    if ((((srcAdd + lengthBytes) - dstAdd) <= 0) || (((dstAdd + lengthBytes) - srcAdd) <= 0)) {
       copyNonOverlappingMemoryWithChunking(srcUnsafeObj, srcAdd, dstUnsafeObj, dstAdd,
           lengthBytes);
       return;

--- a/src/main/java/com/yahoo/memory/MapHandle.java
+++ b/src/main/java/com/yahoo/memory/MapHandle.java
@@ -15,9 +15,9 @@ package com.yahoo.memory;
 //Joins a Read-only Handle with an AutoCloseable Map resource.
 public class MapHandle implements Map, Handle {
   AllocateDirectMap dirMap;
-  WritableMemoryImpl wMem;
+  BaseWritableMemoryImpl wMem;
 
-  MapHandle(final AllocateDirectMap dirMap, final WritableMemoryImpl wMem) {
+  MapHandle(final AllocateDirectMap dirMap, final BaseWritableMemoryImpl wMem) {
     this.dirMap = dirMap;
     this.wMem = wMem;
   }
@@ -25,7 +25,7 @@ public class MapHandle implements Map, Handle {
   @SuppressWarnings("resource") //called from memory
   static MapHandle map(final ResourceState state) throws Exception {
     final AllocateDirectMap dirMap = AllocateDirectMap.map(state);
-    final WritableMemoryImpl wMem = new WritableMemoryImpl(state);
+    final BaseWritableMemoryImpl wMem = new WritableMemoryImpl(state);
     return new MapHandle(dirMap, wMem);
   }
 

--- a/src/main/java/com/yahoo/memory/Memory.java
+++ b/src/main/java/com/yahoo/memory/Memory.java
@@ -415,8 +415,11 @@ public abstract class Memory {
 
   /**
    * Copies bytes from a source range of this Memory to a destination range of the given Memory
-   * using the same low-level system copy function as found in
-   * {@link java.lang.System#arraycopy(Object, int, Object, int, int)}.
+   * with the same semantics when copying between overlapping ranges of bytes as method
+   * {@link java.lang.System#arraycopy(Object, int, Object, int, int)} has. However, if the source
+   * and the destination ranges are exactly the same, this method throws {@link
+   * IllegalArgumentException}, because it should never be needed in real-world scenarios and
+   * therefore indicates a bug.
    * @param srcOffsetBytes the source offset for this Memory
    * @param destination the destination Memory, which may not be Read-Only.
    * @param dstOffsetBytes the destination offset

--- a/src/main/java/com/yahoo/memory/Memory.java
+++ b/src/main/java/com/yahoo/memory/Memory.java
@@ -430,7 +430,33 @@ public abstract class Memory {
   public abstract void copyTo(long srcOffsetBytes, WritableMemory destination, long dstOffsetBytes,
       long lengthBytes);
 
+  /**
+   * Returns true if the given Memory has equal contents to this Memory.
+   * @param that the given Memory
+   * @return true if the given Memory has equal contents to this Memory.
+   */
+  public abstract boolean equalTo(Memory that);
+
+  /**
+   * Returns true if the given Memory has equal contents to this Memory in the given range of
+   * bytes.
+   * @param thisOffsetBytes the starting offset in bytes for this Memory
+   * @param that the given Memory
+   * @param thatOffsetBytes the starting offset in bytes for the given Memory
+   * @param lengthBytes the size of the range of bytes
+   * @return true if the given Memory has equal contents to this Memory in the given range of
+   * bytes.
+   */
+  public abstract boolean equalTo(long thisOffsetBytes, Memory that, long thatOffsetBytes,
+      long lengthBytes);
+
   //OTHER READ METHODS XXX
+  /**
+   * Convenience method to check that this Memory is valid and the given offsetBytes and
+   * lengthBytes are within the capacity of this Memory.
+   * @param offsetBytes the given offset in bytes of this Memory
+   * @param lengthBytes the given length in bytes of this Memory
+   */
   public abstract void checkValidAndBounds(long offsetBytes, long lengthBytes);
 
   /**

--- a/src/main/java/com/yahoo/memory/Memory.java
+++ b/src/main/java/com/yahoo/memory/Memory.java
@@ -400,7 +400,8 @@ public abstract class Memory {
   //OTHER PRIMITIVE READ METHODS: compareTo, copyTo XXX
   /**
    * Compares the bytes of this Memory to <i>that</i> Memory.
-   * Returns <i>(this &lt; that) ? -1 : (this &gt; that) ? 1 : 0;</i>.
+   * Returns <i>(this &lt; that) ? (some negative value) : (this &gt; that) ? (some positive value)
+   * : 0;</i>.
    * If all bytes are equal up to the shorter of the two lengths, the shorter length is considered
    * to be less than the other.
    * @param thisOffsetBytes the starting offset for <i>this Memory</i>
@@ -408,7 +409,8 @@ public abstract class Memory {
    * @param that the other Memory to compare with
    * @param thatOffsetBytes the starting offset for <i>that Memory</i>
    * @param thatLengthBytes the length of the region to compare from <i>that Memory</i>
-   * @return <i>(this &lt; that) ? -1 : (this &gt; that) ? 1 : 0;</i>
+   * @return <i>(this &lt; that) ? (some negative value) : (this &gt; that) ? (some positive value)
+   * : 0;</i>
    */
   public abstract int compareTo(long thisOffsetBytes, long thisLengthBytes, Memory that,
       long thatOffsetBytes, long thatLengthBytes);

--- a/src/main/java/com/yahoo/memory/WritableBuffer.java
+++ b/src/main/java/com/yahoo/memory/WritableBuffer.java
@@ -40,7 +40,7 @@ public abstract class WritableBuffer extends Buffer {
     final ResourceState state = new ResourceState();
     state.putByteBuffer(byteBuf);
     AccessByteBuffer.wrap(state);
-    final WritableBufferImpl impl = new WritableBufferImpl(state);
+    final BaseWritableBufferImpl impl = new WritableBufferImpl(state);
     impl.setStartPositionEnd(0, byteBuf.position(), byteBuf.limit());
     return impl;
   }

--- a/src/main/java/com/yahoo/memory/WritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableBufferImpl.java
@@ -297,31 +297,6 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
             copyBytes);
   }
 
-  @Override
-  public ByteOrder getResourceOrder() {
-    state.assertValid();
-    return state.order();
-  }
-
-  @Override
-  public boolean swapBytes() {
-    return state.isSwapBytes();
-  }
-
-  @Override
-  public String toHexString(final String header, final long offsetBytes, final int lengthBytes) {
-    state.checkValid();
-    final String klass = this.getClass().getSimpleName();
-    final String s1 = String.format("(..., %d, %d)", offsetBytes, lengthBytes);
-    final long hcode = hashCode() & 0XFFFFFFFFL;
-    final String call = ".toHexString" + s1 + ", hashCode: " + hcode;
-    final StringBuilder sb = new StringBuilder();
-    sb.append("### ").append(klass).append(" SUMMARY ###").append(LS);
-    sb.append("Header Comment      : ").append(header).append(LS);
-    sb.append("Call Parameters     : ").append(call);
-    return Memory.toHex(sb.toString(), offsetBytes, lengthBytes, state);
-  }
-
   //PRIMITIVE putXXX() and putXXXArray() XXX
   @Override
   public void putChar(final char value) {

--- a/src/main/java/com/yahoo/memory/WritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableBufferImpl.java
@@ -5,7 +5,6 @@
 
 package com.yahoo.memory;
 
-import static com.yahoo.memory.BaseWritableMemoryImpl.copyMemoryCheckingDifferentObject;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_CHAR_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_CHAR_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_DOUBLE_BASE_OFFSET;
@@ -135,7 +134,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthChars) << CHAR_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingDifferentObject(
+    CompareAndCopy.copyMemoryCheckingDifferentObject(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
@@ -166,7 +165,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthDoubles) << DOUBLE_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingDifferentObject(
+    CompareAndCopy.copyMemoryCheckingDifferentObject(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
@@ -196,7 +195,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthFloats) << FLOAT_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingDifferentObject(
+    CompareAndCopy.copyMemoryCheckingDifferentObject(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
@@ -226,7 +225,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthInts) << INT_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingDifferentObject(
+    CompareAndCopy.copyMemoryCheckingDifferentObject(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
@@ -256,7 +255,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthLongs) << LONG_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingDifferentObject(
+    CompareAndCopy.copyMemoryCheckingDifferentObject(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
@@ -286,7 +285,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthShorts) << SHORT_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingDifferentObject(
+    CompareAndCopy.copyMemoryCheckingDifferentObject(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
@@ -317,7 +316,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthChars) << CHAR_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingDifferentObject(
+    CompareAndCopy.copyMemoryCheckingDifferentObject(
             srcArray,
             ARRAY_CHAR_BASE_OFFSET + (((long) srcOffset) << CHAR_SHIFT),
             unsafeObj,
@@ -348,7 +347,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthDoubles) << DOUBLE_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingDifferentObject(
+    CompareAndCopy.copyMemoryCheckingDifferentObject(
             srcArray,
             ARRAY_DOUBLE_BASE_OFFSET + (((long) srcOffset) << DOUBLE_SHIFT),
             unsafeObj,
@@ -378,7 +377,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthFloats) << FLOAT_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingDifferentObject(
+    CompareAndCopy.copyMemoryCheckingDifferentObject(
             srcArray,
             ARRAY_FLOAT_BASE_OFFSET + (((long) srcOffset) << FLOAT_SHIFT),
             unsafeObj,
@@ -408,7 +407,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthInts) << INT_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingDifferentObject(
+    CompareAndCopy.copyMemoryCheckingDifferentObject(
             srcArray,
             ARRAY_INT_BASE_OFFSET + (((long) srcOffset) << INT_SHIFT),
             unsafeObj,
@@ -438,7 +437,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthLongs) << LONG_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingDifferentObject(
+    CompareAndCopy.copyMemoryCheckingDifferentObject(
             srcArray,
             ARRAY_LONG_BASE_OFFSET + (((long) srcOffset) << LONG_SHIFT),
             unsafeObj,
@@ -468,7 +467,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthShorts) << SHORT_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingDifferentObject(
+    CompareAndCopy.copyMemoryCheckingDifferentObject(
             srcArray,
             ARRAY_SHORT_BASE_OFFSET + (((long) srcOffset) << SHORT_SHIFT),
             unsafeObj,

--- a/src/main/java/com/yahoo/memory/WritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableBufferImpl.java
@@ -5,10 +5,6 @@
 
 package com.yahoo.memory;
 
-import static com.yahoo.memory.UnsafeUtil.ARRAY_BOOLEAN_BASE_OFFSET;
-import static com.yahoo.memory.UnsafeUtil.ARRAY_BOOLEAN_INDEX_SCALE;
-import static com.yahoo.memory.UnsafeUtil.ARRAY_BYTE_BASE_OFFSET;
-import static com.yahoo.memory.UnsafeUtil.ARRAY_BYTE_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_CHAR_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_CHAR_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_DOUBLE_BASE_OFFSET;
@@ -32,7 +28,6 @@ import static com.yahoo.memory.UnsafeUtil.assertBounds;
 import static com.yahoo.memory.UnsafeUtil.checkBounds;
 import static com.yahoo.memory.UnsafeUtil.unsafe;
 
-import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 /*
@@ -53,11 +48,8 @@ import java.nio.ByteOrder;
  * @author Roman Leventov
  * @author Lee Rhodes
  */
-class WritableBufferImpl extends WritableBuffer {
-  final ResourceState state;
-  final Object unsafeObj; //Array objects are held here.
+class WritableBufferImpl extends BaseWritableBufferImpl {
   final long unsafeObjHeader; //Heap ByteBuffer includes the slice() offset here.
-  final long cumBaseOffset; //Holds the cumulative offset to the start of data.
   BaseWritableMemoryImpl originMemory = null; //If I came from here ...
 
   //Static variable for cases where byteBuf/array sizes are zero
@@ -69,10 +61,7 @@ class WritableBufferImpl extends WritableBuffer {
 
   WritableBufferImpl(final ResourceState state) {
     super(state);
-    this.state = state;
-    unsafeObj = state.getUnsafeObject();
     unsafeObjHeader = state.getUnsafeObjectHeader();
-    cumBaseOffset = state.getCumBaseOffset();
   }
 
   //DUPLICATES & REGIONS XXX
@@ -128,67 +117,6 @@ class WritableBufferImpl extends WritableBuffer {
   }
 
   //PRIMITIVE getXXX() and getXXXArray() XXX
-  @Override
-  public boolean getBoolean() {
-    state.assertValid();
-    final long pos = getPosition();
-    incrementAndAssertPosition(pos, ARRAY_BOOLEAN_INDEX_SCALE);
-    return unsafe.getBoolean(unsafeObj, cumBaseOffset + pos);
-  }
-
-  @Override
-  public boolean getBoolean(final long offsetBytes) {
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE, capacity);
-    return unsafe.getBoolean(unsafeObj, cumBaseOffset + offsetBytes);
-  }
-
-  @Override
-  public void getBooleanArray(final boolean[] dstArray, final int dstOffset,
-      final int lengthBooleans) {
-    state.checkValid();
-    checkBounds(dstOffset, lengthBooleans, dstArray.length);
-    final long pos = getPosition();
-    final long copyBytes = lengthBooleans;
-    incrementAndCheckPosition(pos, copyBytes);
-    unsafe.copyMemory(
-            unsafeObj,
-            cumBaseOffset + pos,
-            dstArray,
-            ARRAY_BOOLEAN_BASE_OFFSET + dstOffset,
-            copyBytes);
-  }
-
-  @Override
-  public byte getByte() {
-    state.assertValid();
-    final long pos = getPosition();
-    incrementAndAssertPosition(pos, ARRAY_BYTE_INDEX_SCALE);
-    return unsafe.getByte(unsafeObj, cumBaseOffset + pos);
-  }
-
-  @Override
-  public byte getByte(final long offsetBytes) {
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_BYTE_INDEX_SCALE, capacity);
-    return unsafe.getByte(unsafeObj, cumBaseOffset + offsetBytes);
-  }
-
-  @Override
-  public void getByteArray(final byte[] dstArray, final int dstOffset, final int lengthBytes) {
-    state.checkValid();
-    checkBounds(dstOffset, lengthBytes, dstArray.length);
-    final long pos = getPosition();
-    final long copyBytes = lengthBytes;
-    incrementAndCheckPosition(pos, copyBytes);
-    unsafe.copyMemory(
-            unsafeObj,
-            cumBaseOffset + pos,
-            dstArray,
-            ARRAY_BYTE_BASE_OFFSET + dstOffset,
-            copyBytes);
-  }
-
   @Override
   public char getChar() {
     state.assertValid();
@@ -370,99 +298,10 @@ class WritableBufferImpl extends WritableBuffer {
             copyBytes);
   }
 
-  //OTHER PRIMITIVE READ METHODS: copyTo, compareTo XXX
-  @Override
-  public int compareTo(final long thisOffsetBytes, final long thisLengthBytes, final Buffer that,
-          final long thatOffsetBytes, final long thatLengthBytes) {
-    state.checkValid();
-    that.getResourceState().checkValid();
-    checkBounds(thisOffsetBytes, thisLengthBytes, capacity);
-    checkBounds(thatOffsetBytes, thatLengthBytes, that.capacity);
-    final long thisAdd = getCumulativeOffset() + thisOffsetBytes;
-    final long thatAdd = that.getCumulativeOffset() + thatOffsetBytes;
-    final Object thisObj = (isDirect()) ? null : unsafeObj;
-    final Object thatObj = (that.isDirect()) ? null : ((WritableBuffer)that).getArray();
-    final long lenBytes = Math.min(thisLengthBytes, thatLengthBytes);
-    for (long i = 0; i < lenBytes; i++) {
-      final int thisByte = unsafe.getByte(thisObj, thisAdd + i);
-      final int thatByte = unsafe.getByte(thatObj, thatAdd + i);
-      if (thisByte < thatByte) { return -1; }
-      if (thisByte > thatByte) { return  1; }
-    }
-    return Long.compare(thisLengthBytes, thatLengthBytes);
-  }
-
-  /*
-   * Develper notes: There is no copyTo for Buffers because of the ambiguity of what to do with
-   * the positional values. Switch to Memory view to do copyTo.
-   */
-
-  //OTHER READ METHODS XXX
-  @Override
-  public void checkValidAndBounds(final long offsetBytes, final long lengthBytes) {
-    state.checkValid();
-    checkBounds(offsetBytes, lengthBytes, capacity);
-  }
-
-  @Override
-  public long getCapacity() {
-    state.assertValid();
-    return capacity;
-  }
-
-  @Override
-  public long getCumulativeOffset() {
-    state.assertValid();
-    return cumBaseOffset;
-  }
-
-  @Override
-  public long getRegionOffset() {
-    state.assertValid();
-    return state.getRegionOffset();
-  }
-
   @Override
   public ByteOrder getResourceOrder() {
     state.assertValid();
     return state.order();
-  }
-
-  @Override
-  public boolean hasArray() {
-    state.assertValid();
-    return (unsafeObj != null);
-  }
-
-  @Override
-  public boolean hasByteBuffer() {
-    state.assertValid();
-    return state.getByteBuffer() != null;
-  }
-
-  @Override
-  public boolean isDirect() {
-    state.assertValid();
-    return state.isDirect();
-  }
-
-  @Override
-  public boolean isResourceReadOnly() {
-    state.assertValid();
-    return state.isResourceReadOnly();
-  }
-
-  @Override
-  public boolean isSameResource(final Buffer that) {
-    if (that == null) { return false; }
-    state.assertValid();
-    that.getResourceState().checkValid();
-    return state.isSameResource(that.getResourceState());
-  }
-
-  @Override
-  public boolean isValid() {
-    return state.isValid();
   }
 
   @Override
@@ -485,67 +324,6 @@ class WritableBufferImpl extends WritableBuffer {
   }
 
   //PRIMITIVE putXXX() and putXXXArray() XXX
-  @Override
-  public void putBoolean(final boolean value) {
-    state.assertValid();
-    final long pos = getPosition();
-    incrementAndAssertPosition(pos, ARRAY_BOOLEAN_INDEX_SCALE);
-    unsafe.putBoolean(unsafeObj, cumBaseOffset + pos, value);
-  }
-
-  @Override
-  public void putBoolean(final long offsetBytes, final boolean value) {
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE, capacity);
-    unsafe.putBoolean(unsafeObj, cumBaseOffset + offsetBytes, value);
-  }
-
-  @Override
-  public void putBooleanArray(final boolean[] srcArray, final int srcOffset,
-      final int lengthBooleans) {
-    state.checkValid();
-    checkBounds(srcOffset, lengthBooleans, srcArray.length);
-    final long pos = getPosition();
-    final long copyBytes = lengthBooleans;
-    incrementAndCheckPosition(pos, copyBytes);
-    unsafe.copyMemory(
-            srcArray,
-            ARRAY_BOOLEAN_BASE_OFFSET + srcOffset,
-            unsafeObj,
-            cumBaseOffset + pos,
-            copyBytes);
-  }
-
-  @Override
-  public void putByte(final byte value) {
-    state.assertValid();
-    final long pos = getPosition();
-    incrementAndAssertPosition(pos, ARRAY_BYTE_INDEX_SCALE);
-    unsafe.putByte(unsafeObj, cumBaseOffset + pos, value);
-  }
-
-  @Override
-  public void putByte(final long offsetBytes, final byte value) {
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_BYTE_INDEX_SCALE, capacity);
-    unsafe.putByte(unsafeObj, cumBaseOffset + offsetBytes, value);
-  }
-
-  @Override
-  public void putByteArray(final byte[] srcArray, final int srcOffset, final int lengthBytes) {
-    state.checkValid();
-    checkBounds(srcOffset, lengthBytes, srcArray.length);
-    final long pos = getPosition();
-    final long copyBytes = lengthBytes;
-    incrementAndCheckPosition(pos, copyBytes);
-    unsafe.copyMemory(
-            srcArray,
-            ARRAY_BYTE_BASE_OFFSET + srcOffset,
-            unsafeObj,
-            cumBaseOffset + pos,
-            copyBytes);
-  }
-
   @Override
   public void putChar(final char value) {
     state.assertValid();
@@ -727,36 +505,4 @@ class WritableBufferImpl extends WritableBuffer {
             copyBytes);
   }
 
-  //OTHER XXX
-  @Override
-  public Object getArray() {
-    state.assertValid();
-    return unsafeObj;
-  }
-
-  @Override
-  public ByteBuffer getByteBuffer() {
-    state.assertValid();
-    return state.getByteBuffer();
-  }
-
-  @Override
-  public void clear() {
-    fill((byte)0);
-  }
-
-  @Override
-  public void fill(final byte value) {
-    state.checkValid();
-    final long pos = getPosition();
-    final long len = getEnd() - pos;
-    checkInvariants(getStart(), pos + len, getEnd(), getCapacity());
-    unsafe.setMemory(unsafeObj, cumBaseOffset + pos, len, value);
-  }
-
-  @Override
-  final ResourceState getResourceState() {
-    state.assertValid();
-    return state;
-  }
 }

--- a/src/main/java/com/yahoo/memory/WritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableBufferImpl.java
@@ -49,7 +49,6 @@ import java.nio.ByteOrder;
  * @author Lee Rhodes
  */
 class WritableBufferImpl extends BaseWritableBufferImpl {
-  final long unsafeObjHeader; //Heap ByteBuffer includes the slice() offset here.
   BaseWritableMemoryImpl originMemory = null; //If I came from here ...
 
   //Static variable for cases where byteBuf/array sizes are zero
@@ -61,7 +60,6 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
 
   WritableBufferImpl(final ResourceState state) {
     super(state);
-    unsafeObjHeader = state.getUnsafeObjectHeader();
   }
 
   //DUPLICATES & REGIONS XXX

--- a/src/main/java/com/yahoo/memory/WritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableBufferImpl.java
@@ -5,7 +5,7 @@
 
 package com.yahoo.memory;
 
-import static com.yahoo.memory.BaseWritableMemoryImpl.copyMemoryCheckingNonOverlapping;
+import static com.yahoo.memory.BaseWritableMemoryImpl.copyMemoryCheckingDifferentObject;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_CHAR_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_CHAR_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_DOUBLE_BASE_OFFSET;
@@ -135,7 +135,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthChars) << CHAR_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
@@ -166,7 +166,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthDoubles) << DOUBLE_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
@@ -196,7 +196,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthFloats) << FLOAT_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
@@ -226,7 +226,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthInts) << INT_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
@@ -256,7 +256,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthLongs) << LONG_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
@@ -286,7 +286,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthShorts) << SHORT_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
@@ -317,7 +317,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthChars) << CHAR_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
             srcArray,
             ARRAY_CHAR_BASE_OFFSET + (((long) srcOffset) << CHAR_SHIFT),
             unsafeObj,
@@ -348,7 +348,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthDoubles) << DOUBLE_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
             srcArray,
             ARRAY_DOUBLE_BASE_OFFSET + (((long) srcOffset) << DOUBLE_SHIFT),
             unsafeObj,
@@ -378,7 +378,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthFloats) << FLOAT_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
             srcArray,
             ARRAY_FLOAT_BASE_OFFSET + (((long) srcOffset) << FLOAT_SHIFT),
             unsafeObj,
@@ -408,7 +408,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthInts) << INT_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
             srcArray,
             ARRAY_INT_BASE_OFFSET + (((long) srcOffset) << INT_SHIFT),
             unsafeObj,
@@ -438,7 +438,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthLongs) << LONG_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
             srcArray,
             ARRAY_LONG_BASE_OFFSET + (((long) srcOffset) << LONG_SHIFT),
             unsafeObj,
@@ -468,7 +468,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthShorts) << SHORT_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
             srcArray,
             ARRAY_SHORT_BASE_OFFSET + (((long) srcOffset) << SHORT_SHIFT),
             unsafeObj,

--- a/src/main/java/com/yahoo/memory/WritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableBufferImpl.java
@@ -58,7 +58,7 @@ class WritableBufferImpl extends WritableBuffer {
   final Object unsafeObj; //Array objects are held here.
   final long unsafeObjHeader; //Heap ByteBuffer includes the slice() offset here.
   final long cumBaseOffset; //Holds the cumulative offset to the start of data.
-  WritableMemoryImpl originMemory = null; //If I came from here ...
+  BaseWritableMemoryImpl originMemory = null; //If I came from here ...
 
   //Static variable for cases where byteBuf/array sizes are zero
   final static WritableBufferImpl ZERO_SIZE_BUFFER;

--- a/src/main/java/com/yahoo/memory/WritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableBufferImpl.java
@@ -5,6 +5,7 @@
 
 package com.yahoo.memory;
 
+import static com.yahoo.memory.BaseWritableMemoryImpl.copyMemoryCheckingNonOverlapping;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_CHAR_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_CHAR_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_DOUBLE_BASE_OFFSET;
@@ -137,7 +138,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthChars) << CHAR_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
@@ -168,7 +169,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthDoubles) << DOUBLE_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
@@ -198,7 +199,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthFloats) << FLOAT_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
@@ -228,7 +229,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthInts) << INT_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
@@ -258,7 +259,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthLongs) << LONG_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
@@ -288,7 +289,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthShorts) << SHORT_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
@@ -344,7 +345,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthChars) << CHAR_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
             srcArray,
             ARRAY_CHAR_BASE_OFFSET + (((long) srcOffset) << CHAR_SHIFT),
             unsafeObj,
@@ -375,7 +376,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthDoubles) << DOUBLE_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
             srcArray,
             ARRAY_DOUBLE_BASE_OFFSET + (((long) srcOffset) << DOUBLE_SHIFT),
             unsafeObj,
@@ -405,7 +406,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthFloats) << FLOAT_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
             srcArray,
             ARRAY_FLOAT_BASE_OFFSET + (((long) srcOffset) << FLOAT_SHIFT),
             unsafeObj,
@@ -435,7 +436,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthInts) << INT_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
             srcArray,
             ARRAY_INT_BASE_OFFSET + (((long) srcOffset) << INT_SHIFT),
             unsafeObj,
@@ -465,7 +466,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthLongs) << LONG_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
             srcArray,
             ARRAY_LONG_BASE_OFFSET + (((long) srcOffset) << LONG_SHIFT),
             unsafeObj,
@@ -495,7 +496,7 @@ class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthShorts) << SHORT_SHIFT;
     incrementAndCheckPosition(pos, copyBytes);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
             srcArray,
             ARRAY_SHORT_BASE_OFFSET + (((long) srcOffset) << SHORT_SHIFT),
             unsafeObj,

--- a/src/main/java/com/yahoo/memory/WritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableBufferImpl.java
@@ -23,13 +23,10 @@ import static com.yahoo.memory.UnsafeUtil.DOUBLE_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.FLOAT_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.INT_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.LONG_SHIFT;
-import static com.yahoo.memory.UnsafeUtil.LS;
 import static com.yahoo.memory.UnsafeUtil.SHORT_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.assertBounds;
 import static com.yahoo.memory.UnsafeUtil.checkBounds;
 import static com.yahoo.memory.UnsafeUtil.unsafe;
-
-import java.nio.ByteOrder;
 
 /*
  * Developer notes: The heavier methods, such as put/get arrays, duplicate, region, clear, fill,

--- a/src/main/java/com/yahoo/memory/WritableMapHandle.java
+++ b/src/main/java/com/yahoo/memory/WritableMapHandle.java
@@ -16,9 +16,9 @@ package com.yahoo.memory;
 public final class WritableMapHandle extends MapHandle implements WritableMap, WritableHandle
 {
   AllocateDirectWritableMap dirWmap;
-  WritableMemoryImpl wMemImpl;
+  BaseWritableMemoryImpl wMemImpl;
 
-  private WritableMapHandle(final AllocateDirectWritableMap dirWmap, final WritableMemoryImpl wMem) {
+  private WritableMapHandle(final AllocateDirectWritableMap dirWmap, final BaseWritableMemoryImpl wMem) {
     super(dirWmap, wMem);
     this.dirWmap = dirWmap;
     wMemImpl = wMem;
@@ -27,7 +27,7 @@ public final class WritableMapHandle extends MapHandle implements WritableMap, W
   @SuppressWarnings("resource") //called from memory
   static WritableMapHandle map(final ResourceState state) throws Exception {
     final AllocateDirectWritableMap dirMap = AllocateDirectWritableMap.map(state);
-    final WritableMemoryImpl wMem = new WritableMemoryImpl(state);
+    final BaseWritableMemoryImpl wMem = new WritableMemoryImpl(state);
     return new WritableMapHandle(dirMap, wMem);
   }
 

--- a/src/main/java/com/yahoo/memory/WritableMemory.java
+++ b/src/main/java/com/yahoo/memory/WritableMemory.java
@@ -42,7 +42,7 @@ public abstract class WritableMemory extends Memory {
     final ResourceState state = new ResourceState();
     state.putByteBuffer(byteBuf);
     AccessByteBuffer.wrap(state);
-    final WritableMemoryImpl impl = new WritableMemoryImpl(state);
+    final BaseWritableMemoryImpl impl = new WritableMemoryImpl(state);
     return impl;
   }
 

--- a/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
@@ -50,7 +50,6 @@ import java.nio.ByteOrder;
  * @author Lee Rhodes
  */
 class WritableMemoryImpl extends BaseWritableMemoryImpl {
-  final long unsafeObjHeader; //Heap ByteBuffer includes the slice() offset here.
 
   //Static variable for cases where byteBuf/array/direct sizes are zero
   final static WritableMemoryImpl ZERO_SIZE_MEMORY;
@@ -61,7 +60,6 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
 
   WritableMemoryImpl(final ResourceState state) {
     super(state);
-    unsafeObjHeader = state.getUnsafeObjectHeader();
   }
 
   //DUPLICATES & REGIONS XXX

--- a/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
@@ -120,7 +120,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthChars) << CHAR_SHIFT;
     checkBounds(offsetBytes, copyBytes, capacity);
     checkBounds(dstOffset, lengthChars, dstArray.length);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
@@ -150,7 +150,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthDoubles) << DOUBLE_SHIFT;
     checkBounds(offsetBytes, copyBytes, capacity);
     checkBounds(dstOffset, lengthDoubles, dstArray.length);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
@@ -172,7 +172,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthFloats) << FLOAT_SHIFT;
     checkBounds(offsetBytes, copyBytes, capacity);
     checkBounds(dstOffset, lengthFloats, dstArray.length);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
@@ -194,7 +194,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthInts) << INT_SHIFT;
     checkBounds(offsetBytes, copyBytes, capacity);
     checkBounds(dstOffset, lengthInts, dstArray.length);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
@@ -216,7 +216,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthLongs) << LONG_SHIFT;
     checkBounds(offsetBytes, copyBytes, capacity);
     checkBounds(dstOffset, lengthLongs, dstArray.length);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
@@ -238,7 +238,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthShorts) << SHORT_SHIFT;
     checkBounds(offsetBytes, copyBytes, capacity);
     checkBounds(dstOffset, lengthShorts, dstArray.length);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
@@ -261,7 +261,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthChars) << CHAR_SHIFT;
     checkBounds(srcOffset, lengthChars, srcArray.length);
     checkBounds(offsetBytes, copyBytes, capacity);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
         srcArray,
         ARRAY_CHAR_BASE_OFFSET + (((long) srcOffset) << CHAR_SHIFT),
         unsafeObj,
@@ -290,7 +290,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthDoubles) << DOUBLE_SHIFT;
     checkBounds(srcOffset, lengthDoubles, srcArray.length);
     checkBounds(offsetBytes, copyBytes, capacity);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
         srcArray,
         ARRAY_DOUBLE_BASE_OFFSET + (((long) srcOffset) << DOUBLE_SHIFT),
         unsafeObj,
@@ -313,7 +313,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthFloats) << FLOAT_SHIFT;
     checkBounds(srcOffset, lengthFloats, srcArray.length);
     checkBounds(offsetBytes, copyBytes, capacity);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
         srcArray,
         ARRAY_FLOAT_BASE_OFFSET + (((long) srcOffset) << FLOAT_SHIFT),
         unsafeObj,
@@ -336,7 +336,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthInts) << INT_SHIFT;
     checkBounds(srcOffset, lengthInts, srcArray.length);
     checkBounds(offsetBytes, copyBytes, capacity);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
         srcArray,
         ARRAY_INT_BASE_OFFSET + (((long) srcOffset) << INT_SHIFT),
         unsafeObj,
@@ -359,7 +359,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthLongs) << LONG_SHIFT;
     checkBounds(srcOffset, lengthLongs, srcArray.length);
     checkBounds(offsetBytes, copyBytes, capacity);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
         srcArray,
         ARRAY_LONG_BASE_OFFSET + (((long) srcOffset) << LONG_SHIFT),
         unsafeObj,
@@ -382,7 +382,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthShorts) << SHORT_SHIFT;
     checkBounds(srcOffset, lengthShorts, srcArray.length);
     checkBounds(offsetBytes, copyBytes, capacity);
-    copyMemoryCheckingNonOverlapping(
+    copyMemoryCheckingDifferentObject(
         srcArray,
         ARRAY_SHORT_BASE_OFFSET + (((long) srcOffset) << SHORT_SHIFT),
         unsafeObj,

--- a/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
@@ -22,14 +22,12 @@ import static com.yahoo.memory.UnsafeUtil.DOUBLE_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.FLOAT_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.INT_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.LONG_SHIFT;
-import static com.yahoo.memory.UnsafeUtil.LS;
 import static com.yahoo.memory.UnsafeUtil.SHORT_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.assertBounds;
 import static com.yahoo.memory.UnsafeUtil.checkBounds;
 import static com.yahoo.memory.UnsafeUtil.unsafe;
 
 import java.io.IOException;
-import java.nio.ByteOrder;
 
 /*
  * Developer notes: The heavier methods, such as put/get arrays, duplicate, region, clear, fill,

--- a/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
@@ -120,7 +120,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthChars) << CHAR_SHIFT;
     checkBounds(offsetBytes, copyBytes, capacity);
     checkBounds(dstOffset, lengthChars, dstArray.length);
-    copyMemoryCheckingDifferentObject(
+    CompareAndCopy.copyMemoryCheckingDifferentObject(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
@@ -150,7 +150,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthDoubles) << DOUBLE_SHIFT;
     checkBounds(offsetBytes, copyBytes, capacity);
     checkBounds(dstOffset, lengthDoubles, dstArray.length);
-    copyMemoryCheckingDifferentObject(
+    CompareAndCopy.copyMemoryCheckingDifferentObject(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
@@ -172,7 +172,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthFloats) << FLOAT_SHIFT;
     checkBounds(offsetBytes, copyBytes, capacity);
     checkBounds(dstOffset, lengthFloats, dstArray.length);
-    copyMemoryCheckingDifferentObject(
+    CompareAndCopy.copyMemoryCheckingDifferentObject(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
@@ -194,7 +194,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthInts) << INT_SHIFT;
     checkBounds(offsetBytes, copyBytes, capacity);
     checkBounds(dstOffset, lengthInts, dstArray.length);
-    copyMemoryCheckingDifferentObject(
+    CompareAndCopy.copyMemoryCheckingDifferentObject(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
@@ -216,7 +216,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthLongs) << LONG_SHIFT;
     checkBounds(offsetBytes, copyBytes, capacity);
     checkBounds(dstOffset, lengthLongs, dstArray.length);
-    copyMemoryCheckingDifferentObject(
+    CompareAndCopy.copyMemoryCheckingDifferentObject(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
@@ -238,7 +238,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthShorts) << SHORT_SHIFT;
     checkBounds(offsetBytes, copyBytes, capacity);
     checkBounds(dstOffset, lengthShorts, dstArray.length);
-    copyMemoryCheckingDifferentObject(
+    CompareAndCopy.copyMemoryCheckingDifferentObject(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
@@ -261,7 +261,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthChars) << CHAR_SHIFT;
     checkBounds(srcOffset, lengthChars, srcArray.length);
     checkBounds(offsetBytes, copyBytes, capacity);
-    copyMemoryCheckingDifferentObject(
+    CompareAndCopy.copyMemoryCheckingDifferentObject(
         srcArray,
         ARRAY_CHAR_BASE_OFFSET + (((long) srcOffset) << CHAR_SHIFT),
         unsafeObj,
@@ -290,7 +290,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthDoubles) << DOUBLE_SHIFT;
     checkBounds(srcOffset, lengthDoubles, srcArray.length);
     checkBounds(offsetBytes, copyBytes, capacity);
-    copyMemoryCheckingDifferentObject(
+    CompareAndCopy.copyMemoryCheckingDifferentObject(
         srcArray,
         ARRAY_DOUBLE_BASE_OFFSET + (((long) srcOffset) << DOUBLE_SHIFT),
         unsafeObj,
@@ -313,7 +313,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthFloats) << FLOAT_SHIFT;
     checkBounds(srcOffset, lengthFloats, srcArray.length);
     checkBounds(offsetBytes, copyBytes, capacity);
-    copyMemoryCheckingDifferentObject(
+    CompareAndCopy.copyMemoryCheckingDifferentObject(
         srcArray,
         ARRAY_FLOAT_BASE_OFFSET + (((long) srcOffset) << FLOAT_SHIFT),
         unsafeObj,
@@ -336,7 +336,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthInts) << INT_SHIFT;
     checkBounds(srcOffset, lengthInts, srcArray.length);
     checkBounds(offsetBytes, copyBytes, capacity);
-    copyMemoryCheckingDifferentObject(
+    CompareAndCopy.copyMemoryCheckingDifferentObject(
         srcArray,
         ARRAY_INT_BASE_OFFSET + (((long) srcOffset) << INT_SHIFT),
         unsafeObj,
@@ -359,7 +359,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthLongs) << LONG_SHIFT;
     checkBounds(srcOffset, lengthLongs, srcArray.length);
     checkBounds(offsetBytes, copyBytes, capacity);
-    copyMemoryCheckingDifferentObject(
+    CompareAndCopy.copyMemoryCheckingDifferentObject(
         srcArray,
         ARRAY_LONG_BASE_OFFSET + (((long) srcOffset) << LONG_SHIFT),
         unsafeObj,
@@ -382,7 +382,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthShorts) << SHORT_SHIFT;
     checkBounds(srcOffset, lengthShorts, srcArray.length);
     checkBounds(offsetBytes, copyBytes, capacity);
-    copyMemoryCheckingDifferentObject(
+    CompareAndCopy.copyMemoryCheckingDifferentObject(
         srcArray,
         ARRAY_SHORT_BASE_OFFSET + (((long) srcOffset) << SHORT_SHIFT),
         unsafeObj,

--- a/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
@@ -122,7 +122,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthChars) << CHAR_SHIFT;
     checkBounds(offsetBytes, copyBytes, capacity);
     checkBounds(dstOffset, lengthChars, dstArray.length);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
@@ -152,7 +152,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthDoubles) << DOUBLE_SHIFT;
     checkBounds(offsetBytes, copyBytes, capacity);
     checkBounds(dstOffset, lengthDoubles, dstArray.length);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
@@ -174,7 +174,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthFloats) << FLOAT_SHIFT;
     checkBounds(offsetBytes, copyBytes, capacity);
     checkBounds(dstOffset, lengthFloats, dstArray.length);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
@@ -196,7 +196,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthInts) << INT_SHIFT;
     checkBounds(offsetBytes, copyBytes, capacity);
     checkBounds(dstOffset, lengthInts, dstArray.length);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
@@ -218,7 +218,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthLongs) << LONG_SHIFT;
     checkBounds(offsetBytes, copyBytes, capacity);
     checkBounds(dstOffset, lengthLongs, dstArray.length);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
@@ -240,7 +240,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthShorts) << SHORT_SHIFT;
     checkBounds(offsetBytes, copyBytes, capacity);
     checkBounds(dstOffset, lengthShorts, dstArray.length);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
@@ -289,7 +289,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthChars) << CHAR_SHIFT;
     checkBounds(srcOffset, lengthChars, srcArray.length);
     checkBounds(offsetBytes, copyBytes, capacity);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
         srcArray,
         ARRAY_CHAR_BASE_OFFSET + (((long) srcOffset) << CHAR_SHIFT),
         unsafeObj,
@@ -318,7 +318,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthDoubles) << DOUBLE_SHIFT;
     checkBounds(srcOffset, lengthDoubles, srcArray.length);
     checkBounds(offsetBytes, copyBytes, capacity);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
         srcArray,
         ARRAY_DOUBLE_BASE_OFFSET + (((long) srcOffset) << DOUBLE_SHIFT),
         unsafeObj,
@@ -341,7 +341,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthFloats) << FLOAT_SHIFT;
     checkBounds(srcOffset, lengthFloats, srcArray.length);
     checkBounds(offsetBytes, copyBytes, capacity);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
         srcArray,
         ARRAY_FLOAT_BASE_OFFSET + (((long) srcOffset) << FLOAT_SHIFT),
         unsafeObj,
@@ -364,7 +364,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthInts) << INT_SHIFT;
     checkBounds(srcOffset, lengthInts, srcArray.length);
     checkBounds(offsetBytes, copyBytes, capacity);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
         srcArray,
         ARRAY_INT_BASE_OFFSET + (((long) srcOffset) << INT_SHIFT),
         unsafeObj,
@@ -387,7 +387,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthLongs) << LONG_SHIFT;
     checkBounds(srcOffset, lengthLongs, srcArray.length);
     checkBounds(offsetBytes, copyBytes, capacity);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
         srcArray,
         ARRAY_LONG_BASE_OFFSET + (((long) srcOffset) << LONG_SHIFT),
         unsafeObj,
@@ -410,7 +410,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     final long copyBytes = ((long) lengthShorts) << SHORT_SHIFT;
     checkBounds(srcOffset, lengthShorts, srcArray.length);
     checkBounds(offsetBytes, copyBytes, capacity);
-    unsafe.copyMemory(
+    copyMemoryCheckingNonOverlapping(
         srcArray,
         ARRAY_SHORT_BASE_OFFSET + (((long) srcOffset) << SHORT_SHIFT),
         unsafeObj,

--- a/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
@@ -248,32 +248,6 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
         copyBytes);
   }
 
-  @Override
-  public ByteOrder getResourceOrder() {
-    state.assertValid();
-    return state.order();
-  }
-
-  @Override
-  public boolean swapBytes() {
-    state.assertValid();
-    return state.isSwapBytes();
-  }
-
-  @Override
-  public String toHexString(final String header, final long offsetBytes, final int lengthBytes) {
-    state.checkValid();
-    final String klass = this.getClass().getSimpleName();
-    final String s1 = String.format("(..., %d, %d)", offsetBytes, lengthBytes);
-    final long hcode = hashCode() & 0XFFFFFFFFL;
-    final String call = ".toHexString" + s1 + ", hashCode: " + hcode;
-    final StringBuilder sb = new StringBuilder();
-    sb.append("### ").append(klass).append(" SUMMARY ###").append(LS);
-    sb.append("Header Comment      : ").append(header).append(LS);
-    sb.append("Call Parameters     : ").append(call);
-    return Memory.toHex(sb.toString(), offsetBytes, lengthBytes, state);
-  }
-
   //PRIMITIVE putXXX() and putXXXArray() implementations XXX
   @Override
   public void putChar(final long offsetBytes, final char value) {

--- a/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
@@ -5,10 +5,6 @@
 
 package com.yahoo.memory;
 
-import static com.yahoo.memory.UnsafeUtil.ARRAY_BOOLEAN_BASE_OFFSET;
-import static com.yahoo.memory.UnsafeUtil.ARRAY_BOOLEAN_INDEX_SCALE;
-import static com.yahoo.memory.UnsafeUtil.ARRAY_BYTE_BASE_OFFSET;
-import static com.yahoo.memory.UnsafeUtil.ARRAY_BYTE_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_CHAR_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_CHAR_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_DOUBLE_BASE_OFFSET;
@@ -33,7 +29,6 @@ import static com.yahoo.memory.UnsafeUtil.checkBounds;
 import static com.yahoo.memory.UnsafeUtil.unsafe;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 /*
@@ -54,12 +49,8 @@ import java.nio.ByteOrder;
  * @author Roman Leventov
  * @author Lee Rhodes
  */
-class WritableMemoryImpl extends WritableMemory {
-  final ResourceState state;
-  final Object unsafeObj; //Array objects are held here.
+class WritableMemoryImpl extends BaseWritableMemoryImpl {
   final long unsafeObjHeader; //Heap ByteBuffer includes the slice() offset here.
-  final long capacity;
-  final long cumBaseOffset; //Holds the cumulative offset to the start of data.
 
   //Static variable for cases where byteBuf/array/direct sizes are zero
   final static WritableMemoryImpl ZERO_SIZE_MEMORY;
@@ -69,11 +60,8 @@ class WritableMemoryImpl extends WritableMemory {
   }
 
   WritableMemoryImpl(final ResourceState state) {
-    this.state = state;
-    unsafeObj = state.getUnsafeObject();
+    super(state);
     unsafeObjHeader = state.getUnsafeObjectHeader();
-    capacity = state.getCapacity();
-    cumBaseOffset = state.getCumBaseOffset();
   }
 
   //DUPLICATES & REGIONS XXX
@@ -122,50 +110,6 @@ class WritableMemoryImpl extends WritableMemory {
   }
 
   ///PRIMITIVE getXXX() and getXXXArray() XXX
-  @Override
-  public boolean getBoolean(final long offsetBytes) {
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE, capacity);
-    return unsafe.getBoolean(unsafeObj, cumBaseOffset + offsetBytes);
-  }
-
-  @Override
-  public void getBooleanArray(final long offsetBytes, final boolean[] dstArray,
-      final int dstOffset, final int lengthBooleans) {
-    state.checkValid();
-    final long copyBytes = lengthBooleans;
-    checkBounds(offsetBytes, copyBytes, capacity);
-    checkBounds(dstOffset, lengthBooleans, dstArray.length);
-    unsafe.copyMemory(
-        unsafeObj,
-        cumBaseOffset + offsetBytes,
-        dstArray,
-        ARRAY_BOOLEAN_BASE_OFFSET + dstOffset,
-        copyBytes);
-  }
-
-  @Override
-  public byte getByte(final long offsetBytes) {
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_BYTE_INDEX_SCALE, capacity);
-    return unsafe.getByte(unsafeObj, cumBaseOffset + offsetBytes);
-  }
-
-  @Override
-  public void getByteArray(final long offsetBytes, final byte[] dstArray, final int dstOffset,
-      final int lengthBytes) {
-    state.checkValid();
-    final long copyBytes = lengthBytes;
-    checkBounds(offsetBytes, copyBytes, capacity);
-    checkBounds(dstOffset, lengthBytes, dstArray.length);
-    unsafe.copyMemory(
-        unsafeObj,
-        cumBaseOffset + offsetBytes,
-        dstArray,
-        ARRAY_BYTE_BASE_OFFSET + dstOffset,
-        copyBytes);
-  }
-
   @Override
   public char getChar(final long offsetBytes) {
     state.assertValid();
@@ -306,121 +250,10 @@ class WritableMemoryImpl extends WritableMemory {
         copyBytes);
   }
 
-  //OTHER PRIMITIVE READ METHODS: compareTo, copyTo XXX
-  @Override
-  public int compareTo(final long thisOffsetBytes, final long thisLengthBytes, final Memory that,
-      final long thatOffsetBytes, final long thatLengthBytes) {
-    state.checkValid();
-    checkBounds(thisOffsetBytes, thisLengthBytes, capacity);
-    checkBounds(thatOffsetBytes, thatLengthBytes, that.getCapacity());
-    if (isSameResource(that)) {
-      if (thisOffsetBytes == thatOffsetBytes) {
-        return 0;
-      }
-    } else {
-      that.getResourceState().checkValid();
-    }
-    final long thisAdd = getCumulativeOffset(thisOffsetBytes);
-    final long thatAdd = that.getCumulativeOffset(thatOffsetBytes);
-    final Object thisObj = (isDirect()) ? null : unsafeObj;
-    final Object thatObj = (that.isDirect()) ? null : ((WritableMemory)that).getArray();
-    final long lenBytes = Math.min(thisLengthBytes, thatLengthBytes);
-    for (long i = 0; i < lenBytes; i++) {
-      final int thisByte = unsafe.getByte(thisObj, thisAdd + i);
-      final int thatByte = unsafe.getByte(thatObj, thatAdd + i);
-      if (thisByte < thatByte) { return -1; }
-      if (thisByte > thatByte) { return  1; }
-    }
-    return Long.compare(thisLengthBytes, thatLengthBytes);
-  }
-
-  @Override
-  public void copyTo(final long srcOffsetBytes, final WritableMemory destination,
-      final long dstOffsetBytes, final long lengthBytes) {
-    state.checkValid();
-    checkBounds(srcOffsetBytes, lengthBytes, capacity);
-    checkBounds(dstOffsetBytes, lengthBytes, destination.getCapacity());
-    if (isSameResource(destination)) {
-      if (srcOffsetBytes == dstOffsetBytes) {
-        return;
-      }
-    } else {
-      destination.getResourceState().checkValid();
-    }
-    final long srcAdd = getCumulativeOffset(srcOffsetBytes);
-    final long dstAdd = destination.getCumulativeOffset(dstOffsetBytes);
-    final Object srcParent = (isDirect()) ? null : unsafeObj;
-    final Object dstParent = (destination.isDirect()) ? null : destination.getArray();
-    final long lenBytes = lengthBytes;
-    unsafe.copyMemory(srcParent, srcAdd, dstParent, dstAdd, lenBytes);
-  }
-
-  //OTHER READ METHODS XXX
-  @Override
-  public void checkValidAndBounds(final long offsetBytes, final long lengthBytes) {
-    state.checkValid();
-    checkBounds(offsetBytes, lengthBytes, capacity);
-  }
-
-  @Override
-  public long getCapacity() {
-    state.assertValid();
-    return capacity;
-  }
-
-  @Override
-  public long getCumulativeOffset(final long offsetBytes) {
-    state.assertValid();
-    return cumBaseOffset + offsetBytes;
-  }
-
-  @Override
-  public long getRegionOffset(final long offsetBytes) {
-    state.assertValid();
-    return state.getRegionOffset() + offsetBytes;
-  }
-
   @Override
   public ByteOrder getResourceOrder() {
     state.assertValid();
     return state.order();
-  }
-
-  @Override
-  public boolean hasArray() {
-    state.assertValid();
-    return unsafeObj != null;
-  }
-
-  @Override
-  public boolean hasByteBuffer() {
-    state.assertValid();
-    return state.getByteBuffer() != null;
-  }
-
-  @Override
-  public boolean isDirect() {
-    state.assertValid();
-    return state.isDirect();
-  }
-
-  @Override
-  public boolean isResourceReadOnly() {
-    state.assertValid();
-    return state.isResourceReadOnly();
-  }
-
-  @Override
-  public boolean isSameResource(final Memory that) {
-    if (that == null) { return false; }
-    state.checkValid();
-    that.getResourceState().checkValid();
-    return state.isSameResource(that.getResourceState());
-  }
-
-  @Override
-  public boolean isValid() {
-    return state.isValid();
   }
 
   @Override
@@ -444,52 +277,6 @@ class WritableMemoryImpl extends WritableMemory {
   }
 
   //PRIMITIVE putXXX() and putXXXArray() implementations XXX
-  @Override
-  public void putBoolean(final long offsetBytes, final boolean value) {
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE, capacity);
-    unsafe.putBoolean(unsafeObj, cumBaseOffset + offsetBytes, value);
-  }
-
-  @Override
-  public void putBooleanArray(final long offsetBytes, final boolean[] srcArray, final int srcOffset,
-      final int lengthBooleans) {
-    state.checkValid();
-    final long copyBytes = lengthBooleans;
-    checkBounds(srcOffset, lengthBooleans, srcArray.length);
-    checkBounds(offsetBytes, copyBytes, capacity);
-    unsafe.copyMemory(
-        srcArray,
-        ARRAY_BOOLEAN_BASE_OFFSET + srcOffset,
-        unsafeObj,
-        cumBaseOffset + offsetBytes,
-        copyBytes
-    );
-  }
-
-  @Override
-  public void putByte(final long offsetBytes, final byte value) {
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_BYTE_INDEX_SCALE, capacity);
-    unsafe.putByte(unsafeObj, cumBaseOffset + offsetBytes, value);
-  }
-
-  @Override
-  public void putByteArray(final long offsetBytes, final byte[] srcArray, final int srcOffset,
-      final int lengthBytes) {
-    state.checkValid();
-    final long copyBytes = lengthBytes;
-    checkBounds(srcOffset, lengthBytes, srcArray.length);
-    checkBounds(offsetBytes, copyBytes, capacity);
-    unsafe.copyMemory(
-        srcArray,
-        ARRAY_BYTE_BASE_OFFSET + srcOffset,
-        unsafeObj,
-        cumBaseOffset + offsetBytes,
-        copyBytes
-    );
-  }
-
   @Override
   public void putChar(final long offsetBytes, final char value) {
     state.assertValid();
@@ -657,91 +444,4 @@ class WritableMemoryImpl extends WritableMemory {
     assertBounds(offsetBytes, ARRAY_LONG_INDEX_SCALE, capacity);
     return unsafe.compareAndSwapLong(unsafeObj, cumBaseOffset + offsetBytes, expect, update);
   }
-
-  //OTHER WRITE METHODS XXX
-  @Override
-  public Object getArray() {
-    state.assertValid();
-    return unsafeObj;
-  }
-
-  @Override
-  public ByteBuffer getByteBuffer() {
-    state.assertValid();
-    return state.getByteBuffer();
-  }
-
-  @Override
-  public void clear() {
-    fill(0, capacity, (byte) 0);
-  }
-
-  @Override
-  public void clear(final long offsetBytes, final long lengthBytes) {
-    fill(offsetBytes, lengthBytes, (byte) 0);
-  }
-
-  @Override
-  public void clearBits(final long offsetBytes, final byte bitMask) {
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_BYTE_INDEX_SCALE, capacity);
-    final long cumBaseOff = cumBaseOffset + offsetBytes;
-    int value = unsafe.getByte(unsafeObj, cumBaseOff) & 0XFF;
-    value &= ~bitMask;
-    unsafe.putByte(unsafeObj, cumBaseOff, (byte)value);
-  }
-
-  @Override
-  public void fill(final byte value) {
-    fill(0, capacity, value);
-  }
-
-  @Override
-  public void fill(final long offsetBytes, final long lengthBytes, final byte value) {
-    state.checkValid();
-    checkBounds(offsetBytes, lengthBytes, capacity);
-    unsafe.setMemory(unsafeObj, cumBaseOffset + offsetBytes, lengthBytes, value);
-  }
-
-  @Override
-  public void setBits(final long offsetBytes, final byte bitMask) {
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_BYTE_INDEX_SCALE, capacity);
-    final long myOffset = cumBaseOffset + offsetBytes;
-    final byte value = unsafe.getByte(unsafeObj, myOffset);
-    unsafe.putByte(unsafeObj, myOffset, (byte)(value | bitMask));
-  }
-
-  //OTHER XXX
-  @Override
-  public MemoryRequestServer getMemoryRequestServer() { //only applicable to writable
-    state.assertValid();
-    return state.getMemoryRequestServer();
-  }
-
-  @Override
-  public void setMemoryRequest(final MemoryRequestServer memReqSvr) {
-    state.assertValid();
-    state.setMemoryRequestServer(memReqSvr);
-  }
-
-  @Override
-  public WritableDirectHandle getHandle() {
-    state.assertValid();
-    return state.getHandle();
-  }
-
-  @Override
-  public void setHandle(final WritableDirectHandle handle) {
-    state.assertValid();
-    state.setHandle(handle);
-  }
-
-  //RESTRICTED XXX
-
-  @Override
-  ResourceState getResourceState() {
-    return state;
-  }
-
 }

--- a/src/test/java/com/yahoo/memory/WritableMemoryImplTest.java
+++ b/src/test/java/com/yahoo/memory/WritableMemoryImplTest.java
@@ -205,11 +205,10 @@ public class WritableMemoryImplTest {
 
   //Copy Within tests
 
-  @Test
+  @Test(expectedExceptions = IllegalArgumentException.class)
   public void checkDegenerateCopyTo() {
     WritableMemory wmem = WritableMemory.allocate(64);
     wmem.copyTo(0, wmem, 0, 64);
-    //TODO
   }
 
   @Test

--- a/src/test/java/com/yahoo/memory/WritableMemoryImplTest.java
+++ b/src/test/java/com/yahoo/memory/WritableMemoryImplTest.java
@@ -609,6 +609,14 @@ public class WritableMemoryImplTest {
   }
 
   @Test
+  public void testCompareToSameStart() {
+    Memory mem = WritableMemory.allocate(3);
+    assertEquals(-1, mem.compareTo(0, 1, mem, 0, 2));
+    assertEquals(0, mem.compareTo(1, 1, mem, 1, 1));
+    assertEquals(1, mem.compareTo(1, 2, mem, 1, 1));
+  }
+
+  @Test
   public void checkAsBuffer() {
     WritableMemory wmem = WritableMemory.allocate(64);
     WritableBuffer wbuf = wmem.asWritableBuffer();

--- a/src/test/java/com/yahoo/memory/WritableMemoryTest.java
+++ b/src/test/java/com/yahoo/memory/WritableMemoryTest.java
@@ -31,4 +31,13 @@ public class WritableMemoryTest {
     assertEquals(wbuf.getResourceOrder(), ByteOrder.BIG_ENDIAN);
   }
 
+  @Test
+  public void checkGetArray() {
+    byte[] byteArr = new byte[64];
+    WritableMemory wmem = WritableMemory.wrap(byteArr);
+    assertTrue(wmem.getArray() == byteArr);
+    WritableBuffer wbuf = wmem.asWritableBuffer();
+    assertTrue(wbuf.getArray() == byteArr);
+  }
+
 }

--- a/src/test/java/com/yahoo/memory/WritableMemoryTest.java
+++ b/src/test/java/com/yahoo/memory/WritableMemoryTest.java
@@ -40,4 +40,11 @@ public class WritableMemoryTest {
     assertTrue(wbuf.getArray() == byteArr);
   }
 
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void checkSelfArrayCopy() {
+    byte[] srcAndDst = new byte[128];
+    WritableMemory wmem = WritableMemory.wrap(srcAndDst);
+    wmem.getByteArray(0, srcAndDst, 64, 64);  //non-overlapping
+  }
+
 }

--- a/src/test/java/com/yahoo/memory/WritableMemoryTest.java
+++ b/src/test/java/com/yahoo/memory/WritableMemoryTest.java
@@ -6,6 +6,7 @@
 package com.yahoo.memory;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import java.nio.ByteBuffer;
@@ -46,5 +47,65 @@ public class WritableMemoryTest {
     WritableMemory wmem = WritableMemory.wrap(srcAndDst);
     wmem.getByteArray(0, srcAndDst, 64, 64);  //non-overlapping
   }
+
+  @Test
+  public void checkEquals() {
+    int len = 7;
+    WritableMemory wmem1 = WritableMemory.allocate(len);
+    assertTrue(wmem1.equalTo(wmem1));
+
+    WritableMemory wmem2 = WritableMemory.allocate(len + 1);
+    assertFalse(wmem1.equalTo(wmem2));
+
+    WritableMemory reg1 = wmem1.writableRegion(0, wmem1.getCapacity());
+    assertTrue(wmem1.equalTo(reg1));
+
+    wmem2 = WritableMemory.allocate(len);
+    for (int i = 0; i < len; i++) {
+      wmem1.putByte(i, (byte) i);
+      wmem2.putByte(i, (byte) i);
+    }
+    assertTrue(wmem1.equalTo(wmem2));
+    assertTrue(wmem1.equalTo(0, wmem1, 0, len));
+
+    reg1 = wmem1.writableRegion(0, wmem1.getCapacity());
+    assertTrue(wmem1.equalTo(0, reg1, 0, len));
+
+    len = 24;
+    wmem1 = WritableMemory.allocate(len);
+    wmem2 = WritableMemory.allocate(len);
+    for (int i = 0; i < len; i++) {
+      wmem1.putByte(i, (byte) i);
+      wmem2.putByte(i, (byte) i);
+    }
+    assertTrue(wmem1.equalTo(0, wmem2, 0, len - 1));
+    assertTrue(wmem1.equalTo(0, wmem2, 0, len));
+    wmem2.putByte(0, (byte) 10);
+    assertFalse(wmem1.equalTo(0, wmem2, 0, len));
+    wmem2.putByte(0,  (byte) 0);
+    wmem2.putByte(len - 2, (byte) 0);
+    assertFalse(wmem1.equalTo(0, wmem2, 0, len - 1));
+  }
+
+  @Test
+  public void checkEquals2() {
+    int len = 23;
+    WritableMemory wmem1 = WritableMemory.allocate(len);
+    assertTrue(wmem1.equalTo(wmem1));
+
+    WritableMemory wmem2 = WritableMemory.allocate(len + 1);
+    assertFalse(wmem1.equalTo(wmem2));
+
+
+
+    for (int i = 0; i < len; i++) {
+      wmem1.putByte(i, (byte) i);
+      wmem2.putByte(i, (byte) i);
+    }
+
+    assertTrue(wmem1.equalTo(0, wmem2, 0, len));
+    assertTrue(wmem1.equalTo(1, wmem2, 1, len - 1));
+  }
+
 
 }


### PR DESCRIPTION
1. Extract common `BaseWritableMemoryImpl` and `BaseWritableBufferImpl` in preparation for introduction of non-native Memory and Buffer impls.

2. I cannot agree with the current state of copyTo().

 - You previously said that you don't see long pauses connected to Unsafe.getMemory() anymore. Checking the OpenJDK development history proves that it was indeed fixed, but only in OpenJDK 9, not in OpenJDK 8. So we need to retain chunked copy logic.
 - I made `copyTo()` to tolerate overlapping ranges, but not when the ranges match exactly, because I don't see any cases (including "corner") when it could possibly be a benign intention of the caller, not a bug.
 - I added checks (and chunked copy) to all "getArray" and "putArray" methods. I think the library should be safe and correct first, and fast only after that. Let's not leave a gate for potentially very hard-to-find bugs, until it proves to be a bottleneck in applications. However, I will agree to put those extra checks under `assert`, if you want.