### PR TITLE
Allow jdk gt1.7

### DIFF
--- a/src/main/java/com/yahoo/memory/AccessByteBuffer.java
+++ b/src/main/java/com/yahoo/memory/AccessByteBuffer.java
@@ -32,7 +32,8 @@ final class AccessByteBuffer {
     }
     catch (final NoSuchFieldException e) {
       throw new RuntimeException(
-              "Could not get offset/byteArray from OnHeap ByteBuffer instance: " + e.getClass());
+          "Could not get offset and byteArray fields from ByteBuffer class: " + e.getClass()
+          + UnsafeUtil.tryIllegalAccessPermit);
     }
   }
 

--- a/src/main/java/com/yahoo/memory/AllocateDirect.java
+++ b/src/main/java/com/yahoo/memory/AllocateDirect.java
@@ -41,15 +41,11 @@ final class AllocateDirect implements AutoCloseable {
 
   @Override
   public void close() {
-    try {
-      if (state.isValid()) {
-        ResourceState.currentDirectMemoryAllocations_.decrementAndGet();
-        ResourceState.currentDirectMemoryAllocated_.addAndGet(-state.getCapacity());
-      }
-      cleaner.clean(); //sets invalid
-    } catch (final Exception e) {
-      throw e;
+    if (state.isValid()) {
+      ResourceState.currentDirectMemoryAllocations_.decrementAndGet();
+      ResourceState.currentDirectMemoryAllocated_.addAndGet(-state.getCapacity());
     }
+    cleaner.clean(); //sets invalid
   }
 
   private static final class Deallocator implements Runnable {

--- a/src/main/java/com/yahoo/memory/AllocateDirectMap.java
+++ b/src/main/java/com/yahoo/memory/AllocateDirectMap.java
@@ -92,15 +92,11 @@ class AllocateDirectMap implements Map {
 
   @Override
   public void close() {
-    try {
-      if (state.isValid()) {
-        ResourceState.currentDirectMemoryMapAllocations_.decrementAndGet();
-        ResourceState.currentDirectMemoryMapAllocated_.addAndGet(-state.getCapacity());
-      }
-      cleaner.clean(); //sets invalid
-    } catch (final Exception e) {
-      throw e;
+    if (state.isValid()) {
+      ResourceState.currentDirectMemoryMapAllocations_.decrementAndGet();
+      ResourceState.currentDirectMemoryMapAllocated_.addAndGet(-state.getCapacity());
     }
+    cleaner.clean(); //sets invalid
   }
 
   // Restricted methods
@@ -147,7 +143,8 @@ class AllocateDirectMap implements Map {
       return mbb;
     } catch (final Exception e) {
       throw new RuntimeException(
-              "Could not create Dummy MappedByteBuffer instance: " + e.getClass());
+              "Could not create Dummy MappedByteBuffer instance: " + e.getClass()
+              + UnsafeUtil.tryIllegalAccessPermit);
     }
   }
 

--- a/src/main/java/com/yahoo/memory/UnsafeUtil.java
+++ b/src/main/java/com/yahoo/memory/UnsafeUtil.java
@@ -13,17 +13,21 @@ import sun.misc.Unsafe;
 /**
  * Provides access to the sun.misc.Unsafe class and its key static fields.
  *
- * <p>The internal static initializer also detects whether the methods unique to the Unsafe class in
- * JDK8 are present; if not, methods that are compatible with JDK7 are substituted using an internal
- * interface.  In order for this to work, this library still needs to be compiled using jdk8
- * and it must be done with both source and target versions of jdk7 specified in pom.xml.
+ * <p>The internal static initializer also detects whether the methods unique to the Unsafe class
+ * in JDK8 are present; if not, methods that are compatible with JDK7 are substituted using an
+ * internal interface.  In order for this to work with jdk7, this library must be compiled using
+ * jdk8 and it must be done with both source and target versions of jdk7 specified in pom.xml.
  * The resultant jar will work on jdk7 and jdk8.</p>
+ *
+ * <p>This may work with jdk9 but might require the JVM arg <i>-permit-illegal-access</i>,
+ * <i>–illegal-access=permit</i> or equivalent. Proper operation with jdk9 or above is not
+ * guaranteed and has not be tested.
  *
  * @author Lee Rhodes
  */
 public final class UnsafeUtil {
   public static final Unsafe unsafe;
-  public static final int JDK;
+  public static final double JDK;
   static final JDKCompatibility compatibilityMethods;
 
   //not an indicator of whether compressed references are used.
@@ -31,8 +35,8 @@ public final class UnsafeUtil {
 
   //For 64-bit JVMs: varies depending on coop: 16 for JVM <= 32GB; 24 for JVM > 32GB
   // Making this constant long-typed, rather than int, to exclude possibility of accidental overflow
-  // in expressions like arrayLength * ARRAY_BYTE_BASE_OFFSET, where arrayLength is int-typed. The
-  // same consideration for constants below: ARRAY_*_INDEX_SCALE, ARRAY_*_INDEX_SHIFT.
+  // in expressions like arrayLength * ARRAY_BYTE_BASE_OFFSET, where arrayLength is int-typed.
+  // The same consideration for constants below: ARRAY_*_INDEX_SCALE, ARRAY_*_INDEX_SHIFT.
   public static final long ARRAY_BOOLEAN_BASE_OFFSET;
   public static final long ARRAY_BYTE_BASE_OFFSET;
   public static final long ARRAY_SHORT_BASE_OFFSET;
@@ -78,6 +82,8 @@ public final class UnsafeUtil {
    * polling by the JVM.
    */
   public static final long UNSAFE_COPY_THRESHOLD = 1L << 20; //2^20
+  static String tryIllegalAccessPermit = " Try setting JVM arg -permit-illegal-access, "
+      + "–illegal-access=permit or equivalent.";
 
   static {
     try {
@@ -94,7 +100,7 @@ public final class UnsafeUtil {
     } catch (final InstantiationException | IllegalAccessException | IllegalArgumentException
         | InvocationTargetException | NoSuchMethodException e) {
       e.printStackTrace();
-      throw new RuntimeException("Unable to acquire Unsafe. ", e);
+      throw new RuntimeException("Unable to acquire Unsafe. " + tryIllegalAccessPermit, e);
     }
 
     //4 on 32-bit systems. 4 on 64-bit systems < 32GB, otherwise 8.
@@ -114,15 +120,27 @@ public final class UnsafeUtil {
     ARRAY_OBJECT_INDEX_SCALE = unsafe.arrayIndexScale(Object[].class);
     OBJECT_SHIFT = ARRAY_OBJECT_INDEX_SCALE == 4 ? 2 : 3;
 
-    final String jdkVer = System.getProperty("java.version");
-    if (jdkVer.startsWith("1.7")) {
-      JDK = 7;
+    JDK = majorJavaVersion(System.getProperty("java.version"));
+    if (JDK == 1.7) {
       compatibilityMethods = new JDK7Compatible(unsafe);
-    } else if (jdkVer.startsWith("1.8")) {
-      JDK = 8;
-      compatibilityMethods = new JDK8Compatible(unsafe);
     } else {
-      throw new ExceptionInInitializerError("JDK must be either 7 or 8");
+      compatibilityMethods = new JDK8Compatible(unsafe);
+    }
+  }
+
+  static double majorJavaVersion(final String jdkVer) { //avail for test
+    //double version = 0;
+    try {
+      final String[] parts = jdkVer.trim().split("[^0-9\\.]")[0].split("\\.");
+      final String num = parts[0] + "." + ((parts.length > 1) ? parts[1] : "0");
+      final double ver = Double.parseDouble(num);
+      if (ver < 1.7) {
+        throw new ExceptionInInitializerError("JDK Major Version must be >= 1.7");
+      }
+      return ver;
+    } catch (final Exception e) {
+      throw new ExceptionInInitializerError("Improper Java -version string: "
+          + jdkVer + "\n" + e);
     }
   }
 

--- a/src/main/java/com/yahoo/memory/UnsafeUtil.java
+++ b/src/main/java/com/yahoo/memory/UnsafeUtil.java
@@ -141,6 +141,14 @@ public final class UnsafeUtil {
 
   private UnsafeUtil() {}
 
+  static long getFieldOffset(final Class<?> c, final String fieldName) {
+    try {
+      return unsafe.objectFieldOffset(c.getDeclaredField(fieldName));
+    } catch (final NoSuchFieldException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
   /**
    * Assert the requested offset and length against the allocated size.
    * The invariants equation is: {@code 0 <= reqOff <= reqLen <= reqOff + reqLen <= allocSize}.

--- a/src/main/java/com/yahoo/memory/UnsafeUtil.java
+++ b/src/main/java/com/yahoo/memory/UnsafeUtil.java
@@ -21,7 +21,7 @@ import sun.misc.Unsafe;
  *
  * <p>This may work with jdk9 but might require the JVM arg <i>-permit-illegal-access</i>,
  * <i>–illegal-access=permit</i> or equivalent. Proper operation with jdk9 or above is not
- * guaranteed and has not be tested.
+ * guaranteed and has not been tested.
  *
  * @author Lee Rhodes
  */

--- a/src/main/java/com/yahoo/memory/WritableDirectHandle.java
+++ b/src/main/java/com/yahoo/memory/WritableDirectHandle.java
@@ -31,7 +31,7 @@ public class WritableDirectHandle implements AutoCloseable, WritableHandle {
 
   @Override
   public void close() {
-    if ((direct != null) && (direct.state.isValid())) {
+    if (direct != null) {
       direct.close();
       direct = null;
     }

--- a/src/test/java/com/yahoo/memory/UnsafeUtilTest.java
+++ b/src/test/java/com/yahoo/memory/UnsafeUtilTest.java
@@ -53,6 +53,30 @@ public class UnsafeUtilTest {
   }
 
   @Test
+  public void checkJdkString() {
+    String[] jdkStr = {"1.7.0_80", "1.8.0_121", "1.8.0_162", "9.0.4", "10.0.1", "11",
+        "12b", "12_.2"};
+    int len = jdkStr.length;
+    for (int i = 0; i < len; i++) {
+      String jdkVer = jdkStr[i];
+      UnsafeUtil.majorJavaVersion(jdkVer);
+    }
+    try { //valid but < 1.7
+      UnsafeUtil.majorJavaVersion("1.6.0_65");
+      fail();
+    } catch (ExceptionInInitializerError e) {
+      //println("" + e);
+    }
+    try { //invalid;
+      UnsafeUtil.majorJavaVersion("b");
+      fail();
+    } catch (ExceptionInInitializerError e) {
+      //println("" + e);
+    }
+
+  }
+
+  @Test
   public void printlnTest() {
     println("PRINTING: "+this.getClass().getName());
   }


### PR DESCRIPTION
The extraction of the java version string is more flexible so we can do numeric comparisons on the version number.  To run with versions greater than 1.8, it is documented that:

> This may work with jdk9 but might require the JVM arg _-permit-illegal-access_,
> _–illegal-access=permit_ or equivalent. Proper operation with jdk9 or above is not
> guaranteed and has not been tested.

This also adds some unit tests.