### PR TITLE
Read-write safety and minor changes and cleanups

### DIFF
--- a/src/main/java/com/yahoo/memory/AllocateDirectMap.java
+++ b/src/main/java/com/yahoo/memory/AllocateDirectMap.java
@@ -7,9 +7,6 @@ package com.yahoo.memory;
 
 import static com.yahoo.memory.UnsafeUtil.unsafe;
 
-import sun.misc.Cleaner;
-import sun.nio.ch.FileChannelImpl;
-
 import java.io.File;
 import java.io.FileDescriptor;
 import java.io.IOException;
@@ -26,6 +23,9 @@ import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Set;
+
+import sun.misc.Cleaner;
+import sun.nio.ch.FileChannelImpl;
 
 /**
  * Allocates direct memory used to memory map files for read operations.
@@ -122,11 +122,11 @@ class AllocateDirectMap implements Map {
     final String mode = state.isResourceReadOnly() ? "r" : "rw";
     final RandomAccessFile raf = new RandomAccessFile(file, mode);
     state.putRandomAccessFile(raf);
-    if (fileOffset + capacity > raf.length()) {
+    if ((fileOffset + capacity) > raf.length()) {
       if (state.isResourceReadOnly()) {
         throw new IllegalStateException(
-            "File is shorter than the region that is requested to be mapped: file length=" +
-                raf.length() + ", mapping offset=" + fileOffset + ", mapping size=" + capacity);
+            "File is shorter than the region that is requested to be mapped: file length="
+           + raf.length() + ", mapping offset=" + fileOffset + ", mapping size=" + capacity);
       } else {
         raf.setLength(fileOffset + capacity);
       }

--- a/src/main/java/com/yahoo/memory/AllocateDirectWritableMap.java
+++ b/src/main/java/com/yahoo/memory/AllocateDirectWritableMap.java
@@ -6,6 +6,7 @@
 package com.yahoo.memory;
 
 import java.io.FileDescriptor;
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.MappedByteBuffer;
 
@@ -32,10 +33,10 @@ final class AllocateDirectWritableMap extends AllocateDirectMap implements Writa
    *
    * @param state the ResourceState
    * @return A new AllocateDirectWritableMap
-   * @throws Exception file not found or RuntimeException, etc.
+   * @throws IOException file not found or RuntimeException, etc.
    */
   //@SuppressWarnings("resource")
