### PR TITLE
Fix a bug in CompareAndCopy.equals(); optimize performance

### DIFF
--- a/src/main/java/com/yahoo/memory/BaseWritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/BaseWritableMemoryImpl.java
@@ -37,16 +37,6 @@ import java.nio.ByteOrder;
  */
 abstract class BaseWritableMemoryImpl extends WritableMemory {
 
-  /**
-   * Don't use {@link sun.misc.Unsafe#copyMemory} to copy blocks of memory larger than this
-   * threshold, because internally it doesn't have safepoint polls, that may cause long
-   * "Time To Safe Point" pauses in the application. This has been fixed in JDK 9 (see
-   * https://bugs.openjdk.java.net/browse/JDK-8149596 and
-   * https://bugs.openjdk.java.net/browse/JDK-8141491), but not in JDK 8, so the Memory library
-   * should keep having this boilerplate as long as it supports Java 8.
-   */
-  static final long UNSAFE_COPY_MEMORY_THRESHOLD = 1024 * 1024;
-
   final ResourceState state;
   final Object unsafeObj; //Array objects are held here.
   final long capacity;

--- a/src/main/java/com/yahoo/memory/CompareAndCopy.java
+++ b/src/main/java/com/yahoo/memory/CompareAndCopy.java
@@ -73,11 +73,11 @@ final class CompareAndCopy {
   static boolean equals(final ResourceState state1, final ResourceState state2) {
     final long cap1 = state1.getCapacity();
     final long cap2 = state2.getCapacity();
-    return cap1 == cap2 && equals(state1, 0, state2, 0, cap1);
+    return (cap1 == cap2) && equals(state1, 0, state2, 0, cap1);
   }
 
-  static boolean equals(final ResourceState state1, long off1, final ResourceState state2,
-      long off2, long lenBytes) {
+  static boolean equals(final ResourceState state1, final long off1, final ResourceState state2,
+      final long off2, long lenBytes) {
     state1.checkValid();
     state2.checkValid();
     if (state1 == state2) { return true; }
@@ -96,7 +96,7 @@ final class CompareAndCopy {
       // int-counted loop to avoid safepoint polls (otherwise why we chunk by
       // UNSAFE_COPY_MEMORY_THRESHOLD)
       int i = 0;
-      for (; i <= chunk - Long.BYTES; i += Long.BYTES) {
+      for (; i <= (chunk - Long.BYTES); i += Long.BYTES) {
         final long v1 = unsafe.getLong(arr1, cumOff1 + i);
         final long v2 = unsafe.getLong(arr2, cumOff2 + i);
         if (v1 == v2) { continue; }

--- a/src/main/java/com/yahoo/memory/CompareAndCopy.java
+++ b/src/main/java/com/yahoo/memory/CompareAndCopy.java
@@ -21,7 +21,7 @@ final class CompareAndCopy {
    * https://bugs.openjdk.java.net/browse/JDK-8141491), but not in JDK 8, so the Memory library
    * should keep having this boilerplate as long as it supports Java 8.
    */
-  static final long UNSAFE_COPY_MEMORY_THRESHOLD = 1024 * 1024;
+  static final int UNSAFE_COPY_MEMORY_THRESHOLD = 1024 * 1024;
 
   static int compare(
       final ResourceState state1, final long offsetBytes1, final long lengthBytes1,
@@ -71,24 +71,13 @@ final class CompareAndCopy {
   }
 
   static boolean equals(final ResourceState state1, final ResourceState state2) {
-    state1.checkValid();
-    state2.checkValid();
-    if (state1 == state2) { return true; }
     final long cap1 = state1.getCapacity();
     final long cap2 = state2.getCapacity();
-    if (cap1 != cap2) { return false; }
-    //capacities are equal
-    final Object arr1 = state1.getUnsafeObject(); //could be null
-    final Object arr2 = state2.getUnsafeObject(); //could be null
-    final long cumOff1 = state1.getCumBaseOffset();
-    final long cumOff2 = state2.getCumBaseOffset();
-    if ((arr1 == arr2) && (cumOff1 == cumOff2)) { return true; }
-    //do it the hard way
-    return equals(state1, 0, state2, 0, cap1);
+    return cap1 == cap2 && equals(state1, 0, state2, 0, cap1);
   }
 
   static boolean equals(final ResourceState state1, long off1, final ResourceState state2,
-      long off2, final long lenBytes) {
+      long off2, long lenBytes) {
     state1.checkValid();
     state2.checkValid();
     if (state1 == state2) { return true; }
@@ -96,40 +85,36 @@ final class CompareAndCopy {
     final long cap2 = state2.getCapacity();
     checkBounds(off1, lenBytes, cap1);
     checkBounds(off2, lenBytes, cap2);
-    final long cumOff1 = state1.getCumBaseOffset() + off1;
-    final long cumOff2 = state2.getCumBaseOffset() + off2;
+    long cumOff1 = state1.getCumBaseOffset() + off1;
+    long cumOff2 = state2.getCumBaseOffset() + off2;
     final Object arr1 = state1.getUnsafeObject(); //could be null
     final Object arr2 = state2.getUnsafeObject(); //could be null
     if ((arr1 == arr2) && (cumOff1 == cumOff2)) { return true; }
 
-    if (lenBytes < 8L) {
-      return equalsByBytes(arr1, cumOff1, arr2, cumOff2, lenBytes);
-    }
-    long longs = lenBytes >>> 3;
-    final long longsThresh = UNSAFE_COPY_MEMORY_THRESHOLD >>> 3;
-    while (longs > 0) {
-      final long chunk = Math.min(longs, longsThresh);
-      for (long i = 0L; i < chunk; i++) {
-        final long v1 = unsafe.getLong(arr1, cumOff1 + (i << 3));
-        final long v2 = unsafe.getLong(arr2, cumOff2 + (i << 3));
+    while (lenBytes >= Long.BYTES) {
+      final int chunk = (int) Math.min(lenBytes, UNSAFE_COPY_MEMORY_THRESHOLD);
+      // int-counted loop to avoid safepoint polls (otherwise why we chunk by
+      // UNSAFE_COPY_MEMORY_THRESHOLD)
+      int i = 0;
+      for (; i <= chunk - Long.BYTES; i += Long.BYTES) {
+        final long v1 = unsafe.getLong(arr1, cumOff1 + i);
+        final long v2 = unsafe.getLong(arr2, cumOff2 + i);
         if (v1 == v2) { continue; }
         else { return false; }
       }
-      longs -= chunk;
-      off1 += chunk;
-      off2 += chunk;
+      lenBytes -= i;
+      cumOff1 += i;
+      cumOff2 += i;
     }
-    final long longBytes = lenBytes & ~0X7;
-    final long remBytes = lenBytes - longBytes;
     //check the remainder bytes, if any
-    return (remBytes == 0) ? true
-        : equalsByBytes(arr1, cumOff1 + longBytes, arr2, cumOff2 + longBytes, remBytes);
+    return (lenBytes == 0) ? true : equalsByBytes(arr1, cumOff1, arr2, cumOff2, (int) lenBytes);
   }
 
   //use only for short runs
   private static boolean equalsByBytes(final Object arr1, final long cumOff1, final Object arr2,
-      final long cumOff2, final long lenBytes) {
-    for (long i = 0; i < lenBytes; i++) {
+      final long cumOff2, final int lenBytes) {
+    // int-counted loop to avoid safepoint polls
+    for (int i = 0; i < lenBytes; i++) {
       final int v1 = unsafe.getByte(arr1, cumOff1 + i);
       final int v2 = unsafe.getByte(arr2, cumOff2 + i);
       if (v1 == v2) { continue; }

--- a/src/main/java/com/yahoo/memory/UnsafeUtil.java
+++ b/src/main/java/com/yahoo/memory/UnsafeUtil.java
@@ -5,10 +5,10 @@
 
 package com.yahoo.memory;
 
-import sun.misc.Unsafe;
-
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+
+import sun.misc.Unsafe;
 
 /**
  * Provides access to the sun.misc.Unsafe class and its key static fields.

--- a/src/main/java/com/yahoo/memory/UnsafeUtil.java
+++ b/src/main/java/com/yahoo/memory/UnsafeUtil.java
@@ -5,10 +5,10 @@
 
 package com.yahoo.memory;
 
+import sun.misc.Unsafe;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-
-import sun.misc.Unsafe;
 
 /**
  * Provides access to the sun.misc.Unsafe class and its key static fields.
@@ -72,12 +72,6 @@ public final class UnsafeUtil {
   public static final String LS = System.getProperty("line.separator");
 
   //@formatter:on
-
-  /**
-   * Large memory copies are broken into segments of bytes of this size to allow for safepoint
-   * polling by the JVM.
-   */
-  public static final long UNSAFE_COPY_THRESHOLD = 1L << 20; //2^20
 
   static {
     try {

--- a/src/test/java/com/yahoo/memory/CopyMemoryTest.java
+++ b/src/test/java/com/yahoo/memory/CopyMemoryTest.java
@@ -5,9 +5,8 @@
 
 package com.yahoo.memory;
 
-import static com.yahoo.memory.BaseWritableMemoryImpl.UNSAFE_COPY_MEMORY_THRESHOLD;
+import static com.yahoo.memory.CompareAndCopy.UNSAFE_COPY_MEMORY_THRESHOLD;
 import static org.testng.Assert.assertEquals;
-//import static org.testng.Assert.assertTrue;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/src/test/java/com/yahoo/memory/CopyMemoryTest.java
+++ b/src/test/java/com/yahoo/memory/CopyMemoryTest.java
@@ -8,10 +8,10 @@ package com.yahoo.memory;
 import static com.yahoo.memory.CompareAndCopy.UNSAFE_COPY_MEMORY_THRESHOLD;
 import static org.testng.Assert.assertEquals;
 
+import java.util.concurrent.ThreadLocalRandom;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.util.concurrent.ThreadLocalRandom;
 
 
 public class CopyMemoryTest {
@@ -72,7 +72,7 @@ public class CopyMemoryTest {
     WritableMemory dstMem = genMem(2 * k1, true); //empty
     srcReg.copyTo(0, dstMem, k1 << 3, (k1/2) << 3);
     //println(dstMem.toHexString("dstMem: ", k1 << 3, (k1/2) << 3));
-    check(dstMem, k1, k1/2, k1/2 + 1);
+    check(dstMem, k1, k1/2, (k1/2) + 1);
   }
 
   @Test
@@ -84,7 +84,7 @@ public class CopyMemoryTest {
     Memory srcReg = baseMem.region((k1/2) << 3, (k1/2) << 3);
     WritableMemory dstMem = genMem(2 * k1, true); //empty
     srcReg.copyTo(0, dstMem, k1 << 3, (k1/2) << 3);
-    check(dstMem, k1, k1/2, k1/2 + 1);
+    check(dstMem, k1, k1/2, (k1/2) + 1);
   }
 
   @Test
@@ -97,13 +97,13 @@ public class CopyMemoryTest {
       Memory srcReg = baseMem.region((k1/2) << 3, (k1/2) << 3);
       WritableMemory dstMem = genMem(2 * k1, true); //empty
       srcReg.copyTo(0, dstMem, k1 << 3, (k1/2) << 3);
-      check(dstMem, k1, k1/2, k1/2 + 1);
+      check(dstMem, k1, k1/2, (k1/2) + 1);
     }
   }
 
   @Test
   public void testOverlappingCopyLeftToRight() {
-    byte[] bytes = new byte[(int) (UNSAFE_COPY_MEMORY_THRESHOLD * 5 / 2 + 1)];
+    byte[] bytes = new byte[((UNSAFE_COPY_MEMORY_THRESHOLD * 5) / 2) + 1];
     ThreadLocalRandom.current().nextBytes(bytes);
     byte[] referenceBytes = bytes.clone();
     Memory referenceMem = Memory.wrap(referenceBytes);
@@ -116,7 +116,7 @@ public class CopyMemoryTest {
 
   @Test
   public void testOverlappingCopyRightToLeft() {
-    byte[] bytes = new byte[(int) (UNSAFE_COPY_MEMORY_THRESHOLD * 5 / 2 + 1)];
+    byte[] bytes = new byte[((UNSAFE_COPY_MEMORY_THRESHOLD * 5) / 2) + 1];
     ThreadLocalRandom.current().nextBytes(bytes);
     byte[] referenceBytes = bytes.clone();
     Memory referenceMem = Memory.wrap(referenceBytes);

--- a/src/test/java/com/yahoo/memory/WritableMemoryTest.java
+++ b/src/test/java/com/yahoo/memory/WritableMemoryTest.java
@@ -98,8 +98,6 @@ public class WritableMemoryTest {
     WritableMemory wmem2 = WritableMemory.allocate(len + 1);
     assertFalse(wmem1.equalTo(wmem2));
 
-
-
     for (int i = 0; i < len; i++) {
       wmem1.putByte(i, (byte) i);
       wmem2.putByte(i, (byte) i);

--- a/src/test/java/com/yahoo/memory/WritableMemoryTest.java
+++ b/src/test/java/com/yahoo/memory/WritableMemoryTest.java
@@ -10,11 +10,11 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
-import org.testng.annotations.Test;
-
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.concurrent.ThreadLocalRandom;
+
+import org.testng.annotations.Test;
 
 public class WritableMemoryTest {
 
@@ -113,20 +113,19 @@ public class WritableMemoryTest {
   public void checkLargeEquals() {
     // Size bigger than UNSAFE_COPY_MEMORY_THRESHOLD; size with "reminder" = 7, to test several
     // traits of the implementation
-    byte[] bytes1 = new byte[UNSAFE_COPY_MEMORY_THRESHOLD * 2 + 7];
+    final int thresh = UNSAFE_COPY_MEMORY_THRESHOLD;
+    byte[] bytes1 = new byte[(thresh * 2) + 7];
     ThreadLocalRandom.current().nextBytes(bytes1);
     byte[] bytes2 = bytes1.clone();
     Memory mem1 = Memory.wrap(bytes1);
     Memory mem2 = Memory.wrap(bytes2);
     assertTrue(mem1.equalTo(mem2));
 
-    bytes2[UNSAFE_COPY_MEMORY_THRESHOLD + 10] =
-        (byte) (bytes1[UNSAFE_COPY_MEMORY_THRESHOLD + 10] + 1);
+    bytes2[thresh + 10] = (byte) (bytes1[thresh + 10] + 1);
     assertFalse(mem1.equalTo(mem2));
 
-    bytes2[UNSAFE_COPY_MEMORY_THRESHOLD + 10] = bytes1[UNSAFE_COPY_MEMORY_THRESHOLD + 10];
-    bytes2[UNSAFE_COPY_MEMORY_THRESHOLD * 2 + 3] =
-        (byte) (bytes1[UNSAFE_COPY_MEMORY_THRESHOLD * 2 + 3] + 1);
+    bytes2[thresh + 10] = bytes1[thresh + 10];
+    bytes2[(thresh * 2) + 3] = (byte) (bytes1[(thresh * 2) + 3] + 1);
     assertFalse(mem1.equalTo(mem2));
   }
 }


### PR DESCRIPTION
1. The fixed bug is pinpointed in the added test.

2. Performance

Before:
```
Benchmark               (size)  Mode  Cnt      Score     Error  Units
EqualsBenchmark.equals       1  avgt    5      7.992 ±   0.184  ns/op
EqualsBenchmark.equals      10  avgt    5     11.687 ±   0.643  ns/op
EqualsBenchmark.equals    1000  avgt    5    121.730 ±  11.028  ns/op
EqualsBenchmark.equals  100000  avgt    5  10674.055 ± 290.646  ns/op
```

After:
```
Benchmark               (size)  Mode  Cnt     Score     Error  Units
EqualsBenchmark.equals       1  avgt    5     7.260 ±   0.206  ns/op
EqualsBenchmark.equals      10  avgt    5    10.057 ±   0.286  ns/op
EqualsBenchmark.equals    1000  avgt    5   106.279 ±   5.983  ns/op
EqualsBenchmark.equals  100000  avgt    5  9476.547 ± 451.854  ns/op
```

It proves that safepoints and int vs long-counted loops make difference, although not as dramatic as I expected.

The benchmark is checked in https://github.com/leventov/memory-jmh-benchmarks