### PR TITLE
Fix a bug in getAndAdd implementation; Simplify for performance

### DIFF
--- a/src/main/java/com/yahoo/memory/JDK7Compatible.java
+++ b/src/main/java/com/yahoo/memory/JDK7Compatible.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018, Yahoo! Inc. Licensed under the terms of the
+ * Apache License 2.0. See LICENSE file at the project root for terms.
+ */
+
+package com.yahoo.memory;
+
+final class JDK7Compatible {
+
+  public static long getAndAddLong(final Object obj, final long address, final long increment) {
+    long retVal;
+    do {
+      retVal = UnsafeUtil.unsafe.getLongVolatile(obj, address);
+    } while (!UnsafeUtil.unsafe.compareAndSwapLong(obj, address, retVal, retVal + increment));
+
+    return retVal;
+  }
+
+  public static long getAndSetLong(final Object obj, final long address, final long value) {
+    long retVal;
+    do {
+      retVal = UnsafeUtil.unsafe.getLongVolatile(obj, address);
+    } while (!UnsafeUtil.unsafe.compareAndSwapLong(obj, address, retVal, value));
+
+    return retVal;
+  }
+
+  private JDK7Compatible() {}
+}

--- a/src/main/java/com/yahoo/memory/UnsafeUtil.java
+++ b/src/main/java/com/yahoo/memory/UnsafeUtil.java
@@ -5,10 +5,10 @@
 
 package com.yahoo.memory;
 
-import sun.misc.Unsafe;
-
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+
+import sun.misc.Unsafe;
 
 /**
  * Provides access to the sun.misc.Unsafe class and its key static fields.

--- a/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
@@ -397,7 +397,11 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     state.assertValid();
     assertBounds(offsetBytes, ARRAY_LONG_INDEX_SCALE, capacity);
     final long add = cumBaseOffset + offsetBytes;
-    return UnsafeUtil.compatibilityMethods.getAndAddLong(unsafeObj, add, delta) + delta;
+    if (UnsafeUtil.JDK8_OR_ABOVE) {
+      return unsafe.getAndAddLong(unsafeObj, add, delta);
+    } else {
+      return JDK7Compatible.getAndAddLong(unsafeObj, add, delta);
+    }
   }
 
   @Override
@@ -405,7 +409,11 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     state.assertValid();
     assertBounds(offsetBytes, ARRAY_LONG_INDEX_SCALE, capacity);
     final long add = cumBaseOffset + offsetBytes;
-    return UnsafeUtil.compatibilityMethods.getAndSetLong(unsafeObj, add, newValue);
+    if (UnsafeUtil.JDK8_OR_ABOVE) {
+      return unsafe.getAndSetLong(unsafeObj, add, newValue);
+    } else {
+      return JDK7Compatible.getAndSetLong(unsafeObj, add, newValue);
+    }
   }
 
   @Override

--- a/src/test/java/com/yahoo/memory/UnsafeUtilTest.java
+++ b/src/test/java/com/yahoo/memory/UnsafeUtilTest.java
@@ -6,14 +6,10 @@
 package com.yahoo.memory;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
-
-import java.lang.reflect.Constructor;
 
 import org.testng.annotations.Test;
 
-import com.yahoo.memory.UnsafeUtil.JDKCompatibility;
 
 /**
  * @author Lee Rhodes
@@ -23,31 +19,16 @@ public class UnsafeUtilTest {
 
   @Test
   public void checkJDK7methods() {
-    JDKCompatibility jdk7compatible;
     try {
-      Class<?> inner = Class.forName("com.yahoo.memory.UnsafeUtil$JDK7Compatible");
-      Constructor<?> innerConstructor =
-          inner.getDeclaredConstructor(com.yahoo.memory.UnsafeUtil.unsafe.getClass());
-      innerConstructor.setAccessible(true);
-      jdk7compatible = (com.yahoo.memory.UnsafeUtil.JDKCompatibility)
-          innerConstructor.newInstance(com.yahoo.memory.UnsafeUtil.unsafe);
-      assertTrue(jdk7compatible != null);
-
       final byte[] byteArr = new byte[16];
       byteArr[0] = (byte) 1;
-      if (jdk7compatible != null) {
-        final long one = jdk7compatible.getAndAddLong(byteArr, 16, 1L);
-        assertEquals(one, 1L);
+      final long one = JDK7Compatible.getAndAddLong(byteArr, 16, 1L);
+      assertEquals(one, 1L);
 
-        final long two = jdk7compatible.getAndSetLong(byteArr,  16, 3L);
-        assertEquals(two, 2L);
-        assertEquals(byteArr[0], 3);
-      } else {
-        fail();
-      }
+      final long two = JDK7Compatible.getAndSetLong(byteArr,  16, 3L);
+      assertEquals(two, 2L);
+      assertEquals(byteArr[0], 3);
 
-    } catch (RuntimeException e) {
-      throw new RuntimeException("Failed");
     } catch (Exception e) {
       throw new RuntimeException("Failed");
     }


### PR DESCRIPTION
Implementation of getAndAdd used to actually return the modified value. Also simplified impl, because boolean switch is faster than interface, expecially in code that is compiled only with C1 compiler.