-  static AllocateDirectWritableMap map(final ResourceState state) throws Exception {
+  static AllocateDirectWritableMap map(final ResourceState state) throws IOException {
     if (isFileReadOnly(state.getFile())) {
       throw new ReadOnlyException("File is read-only.");
     }

--- a/src/main/java/com/yahoo/memory/Buffer.java
+++ b/src/main/java/com/yahoo/memory/Buffer.java
@@ -333,6 +333,7 @@ public abstract class Buffer extends BaseBuffer {
    * Returns true if the backing resource is read only
    * @return true if the backing resource is read only
    */
+  @Override
   public abstract boolean isResourceReadOnly();
 
   /**

--- a/src/main/java/com/yahoo/memory/Buffer.java
+++ b/src/main/java/com/yahoo/memory/Buffer.java
@@ -33,7 +33,9 @@ public abstract class Buffer extends BaseBuffer {
    * @return the given ByteBuffer for read-only operations.
    */
   public static Buffer wrap(final ByteBuffer byteBuf) {
-    return WritableBuffer.wrapBB(byteBuf);
+    final Buffer buffer = WritableBuffer.wrapBB(byteBuf);
+    buffer.getResourceState().setResourceReadOnly();
+    return buffer;
   }
 
   //MAP XXX

--- a/src/main/java/com/yahoo/memory/MapHandle.java
+++ b/src/main/java/com/yahoo/memory/MapHandle.java
@@ -5,6 +5,8 @@
 
 package com.yahoo.memory;
 
+import java.io.IOException;
+
 /**
  * Gets a Memory for a memory-mapped, read-only file resource, It is highly recommended that this
  * be created inside a <i>try-with-resources</i> statement.
@@ -23,7 +25,7 @@ public class MapHandle implements Map, Handle {
   }
 
   @SuppressWarnings("resource") //called from memory
-  static MapHandle map(final ResourceState state) throws Exception {
+  static MapHandle map(final ResourceState state) throws IOException {
     final AllocateDirectMap dirMap = AllocateDirectMap.map(state);
     final BaseWritableMemoryImpl wMem = new WritableMemoryImpl(state);
     return new MapHandle(dirMap, wMem);

--- a/src/main/java/com/yahoo/memory/Memory.java
+++ b/src/main/java/com/yahoo/memory/Memory.java
@@ -37,7 +37,9 @@ public abstract class Memory {
    * @return the given ByteBuffer for read-only operations.
    */
   public static Memory wrap(final ByteBuffer byteBuf) {
-    return WritableMemory.wrapBB(byteBuf);
+    final Memory memory = WritableMemory.wrapBB(byteBuf);
+    memory.getResourceState().setResourceReadOnly();
+    return memory;
   }
 
   //MAP XXX
@@ -47,9 +49,9 @@ public abstract class Memory {
    * ordering.
    * @param file the given file to map
    * @return MapHandle for managing this map
-   * @throws Exception if file not found or internal RuntimeException is thrown.
+   * @throws IOException if file not found or internal RuntimeException is thrown.
    */
-  public static MapHandle map(final File file) throws Exception {
+  public static MapHandle map(final File file) throws IOException {
     return map(file, 0, file.length(), ByteOrder.nativeOrder());
   }
 
@@ -61,16 +63,17 @@ public abstract class Memory {
    * @param capacityBytes the size of the allocated direct memory. It may not be negative or zero.
    * @param byteOrder the endianness of the given file. It may not be null.
    * @return MemoryMapHandler for managing this map
-   * @throws Exception file not found or RuntimeException, etc.
+   * @throws IOException file not found or RuntimeException, etc.
    */
   public static MapHandle map(final File file, final long fileOffsetBytes, final long capacityBytes,
-      final ByteOrder byteOrder) throws Exception {
+      final ByteOrder byteOrder) throws IOException {
     zeroCheck(capacityBytes, "Capacity");
     final ResourceState state = new ResourceState();
     state.putFile(file);
     state.putFileOffset(fileOffsetBytes);
     state.putCapacity(capacityBytes);
     state.order(byteOrder);
+    state.setResourceReadOnly();
     return MapHandle.map(state);
   }
 
@@ -104,7 +107,9 @@ public abstract class Memory {
    * @return Memory for read operations
    */
   public static Memory wrap(final boolean[] arr) {
-    return WritableMemory.wrap(arr);
+    final Memory memory = WritableMemory.wrap(arr);
+    memory.getResourceState().setResourceReadOnly();
+    return memory;
   }
 
   /**
@@ -147,6 +152,7 @@ public abstract class Memory {
       final ResourceState state = new ResourceState(arr, Prim.BYTE, lengthBytes);
       state.putRegionOffset(offsetBytes);
       state.order(byteOrder);
+      state.setResourceReadOnly();
       return new WritableMemoryImpl(state);
   }
 
@@ -158,7 +164,9 @@ public abstract class Memory {
    * @return Memory for read operations
    */
   public static Memory wrap(final char[] arr) {
-    return WritableMemory.wrap(arr);
+    final Memory memory = WritableMemory.wrap(arr);
+    memory.getResourceState().setResourceReadOnly();
+    return memory;
   }
 
   /**
@@ -169,7 +177,9 @@ public abstract class Memory {
    * @return Memory for read operations
    */
   public static Memory wrap(final short[] arr) {
-    return WritableMemory.wrap(arr);
+    final Memory memory = WritableMemory.wrap(arr);
+    memory.getResourceState().setResourceReadOnly();
+    return memory;
   }
 
   /**
@@ -180,7 +190,9 @@ public abstract class Memory {
    * @return Memory for read operations
    */
   public static Memory wrap(final int[] arr) {
-    return WritableMemory.wrap(arr);
+    final Memory memory = WritableMemory.wrap(arr);
+    memory.getResourceState().setResourceReadOnly();
+    return memory;
   }
 
   /**
@@ -191,7 +203,9 @@ public abstract class Memory {
    * @return Memory for read operations
    */
   public static Memory wrap(final long[] arr) {
-    return WritableMemory.wrap(arr);
+    final Memory memory = WritableMemory.wrap(arr);
+    memory.getResourceState().setResourceReadOnly();
+    return memory;
   }
 
   /**
@@ -202,7 +216,9 @@ public abstract class Memory {
    * @return Memory for read operations
    */
   public static Memory wrap(final float[] arr) {
-    return WritableMemory.wrap(arr);
+    final Memory memory = WritableMemory.wrap(arr);
+    memory.getResourceState().setResourceReadOnly();
+    return memory;
   }
 
   /**
@@ -213,7 +229,9 @@ public abstract class Memory {
    * @return Memory for read operations
    */
   public static Memory wrap(final double[] arr) {
-    return WritableMemory.wrap(arr);
+    final Memory memory = WritableMemory.wrap(arr);
+    memory.getResourceState().setResourceReadOnly();
+    return memory;
   }
 
   //PRIMITIVE getXXX() and getXXXArray() XXX

--- a/src/main/java/com/yahoo/memory/ResourceState.java
+++ b/src/main/java/com/yahoo/memory/ResourceState.java
@@ -320,6 +320,9 @@ final class ResourceState {
     byteBuf_ = byteBuf;
     resourceOrder_ = byteBuf_.order();
     swapBytes_ = (resourceOrder_ != nativeOrder_);
+    if (byteBuf.isReadOnly()) {
+      setResourceReadOnly();
+    }
   }
 
   //MEMORY MAPPED FILES

--- a/src/main/java/com/yahoo/memory/WritableMapHandle.java
+++ b/src/main/java/com/yahoo/memory/WritableMapHandle.java
@@ -5,6 +5,8 @@
 
 package com.yahoo.memory;
 
+import java.io.IOException;
+
 /**
  * Gets a WritableMemory for a writable memory-mapped file resource. It is highly recommended
  * that this be created inside a <i>try-with-resources</i> statement.
@@ -25,7 +27,7 @@ public final class WritableMapHandle extends MapHandle implements WritableMap, W
   }
 
   @SuppressWarnings("resource") //called from memory
-  static WritableMapHandle map(final ResourceState state) throws Exception {
+  static WritableMapHandle map(final ResourceState state) throws IOException {
     final AllocateDirectWritableMap dirMap = AllocateDirectWritableMap.map(state);
     final BaseWritableMemoryImpl wMem = new WritableMemoryImpl(state);
     return new WritableMapHandle(dirMap, wMem);

--- a/src/main/java/com/yahoo/memory/WritableMemory.java
+++ b/src/main/java/com/yahoo/memory/WritableMemory.java
@@ -9,6 +9,7 @@ import static com.yahoo.memory.Util.zeroCheck;
 import static com.yahoo.memory.WritableMemoryImpl.ZERO_SIZE_MEMORY;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -52,9 +53,9 @@ public abstract class WritableMemory extends Memory {
    * (including those &gt; 2GB). This assumes that the file was written using native byte ordering.
    * @param file the given file to map
    * @return WritableMemoryMapHandler for managing this map
-   * @throws Exception file not found or RuntimeException, etc.
+   * @throws IOException file not found or RuntimeException, etc.
    */
-  public static WritableMapHandle writableMap(final File file) throws Exception {
+  public static WritableMapHandle writableMap(final File file) throws IOException {
     return writableMap(file, 0, file.length(), ByteOrder.nativeOrder());
   }
 
@@ -66,10 +67,10 @@ public abstract class WritableMemory extends Memory {
    * @param capacityBytes the size of the allocated direct memory. It may not be negative or zero.
    * @param byteOrder the endianness of the given file. It may not be null.
    * @return WritableMemoryMapHandler for managing this map
-   * @throws Exception file not found or RuntimeException, etc.
+   * @throws IOException file not found or RuntimeException, etc.
    */
   public static WritableMapHandle writableMap(final File file, final long fileOffsetBytes,
-          final long capacityBytes, final ByteOrder byteOrder) throws Exception {
+          final long capacityBytes, final ByteOrder byteOrder) throws IOException {
     zeroCheck(capacityBytes, "Capacity");
     final ResourceState state = new ResourceState();
     state.putFile(file);

--- a/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
@@ -23,7 +23,6 @@ import static com.yahoo.memory.UnsafeUtil.FLOAT_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.INT_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.LONG_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.SHORT_SHIFT;
-import static com.yahoo.memory.UnsafeUtil.assertBounds;
 import static com.yahoo.memory.UnsafeUtil.checkBounds;
 import static com.yahoo.memory.UnsafeUtil.unsafe;
 
@@ -31,15 +30,14 @@ import java.io.IOException;
 
 /*
  * Developer notes: The heavier methods, such as put/get arrays, duplicate, region, clear, fill,
- * compareTo, etc., use hard checks (checkValid() and checkBounds()), which execute at runtime
- * and throw exceptions if violated. The cost of the runtime checks are minor compared to
- * the rest of the work these methods are doing.
+ * compareTo, etc., use hard checks (checkValid*() and checkBounds()), which execute at runtime and
+ * throw exceptions if violated. The cost of the runtime checks are minor compared to the rest of
+ * the work these methods are doing.
  *
- * <p>The light weight methods, such as put/get primitives, use asserts (assertValid() and
- * assertBounds()), which only execute when asserts are enabled and JIT will remove them
- * entirely from production runtime code. The light weight methods
- * will simplify to a single unsafe call, which is further simplified by JIT to an intrinsic
- * that is often a single CPU instruction.
+ * <p>The light weight methods, such as put/get primitives, use asserts (assertValid*()), which only
+ * execute when asserts are enabled and JIT will remove them entirely from production runtime code.
+ * The light weight methods will simplify to a single unsafe call, which is further simplified by
+ * JIT to an intrinsic that is often a single CPU instruction.
  */
 
 /**
@@ -54,6 +52,7 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
 
   static {
     ZERO_SIZE_MEMORY = new WritableMemoryImpl(new ResourceState(new byte[0], Prim.BYTE, 0));
+    ZERO_SIZE_MEMORY.getResourceState().setResourceReadOnly();
   }
 
   WritableMemoryImpl(final ResourceState state) {
@@ -63,20 +62,22 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
   //DUPLICATES & REGIONS XXX
   @Override
   public WritableMemory writableDuplicate() {
-    state.checkValid();
+    checkValid();
+    if (capacity == 0) { return ZERO_SIZE_MEMORY; }
     final WritableMemoryImpl wMemImpl = new WritableMemoryImpl(state);
     return wMemImpl;
   }
 
   @Override
   public Memory region(final long offsetBytes, final long capacityBytes) {
-    return writableRegion(offsetBytes, capacityBytes);
+    final Memory region = writableRegion(offsetBytes, capacityBytes);
+    region.getResourceState().setResourceReadOnly();
+    return region;
   }
 
   @Override
   public WritableMemory writableRegion(final long offsetBytes, final long capacityBytes) {
-    state.checkValid();
-    checkBounds(offsetBytes, capacityBytes, capacity);
+    checkValidAndBounds(offsetBytes, capacityBytes);
     if (capacityBytes == 0) { return ZERO_SIZE_MEMORY; }
     final ResourceState newState = state.copy();
     newState.putRegionOffset(newState.getRegionOffset() + offsetBytes);
@@ -87,16 +88,28 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
   //BUFFER XXX
   @Override
   public Buffer asBuffer() {
-    return asWritableBuffer();
+    if (state.isResourceReadOnly()) {
+      return asWritableBuffer();
+    }
+    checkValid();
+    final WritableBufferImpl wbuf;
+    if (capacity == 0) {
+      wbuf = WritableBufferImpl.ZERO_SIZE_BUFFER;
+    } else {
+      wbuf = new WritableBufferImpl(state.copy());
+      wbuf.getResourceState().setResourceReadOnly();
+      wbuf.setAndCheckStartPositionEnd(0, 0, capacity);
+      wbuf.originMemory = this;
+    }
+    return wbuf;
   }
 
   @Override
   public WritableBuffer asWritableBuffer() {
-    state.checkValid();
+    checkValid();
     final WritableBufferImpl wbuf;
     if (capacity == 0) {
       wbuf = WritableBufferImpl.ZERO_SIZE_BUFFER;
-      wbuf.originMemory = ZERO_SIZE_MEMORY;
     } else {
       wbuf = new WritableBufferImpl(state);
       wbuf.setAndCheckStartPositionEnd(0, 0, capacity);
@@ -108,17 +121,15 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
   ///PRIMITIVE getXXX() and getXXXArray() XXX
   @Override
   public char getChar(final long offsetBytes) {
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_CHAR_INDEX_SCALE, capacity);
+    assertValidAndBoundsForRead(offsetBytes, ARRAY_CHAR_INDEX_SCALE);
     return unsafe.getChar(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
   @Override
   public void getCharArray(final long offsetBytes, final char[] dstArray, final int dstOffset,
       final int lengthChars) {
-    state.checkValid();
     final long copyBytes = ((long) lengthChars) << CHAR_SHIFT;
-    checkBounds(offsetBytes, copyBytes, capacity);
+    checkValidAndBounds(offsetBytes, copyBytes);
     checkBounds(dstOffset, lengthChars, dstArray.length);
     CompareAndCopy.copyMemoryCheckingDifferentObject(
         unsafeObj,
@@ -131,24 +142,21 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
   @Override
   public int getCharsFromUtf8(final long offsetBytes, final int utf8LengthBytes,
       final Appendable dst) throws IOException, Utf8CodingException {
-    state.checkValid();
-    checkBounds(offsetBytes, utf8LengthBytes, state.getCapacity());
+    checkValidAndBounds(offsetBytes, utf8LengthBytes);
     return Utf8.getCharsFromUtf8(offsetBytes, utf8LengthBytes, dst, state);
   }
 
   @Override
   public double getDouble(final long offsetBytes) {
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_DOUBLE_INDEX_SCALE, capacity);
+    assertValidAndBoundsForRead(offsetBytes, ARRAY_DOUBLE_INDEX_SCALE);
     return unsafe.getDouble(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
   @Override
   public void getDoubleArray(final long offsetBytes, final double[] dstArray, final int dstOffset,
       final int lengthDoubles) {
-    state.checkValid();
     final long copyBytes = ((long) lengthDoubles) << DOUBLE_SHIFT;
-    checkBounds(offsetBytes, copyBytes, capacity);
+    checkValidAndBounds(offsetBytes, copyBytes);
     checkBounds(dstOffset, lengthDoubles, dstArray.length);
     CompareAndCopy.copyMemoryCheckingDifferentObject(
         unsafeObj,
@@ -160,17 +168,15 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
 
   @Override
   public float getFloat(final long offsetBytes) {
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_FLOAT_INDEX_SCALE, capacity);
+    assertValidAndBoundsForRead(offsetBytes, ARRAY_FLOAT_INDEX_SCALE);
     return unsafe.getFloat(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
   @Override
   public void getFloatArray(final long offsetBytes, final float[] dstArray, final int dstOffset,
       final int lengthFloats) {
-    state.checkValid();
     final long copyBytes = ((long) lengthFloats) << FLOAT_SHIFT;
-    checkBounds(offsetBytes, copyBytes, capacity);
+    checkValidAndBounds(offsetBytes, copyBytes);
     checkBounds(dstOffset, lengthFloats, dstArray.length);
     CompareAndCopy.copyMemoryCheckingDifferentObject(
         unsafeObj,
@@ -182,17 +188,15 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
 
   @Override
   public int getInt(final long offsetBytes) {
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_INT_INDEX_SCALE, capacity);
+    assertValidAndBoundsForRead(offsetBytes, ARRAY_INT_INDEX_SCALE);
     return unsafe.getInt(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
   @Override
   public void getIntArray(final long offsetBytes, final int[] dstArray, final int dstOffset,
       final int lengthInts) {
-    state.checkValid();
     final long copyBytes = ((long) lengthInts) << INT_SHIFT;
-    checkBounds(offsetBytes, copyBytes, capacity);
+    checkValidAndBounds(offsetBytes, copyBytes);
     checkBounds(dstOffset, lengthInts, dstArray.length);
     CompareAndCopy.copyMemoryCheckingDifferentObject(
         unsafeObj,
@@ -204,17 +208,15 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
 
   @Override
   public long getLong(final long offsetBytes) {
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_LONG_INDEX_SCALE, capacity);
+    assertValidAndBoundsForRead(offsetBytes, ARRAY_LONG_INDEX_SCALE);
     return unsafe.getLong(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
   @Override
   public void getLongArray(final long offsetBytes, final long[] dstArray, final int dstOffset,
       final int lengthLongs) {
-    state.checkValid();
     final long copyBytes = ((long) lengthLongs) << LONG_SHIFT;
-    checkBounds(offsetBytes, copyBytes, capacity);
+    checkValidAndBounds(offsetBytes, copyBytes);
     checkBounds(dstOffset, lengthLongs, dstArray.length);
     CompareAndCopy.copyMemoryCheckingDifferentObject(
         unsafeObj,
@@ -226,17 +228,15 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
 
   @Override
   public short getShort(final long offsetBytes) {
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_SHORT_INDEX_SCALE, capacity);
+    assertValidAndBoundsForRead(offsetBytes, ARRAY_SHORT_INDEX_SCALE);
     return unsafe.getShort(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
   @Override
   public void getShortArray(final long offsetBytes, final short[] dstArray, final int dstOffset,
       final int lengthShorts) {
-    state.checkValid();
     final long copyBytes = ((long) lengthShorts) << SHORT_SHIFT;
-    checkBounds(offsetBytes, copyBytes, capacity);
+    checkValidAndBounds(offsetBytes, copyBytes);
     checkBounds(dstOffset, lengthShorts, dstArray.length);
     CompareAndCopy.copyMemoryCheckingDifferentObject(
         unsafeObj,
@@ -249,18 +249,16 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
   //PRIMITIVE putXXX() and putXXXArray() implementations XXX
   @Override
   public void putChar(final long offsetBytes, final char value) {
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_CHAR_INDEX_SCALE, capacity);
+    assertValidAndBoundsForWrite(offsetBytes, ARRAY_CHAR_INDEX_SCALE);
     unsafe.putChar(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
   @Override
   public void putCharArray(final long offsetBytes, final char[] srcArray, final int srcOffset,
       final int lengthChars) {
-    state.checkValid();
     final long copyBytes = ((long) lengthChars) << CHAR_SHIFT;
+    checkValidAndBoundsForWrite(offsetBytes, copyBytes);
     checkBounds(srcOffset, lengthChars, srcArray.length);
-    checkBounds(offsetBytes, copyBytes, capacity);
     CompareAndCopy.copyMemoryCheckingDifferentObject(
         srcArray,
         ARRAY_CHAR_BASE_OFFSET + (((long) srcOffset) << CHAR_SHIFT),
@@ -272,24 +270,22 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
 
   @Override
   public long putCharsToUtf8(final long offsetBytes, final CharSequence src) {
-    state.checkValid();
+    checkValid();
     return Utf8.putCharsToUtf8(offsetBytes, src, state);
   }
 
   @Override
   public void putDouble(final long offsetBytes, final double value) {
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_DOUBLE_INDEX_SCALE, capacity);
+    assertValidAndBoundsForWrite(offsetBytes, ARRAY_DOUBLE_INDEX_SCALE);
     unsafe.putDouble(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
   @Override
   public void putDoubleArray(final long offsetBytes, final double[] srcArray, final int srcOffset,
       final int lengthDoubles) {
-    state.checkValid();
     final long copyBytes = ((long) lengthDoubles) << DOUBLE_SHIFT;
+    checkValidAndBoundsForWrite(offsetBytes, copyBytes);
     checkBounds(srcOffset, lengthDoubles, srcArray.length);
-    checkBounds(offsetBytes, copyBytes, capacity);
     CompareAndCopy.copyMemoryCheckingDifferentObject(
         srcArray,
         ARRAY_DOUBLE_BASE_OFFSET + (((long) srcOffset) << DOUBLE_SHIFT),
@@ -301,18 +297,16 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
 
   @Override
   public void putFloat(final long offsetBytes, final float value) {
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_FLOAT_INDEX_SCALE, capacity);
+    assertValidAndBoundsForWrite(offsetBytes, ARRAY_FLOAT_INDEX_SCALE);
     unsafe.putFloat(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
   @Override
   public void putFloatArray(final long offsetBytes, final float[] srcArray, final int srcOffset,
       final int lengthFloats) {
-    state.checkValid();
     final long copyBytes = ((long) lengthFloats) << FLOAT_SHIFT;
+    checkValidAndBoundsForWrite(offsetBytes, copyBytes);
     checkBounds(srcOffset, lengthFloats, srcArray.length);
-    checkBounds(offsetBytes, copyBytes, capacity);
     CompareAndCopy.copyMemoryCheckingDifferentObject(
         srcArray,
         ARRAY_FLOAT_BASE_OFFSET + (((long) srcOffset) << FLOAT_SHIFT),
@@ -324,18 +318,16 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
 
   @Override
   public void putInt(final long offsetBytes, final int value) {
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_INT_INDEX_SCALE, capacity);
+    assertValidAndBoundsForWrite(offsetBytes, ARRAY_INT_INDEX_SCALE);
     unsafe.putInt(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
   @Override
   public void putIntArray(final long offsetBytes, final int[] srcArray, final int srcOffset,
       final int lengthInts) {
-    state.checkValid();
     final long copyBytes = ((long) lengthInts) << INT_SHIFT;
+    checkValidAndBoundsForWrite(offsetBytes, copyBytes);
     checkBounds(srcOffset, lengthInts, srcArray.length);
-    checkBounds(offsetBytes, copyBytes, capacity);
     CompareAndCopy.copyMemoryCheckingDifferentObject(
         srcArray,
         ARRAY_INT_BASE_OFFSET + (((long) srcOffset) << INT_SHIFT),
@@ -347,18 +339,16 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
 
   @Override
   public void putLong(final long offsetBytes, final long value) {
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_LONG_INDEX_SCALE, capacity);
+    assertValidAndBoundsForWrite(offsetBytes, ARRAY_LONG_INDEX_SCALE);
     unsafe.putLong(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
   @Override
   public void putLongArray(final long offsetBytes, final long[] srcArray, final int srcOffset,
       final int lengthLongs) {
-    state.checkValid();
     final long copyBytes = ((long) lengthLongs) << LONG_SHIFT;
+    checkValidAndBoundsForWrite(offsetBytes, copyBytes);
     checkBounds(srcOffset, lengthLongs, srcArray.length);
-    checkBounds(offsetBytes, copyBytes, capacity);
     CompareAndCopy.copyMemoryCheckingDifferentObject(
         srcArray,
         ARRAY_LONG_BASE_OFFSET + (((long) srcOffset) << LONG_SHIFT),
@@ -370,18 +360,16 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
 
   @Override
   public void putShort(final long offsetBytes, final short value) {
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_SHORT_INDEX_SCALE, capacity);
+    assertValidAndBoundsForWrite(offsetBytes, ARRAY_SHORT_INDEX_SCALE);
     unsafe.putShort(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
   @Override
   public void putShortArray(final long offsetBytes, final short[] srcArray, final int srcOffset,
       final int lengthShorts) {
-    state.checkValid();
     final long copyBytes = ((long) lengthShorts) << SHORT_SHIFT;
+    checkValidAndBoundsForWrite(offsetBytes, copyBytes);
     checkBounds(srcOffset, lengthShorts, srcArray.length);
-    checkBounds(offsetBytes, copyBytes, capacity);
     CompareAndCopy.copyMemoryCheckingDifferentObject(
         srcArray,
         ARRAY_SHORT_BASE_OFFSET + (((long) srcOffset) << SHORT_SHIFT),
@@ -394,24 +382,21 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
   //Atomic Write Methods XXX
   @Override
   public long getAndAddLong(final long offsetBytes, final long delta) { //JDK 8+
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_LONG_INDEX_SCALE, capacity);
-    final long add = cumBaseOffset + offsetBytes;
-    return UnsafeUtil.compatibilityMethods.getAndAddLong(unsafeObj, add, delta) + delta;
+    assertValidAndBoundsForWrite(offsetBytes, ARRAY_LONG_INDEX_SCALE);
+    final long addr = cumBaseOffset + offsetBytes;
+    return UnsafeUtil.compatibilityMethods.getAndAddLong(unsafeObj, addr, delta) + delta;
   }
 
   @Override
   public long getAndSetLong(final long offsetBytes, final long newValue) { //JDK 8+
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_LONG_INDEX_SCALE, capacity);
-    final long add = cumBaseOffset + offsetBytes;
-    return UnsafeUtil.compatibilityMethods.getAndSetLong(unsafeObj, add, newValue);
+    assertValidAndBoundsForWrite(offsetBytes, ARRAY_LONG_INDEX_SCALE);
+    final long addr = cumBaseOffset + offsetBytes;
+    return UnsafeUtil.compatibilityMethods.getAndSetLong(unsafeObj, addr, newValue);
   }
 
   @Override
   public boolean compareAndSwapLong(final long offsetBytes, final long expect, final long update) {
-    state.assertValid();
-    assertBounds(offsetBytes, ARRAY_LONG_INDEX_SCALE, capacity);
+    assertValidAndBoundsForWrite(offsetBytes, ARRAY_LONG_INDEX_SCALE);
     return unsafe.compareAndSwapLong(unsafeObj, cumBaseOffset + offsetBytes, expect, update);
   }
 }

--- a/src/test/java/com/yahoo/memory/BufferReadWriteSafetyTest.java
+++ b/src/test/java/com/yahoo/memory/BufferReadWriteSafetyTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2017, Yahoo! Inc. Licensed under the terms of the
+ * Apache License 2.0. See LICENSE file at the project root for terms.
+ */
+
+package com.yahoo.memory;
+
+import org.testng.annotations.Test;
+
+import java.nio.ByteBuffer;
+
+public class BufferReadWriteSafetyTest {
+
+  // Test various operations with read-only Buffer
+
+  private final WritableBuffer buf = (WritableBuffer) Buffer.wrap(ByteBuffer.allocate(8));
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testPutByte() {
+    buf.putByte(0, (byte) 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testPutBytePositional() {
+    buf.putByte((byte) 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testPutBoolean() {
+    buf.putBoolean(0, true);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testPutBooleanPositional() {
+    buf.putBoolean(true);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testPutShort() {
+    buf.putShort(0, (short) 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testPutShortPositional() {
+    buf.putShort((short) 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testPutChar() {
+    buf.putChar(0, (char) 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testPutCharPositional() {
+    buf.putChar((char) 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testPutInt() {
+    buf.putInt(0, 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testPutIntPositional() {
+    buf.putInt(1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testPutLong() {
+    buf.putLong(0, 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testPutLongPositional() {
+    buf.putLong(1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testPutFloat() {
+    buf.putFloat(0, 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testPutFloatPositional() {
+    buf.putFloat(1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testPutDouble() {
+    buf.putDouble(0, 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testPutDoublePositional() {
+    buf.putDouble(1);
+  }
+
+  @Test(expectedExceptions = ReadOnlyException.class)
+  public void testPutByteArray() {
+    buf.putByteArray(new byte[] {1}, 0, 1);
+  }
+
+  @Test(expectedExceptions = ReadOnlyException.class)
+  public void testPutBooleanArray() {
+    buf.putBooleanArray(new boolean[] {true}, 0, 1);
+  }
+
+  @Test(expectedExceptions = ReadOnlyException.class)
+  public void testPutShortArray() {
+    buf.putShortArray(new short[] {1}, 0, 1);
+  }
+
+  @Test(expectedExceptions = ReadOnlyException.class)
+  public void testPutCharArray() {
+    buf.putCharArray(new char[] {1}, 0, 1);
+  }
+
+  @Test(expectedExceptions = ReadOnlyException.class)
+  public void testPutIntArray() {
+    buf.putIntArray(new int[] {1}, 0, 1);
+  }
+
+  @Test(expectedExceptions = ReadOnlyException.class)
+  public void testPutLongArray() {
+    buf.putLongArray(new long[] {1}, 0, 1);
+  }
+
+  @Test(expectedExceptions = ReadOnlyException.class)
+  public void testPutFloatArray() {
+    buf.putFloatArray(new float[] {1}, 0, 1);
+  }
+
+  @Test(expectedExceptions = ReadOnlyException.class)
+  public void testDoubleByteArray() {
+    buf.putDoubleArray(new double[] {1}, 0, 1);
+  }
+
+  // Now, test that various ways to obtain a read-only buffer produce a read-only buffer indeed
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testWritableMemoryAsBuffer() {
+    WritableBuffer buf = (WritableBuffer) WritableMemory.allocate(8).asBuffer();
+    buf.putInt(1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testWritableBufferRegion() {
+    WritableBuffer buf = (WritableBuffer) WritableMemory.allocate(8).asWritableBuffer().region();
+    buf.putInt(1);
+  }
+}

--- a/src/test/java/com/yahoo/memory/BufferTest.java
+++ b/src/test/java/com/yahoo/memory/BufferTest.java
@@ -8,12 +8,12 @@ package com.yahoo.memory;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+import org.testng.annotations.Test;
+import org.testng.collections.Lists;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
-
-import org.testng.annotations.Test;
-import org.testng.collections.Lists;
 
 public class BufferTest {
 
@@ -299,7 +299,7 @@ public class BufferTest {
 
   @Test(expectedExceptions = AssertionError.class)
   public void checkBaseBufferInvariants() {
-    BaseBuffer bb = new BaseBuffer(new ResourceState());
+    BaseBuffer bb = new WritableBufferImpl(new ResourceState());
     bb.setStartPositionEnd(1, 0, 2);
   }
 

--- a/src/test/java/com/yahoo/memory/MemoryReadWriteSafetyTest.java
+++ b/src/test/java/com/yahoo/memory/MemoryReadWriteSafetyTest.java
@@ -5,13 +5,13 @@
 
 package com.yahoo.memory;
 
-import org.testng.annotations.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+
+import org.testng.annotations.Test;
 
 public class MemoryReadWriteSafetyTest {
 
@@ -173,6 +173,7 @@ public class MemoryReadWriteSafetyTest {
     mem.putInt(0, 1);
   }
 
+  @SuppressWarnings("resource")
   @Test(expectedExceptions = AssertionError.class)
   public void testMapFile() throws IOException {
     File tempFile = File.createTempFile("test", "test");
@@ -183,6 +184,7 @@ public class MemoryReadWriteSafetyTest {
     }
   }
 
+  @SuppressWarnings("resource")
   @Test(expectedExceptions = AssertionError.class)
   public void testMapFileWithOffsetsAndBO() throws IOException {
     File tempFile = File.createTempFile("test", "test");
@@ -193,6 +195,7 @@ public class MemoryReadWriteSafetyTest {
     }
   }
 
+  @SuppressWarnings("resource")
   @Test(expectedExceptions = IllegalStateException.class)
   public void testMapFileBeyondTheFileSize() throws IOException {
     File tempFile = File.createTempFile("test", "test");

--- a/src/test/java/com/yahoo/memory/MemoryReadWriteSafetyTest.java
+++ b/src/test/java/com/yahoo/memory/MemoryReadWriteSafetyTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2017, Yahoo! Inc. Licensed under the terms of the
+ * Apache License 2.0. See LICENSE file at the project root for terms.
+ */
+
+package com.yahoo.memory;
+
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+public class MemoryReadWriteSafetyTest {
+
+  // Test various operations with read-only Memory
+
+  final WritableMemory mem = (WritableMemory) Memory.wrap(new byte[8]);
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testPutByte() {
+    mem.putByte(0, (byte) 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testPutBoolean() {
+    mem.putBoolean(0, true);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testPutShort() {
+    mem.putShort(0, (short) 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testPutChar() {
+    mem.putChar(0, (char) 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testPutInt() {
+    mem.putInt(0, 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testPutLong() {
+    mem.putLong(0, 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testPutFloat() {
+    mem.putFloat(0, 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testPutDouble() {
+    mem.putDouble(0, 1);
+  }
+
+  @Test(expectedExceptions = ReadOnlyException.class)
+  public void testPutByteArray() {
+    mem.putByteArray(0, new byte[] {1}, 0, 1);
+  }
+
+  @Test(expectedExceptions = ReadOnlyException.class)
+  public void testPutBooleanArray() {
+    mem.putBooleanArray(0, new boolean[] {true}, 0, 1);
+  }
+
+  @Test(expectedExceptions = ReadOnlyException.class)
+  public void testPutShortArray() {
+    mem.putShortArray(0, new short[] {1}, 0, 1);
+  }
+
+  @Test(expectedExceptions = ReadOnlyException.class)
+  public void testPutCharArray() {
+    mem.putCharArray(0, new char[] {1}, 0, 1);
+  }
+
+  @Test(expectedExceptions = ReadOnlyException.class)
+  public void testPutIntArray() {
+    mem.putIntArray(0, new int[] {1}, 0, 1);
+  }
+
+  @Test(expectedExceptions = ReadOnlyException.class)
+  public void testPutLongArray() {
+    mem.putLongArray(0, new long[] {1}, 0, 1);
+  }
+
+  @Test(expectedExceptions = ReadOnlyException.class)
+  public void testPutFloatArray() {
+    mem.putFloatArray(0, new float[] {1}, 0, 1);
+  }
+
+  @Test(expectedExceptions = ReadOnlyException.class)
+  public void testDoubleByteArray() {
+    mem.putDoubleArray(0, new double[] {1}, 0, 1);
+  }
+
+  // Now, test that various ways to obtain a read-only memory produce a read-only memory indeed
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testWritableMemoryRegion() {
+    WritableMemory mem = (WritableMemory) WritableMemory.allocate(8).region(0, 8);
+    mem.putInt(0, 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testByteArrayWrap() {
+    WritableMemory mem = (WritableMemory) Memory.wrap(new byte[8]);
+    mem.putInt(0, 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testByteArrayWrapWithBO() {
+    WritableMemory mem = (WritableMemory) Memory.wrap(new byte[8], ByteOrder.nativeOrder());
+    mem.putInt(0, 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testByteArrayWrapWithOffsetsAndBO() {
+    WritableMemory mem = (WritableMemory) Memory.wrap(new byte[8], 0, 4, ByteOrder.nativeOrder());
+    mem.putInt(0, 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testBooleanArrayWrap() {
+    WritableMemory mem = (WritableMemory) Memory.wrap(new boolean[8]);
+    mem.putInt(0, 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testShortArrayWrap() {
+    WritableMemory mem = (WritableMemory) Memory.wrap(new short[8]);
+    mem.putInt(0, 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testCharArrayWrap() {
+    WritableMemory mem = (WritableMemory) Memory.wrap(new char[8]);
+    mem.putInt(0, 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testIntArrayWrap() {
+    WritableMemory mem = (WritableMemory) Memory.wrap(new int[8]);
+    mem.putInt(0, 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testLongArrayWrap() {
+    WritableMemory mem = (WritableMemory) Memory.wrap(new long[8]);
+    mem.putInt(0, 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testFloatArrayWrap() {
+    WritableMemory mem = (WritableMemory) Memory.wrap(new float[8]);
+    mem.putInt(0, 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testDoubleArrayWrap() {
+    WritableMemory mem = (WritableMemory) Memory.wrap(new double[8]);
+    mem.putInt(0, 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testByteBufferWrap() {
+    WritableMemory mem = (WritableMemory) Memory.wrap(ByteBuffer.allocate(8));
+    mem.putInt(0, 1);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testMapFile() throws IOException {
+    File tempFile = File.createTempFile("test", "test");
+    tempFile.deleteOnExit();
+    new RandomAccessFile(tempFile, "rw").setLength(8);
+    try (MapHandle h = Memory.map(tempFile)) {
+      ((WritableMemory) h.get()).putInt(0, 1);
+    }
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testMapFileWithOffsetsAndBO() throws IOException {
+    File tempFile = File.createTempFile("test", "test");
+    tempFile.deleteOnExit();
+    new RandomAccessFile(tempFile, "rw").setLength(8);
+    try (MapHandle h = Memory.map(tempFile, 0, 4, ByteOrder.nativeOrder())) {
+      ((WritableMemory) h.get()).putInt(0, 1);
+    }
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void testMapFileBeyondTheFileSize() throws IOException {
+    File tempFile = File.createTempFile("test", "test");
+    tempFile.deleteOnExit();
+    new RandomAccessFile(tempFile, "rw").setLength(8);
+    try (MapHandle unused = Memory.map(tempFile, 0, 16, ByteOrder.nativeOrder())) {
+    }
+  }
+}

--- a/src/test/java/com/yahoo/memory/MemoryWriteToTest.java
+++ b/src/test/java/com/yahoo/memory/MemoryWriteToTest.java
@@ -5,14 +5,14 @@
 
 package com.yahoo.memory;
 
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
 import java.util.concurrent.ThreadLocalRandom;
-
-import org.testng.Assert;
-import org.testng.annotations.Test;
 
 public class MemoryWriteToTest {
 
@@ -70,7 +70,6 @@ public class MemoryWriteToTest {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     try (WritableByteChannel out = Channels.newChannel(baos)) {
       mem.writeTo(0, mem.getCapacity(), out);
-      out.close();
     }
     byte[] result = baos.toByteArray();
     Assert.assertTrue(mem.equalTo(Memory.wrap(result)));

--- a/src/test/java/com/yahoo/memory/ResourceStateTest.java
+++ b/src/test/java/com/yahoo/memory/ResourceStateTest.java
@@ -13,9 +13,9 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
-import java.nio.ByteOrder;
-
 import org.testng.annotations.Test;
+
+import java.nio.ByteOrder;
 
 public class ResourceStateTest {
 
@@ -24,7 +24,7 @@ public class ResourceStateTest {
     ResourceState state = new ResourceState();
     state.putCapacity(1 << 20);
     assertNull(state.getBaseBuffer());
-    BaseBuffer baseBuf = new BaseBuffer(state);
+    BaseBuffer baseBuf = new WritableBufferImpl(state);
     assertNotNull(state.getBaseBuffer());
     assertEquals(baseBuf.getEnd(), 1 << 20);
     try {


### PR DESCRIPTION
Fixes #43.

Also attempts to reduce boilerplate code in the body of WritableMemoryImpl and WritableBufferImpl as much as possible, to reduce the amount of copy-paste in the future non-native impls.

Also some important fixes around file mapping.