### PR TITLE
Some API changes

### DIFF
--- a/src/main/java/com/yahoo/memory/BaseWritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/BaseWritableMemoryImpl.java
@@ -398,13 +398,13 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
   }
 
   @Override
-  public WritableDirectHandle getHandle() {
+  public WritableHandle getHandle() {
     assertValid();
     return state.getHandle();
   }
 
   @Override
-  public void setHandle(final WritableDirectHandle handle) {
+  public void setHandle(final WritableHandle handle) {
     assertValid();
     state.setHandle(handle);
   }

--- a/src/main/java/com/yahoo/memory/DefaultMemoryManager.java
+++ b/src/main/java/com/yahoo/memory/DefaultMemoryManager.java
@@ -25,12 +25,12 @@ final class DefaultMemoryManager implements MemoryManager {
    */
   @Override
   @SuppressWarnings("resource")
-  public WritableDirectHandle allocateDirect(final long capacityBytes) {
+  public WritableHandle allocateDirect(final long capacityBytes) {
     final ResourceState state = new ResourceState();
     state.putCapacity(capacityBytes);
     final AllocateDirect direct = AllocateDirect.allocate(state);
     final WritableMemory wMem = new WritableMemoryImpl(state);
-    final WritableDirectHandle handle = new WritableDirectHandle(direct, wMem);
+    final WritableHandle handle = new WritableDirectHandle(direct, wMem);
     state.setMemoryRequestServer(this);
     state.setHandle(handle);
     return handle;

--- a/src/main/java/com/yahoo/memory/Handle.java
+++ b/src/main/java/com/yahoo/memory/Handle.java
@@ -9,11 +9,14 @@ package com.yahoo.memory;
  * A handle for Memory.
  * @author Lee Rhodes
  */
-public interface Handle {
+public interface Handle extends AutoCloseable {
 
   /**
    * Gets a Memory
    * @return a Memory
    */
   Memory get();
+
+  @Override
+  void close();
 }

--- a/src/main/java/com/yahoo/memory/Memory.java
+++ b/src/main/java/com/yahoo/memory/Memory.java
@@ -29,10 +29,9 @@ public abstract class Memory {
 
   //BYTE BUFFER XXX
   /**
-   * Accesses the given ByteBuffer for read-only operations.
-   *
-   * <p>Note that if the ByteBuffer capacity is zero this will
-   * return a Memory backed by a heap byte array of size zero.
+   * Accesses the given ByteBuffer for read-only operations. The returned Memory object has the same
+   * byte order, as the given ByteBuffer, unless the capacity of the given ByteBuffer is zero, then
+   * endianness of the returned Memory object (as well as backing storage) is unspecified.
    * @param byteBuf the given ByteBuffer, must not be null
    * @return the given ByteBuffer for read-only operations.
    */
@@ -79,10 +78,9 @@ public abstract class Memory {
 
   //REGIONS XXX
   /**
-   * Returns a read only region of this Memory.
+   * Returns a read only region of this Memory. If the given capacityBytes is zero, backing storage
+   * and endianness of the returned Memory object are unspecified.
    * @param offsetBytes the starting offset with respect to this Memory.
-   * If the capacityBytes is zero this method will
-   * return a Memory backed by a heap byte array of size zero.
    * @param capacityBytes the capacity of the region in bytes
    * @return a read only region of this Memory
    */
@@ -90,19 +88,19 @@ public abstract class Memory {
 
   //BUFFER XXX
   /**
-   * Convert this Memory to a Buffer.
-   * The <i>start</i>, <i>position</i> and <i>end</i> are set to zero, zero, and <i>capacity</i>,
-   * respectively.
+   * Creates and returns a new Buffer, backed by this Memory, however, if the capacity of this
+   * Memory object is zero, this method is allowed to return a cached Buffer object, which is
+   * effectively unmodifiable. The <i>start</i>, <i>position</i> and <i>end</i> are set to zero,
+   * zero, and <i>capacity</i>, respectively.
    * @return Buffer
    */
   public abstract Buffer asBuffer();
 
   //ACCESS PRIMITIVE HEAP ARRAYS for readOnly XXX
   /**
-   * Wraps the given primitive array for read operations assuming native byte order.
+   * Wraps the given primitive array for read operations assuming native byte order. If the array
+   * size is zero, backing storage and endianness of the returned Memory object are unspecified.
    * @param arr the given primitive array.
-   * If the array is size zero this method will
-   * return a Memory backed by a heap byte array of size zero.
    * @return Memory for read operations
    */
   public static Memory wrap(final boolean[] arr) {
@@ -112,10 +110,9 @@ public abstract class Memory {
   }
 
   /**
-   * Wraps the given primitive array for read operations assuming native byte order.
+   * Wraps the given primitive array for read operations assuming native byte order. If the array
+   * size is zero, backing storage and endianness of the returned Memory object are unspecified.
    * @param arr the given primitive array.
-   * If the array is size zero this method will
-   * return a Memory backed by a heap byte array of size zero.
    * @return Memory for read operations
    */
   public static Memory wrap(final byte[] arr) {
@@ -123,43 +120,41 @@ public abstract class Memory {
   }
 
   /**
-   * Wraps the given primitive array for read operations assuming the given byte order.
+   * Wraps the given primitive array for read operations with the given byte order. If the array
+   * size is zero, backing storage and endianness of the returned Memory object are unspecified.
    * @param arr the given primitive array.
-   * If the array is size zero this method will
-   * return a Memory backed by a heap byte array of size zero.
    * @param byteOrder the byte order
    * @return Memory for read operations
    */
   public static Memory wrap(final byte[] arr, final ByteOrder byteOrder) {
-      return wrap(arr, 0, arr.length, byteOrder);
+    return wrap(arr, 0, arr.length, byteOrder);
   }
 
   /**
-   * Wraps the given primitive array for read operations assuming the given byte order.
+   * Wraps the given primitive array for read operations with the given byte order. If the given
+   * lengthBytes is zero, backing storage and endianness of the returned Memory object are
+   * unspecified.
    * @param arr the given primitive array.
-   * If the array is size zero this method will
-   * return a Memory backed by a heap byte array of size zero.
    * @param offsetBytes the byte offset into the given array
    * @param lengthBytes the number of bytes to include from the given array
    * @param byteOrder the byte order
    * @return Memory for read operations
    */
   public static Memory wrap(final byte[] arr, final int offsetBytes, final int lengthBytes,
-          final ByteOrder byteOrder) {
-      UnsafeUtil.checkBounds(offsetBytes, lengthBytes, arr.length);
-      if (lengthBytes == 0) { return ZERO_SIZE_MEMORY; }
-      final ResourceState state = new ResourceState(arr, Prim.BYTE, lengthBytes);
-      state.putRegionOffset(offsetBytes);
-      state.order(byteOrder);
-      state.setResourceReadOnly();
-      return new WritableMemoryImpl(state);
+      final ByteOrder byteOrder) {
+    UnsafeUtil.checkBounds(offsetBytes, lengthBytes, arr.length);
+    if (lengthBytes == 0) { return ZERO_SIZE_MEMORY; }
+    final ResourceState state = new ResourceState(arr, Prim.BYTE, lengthBytes);
+    state.putRegionOffset(offsetBytes);
+    state.order(byteOrder);
+    state.setResourceReadOnly();
+    return new WritableMemoryImpl(state);
   }
 
   /**
-   * Wraps the given primitive array for read operations assuming native byte order.
+   * Wraps the given primitive array for read operations assuming native byte order. If the array
+   * size is zero, backing storage and endianness of the returned Memory object are unspecified.
    * @param arr the given primitive array.
-   * If the array is size zero this method will
-   * return a Memory backed by a heap byte array of size zero.
    * @return Memory for read operations
    */
   public static Memory wrap(final char[] arr) {
@@ -169,10 +164,9 @@ public abstract class Memory {
   }
 
   /**
-   * Wraps the given primitive array for read operations assuming native byte order.
+   * Wraps the given primitive array for read operations assuming native byte order. If the array
+   * size is zero, backing storage and endianness of the returned Memory object are unspecified.
    * @param arr the given primitive array.
-   * If the array is size zero this method will
-   * return a Memory backed by a heap byte array of size zero.
    * @return Memory for read operations
    */
   public static Memory wrap(final short[] arr) {
@@ -182,10 +176,9 @@ public abstract class Memory {
   }
 
   /**
-   * Wraps the given primitive array for read operations assuming native byte order.
+   * Wraps the given primitive array for read operations assuming native byte order. If the array
+   * size is zero, backing storage and endianness of the returned Memory object are unspecified.
    * @param arr the given primitive array.
-   * If the array is size zero this method will
-   * return a Memory backed by a heap byte array of size zero.
    * @return Memory for read operations
    */
   public static Memory wrap(final int[] arr) {
@@ -195,10 +188,9 @@ public abstract class Memory {
   }
 
   /**
-   * Wraps the given primitive array for read operations assuming native byte order.
+   * Wraps the given primitive array for read operations assuming native byte order. If the array
+   * size is zero, backing storage and endianness of the returned Memory object are unspecified.
    * @param arr the given primitive array.
-   * If the array is size zero this method will
-   * return a Memory backed by a heap byte array of size zero.
    * @return Memory for read operations
    */
   public static Memory wrap(final long[] arr) {
@@ -208,10 +200,9 @@ public abstract class Memory {
   }
 
   /**
-   * Wraps the given primitive array for read operations assuming native byte order.
+   * Wraps the given primitive array for read operations assuming native byte order. If the array
+   * size is zero, backing storage and endianness of the returned Memory object are unspecified.
    * @param arr the given primitive array.
-   * If the array is size zero this method will
-   * return a Memory backed by a heap byte array of size zero.
    * @return Memory for read operations
    */
   public static Memory wrap(final float[] arr) {
@@ -221,10 +212,9 @@ public abstract class Memory {
   }
 
   /**
-   * Wraps the given primitive array for read operations assuming native byte order.
+   * Wraps the given primitive array for read operations assuming native byte order. If the array
+   * size is zero, backing storage and endianness of the returned Memory object are unspecified.
    * @param arr the given primitive array.
-   * If the array is size zero this method will
-   * return a Memory backed by a heap byte array of size zero.
    * @return Memory for read operations
    */
   public static Memory wrap(final double[] arr) {

--- a/src/main/java/com/yahoo/memory/MemoryManager.java
+++ b/src/main/java/com/yahoo/memory/MemoryManager.java
@@ -14,6 +14,6 @@ package com.yahoo.memory;
  */
 public interface MemoryManager extends MemoryRequestServer {
 
-  WritableDirectHandle allocateDirect(long capacityBytes);
+  WritableHandle allocateDirect(long capacityBytes);
 
 }

--- a/src/main/java/com/yahoo/memory/ResourceState.java
+++ b/src/main/java/com/yahoo/memory/ResourceState.java
@@ -77,7 +77,7 @@ final class ResourceState {
   /**
    * Only relevant when user allocated direct memory is the backing resource.
    */
-  private WritableDirectHandle handle_;
+  private WritableHandle handle_;
 
   //FLAGS
   /**
@@ -250,11 +250,11 @@ final class ResourceState {
     memReqSvr_ = memReqSvr; //may be null
   }
 
-  WritableDirectHandle getHandle() {
+  WritableHandle getHandle() {
     return handle_;
   }
 
-  void setHandle(final WritableDirectHandle handle) {
+  void setHandle(final WritableHandle handle) {
     handle_ = handle; //may be set null
   }
 

--- a/src/main/java/com/yahoo/memory/WritableDirectHandle.java
+++ b/src/main/java/com/yahoo/memory/WritableDirectHandle.java
@@ -13,11 +13,11 @@ package com.yahoo.memory;
  * @author Lee Rhodes
  */
 //Joins a WritableHandle with writable, AutoCloseable AllocateDirect resource
-public class WritableDirectHandle implements AutoCloseable, WritableHandle {
-  AllocateDirect direct = null;
-  WritableMemory wMem = null;
+final class WritableDirectHandle implements WritableHandle {
+  AllocateDirect direct;
+  WritableMemory wMem;
 
-  public WritableDirectHandle(final AllocateDirect direct, final WritableMemory wMem) {
+  WritableDirectHandle(final AllocateDirect direct, final WritableMemory wMem) {
     this.direct = direct;
     this.wMem = wMem;
   }

--- a/src/main/java/com/yahoo/memory/package-info.java
+++ b/src/main/java/com/yahoo/memory/package-info.java
@@ -68,7 +68,7 @@
  *
  * <ul><li>{@link com.yahoo.memory.MapHandle} for read-only access to a memory-mapped file</li>
  * <li>{@link com.yahoo.memory.WritableMapHandle} for writable access to a memory-mapped file</li>
- * <li>{@link com.yahoo.memory.WritableDirectHandle} for writable access to off-heap memory.</li>
+ * <li>{@link com.yahoo.memory.WritableHandle} for writable access to off-heap memory.</li>
  * </ul>
  *
  * <p>As long as the implementation handle is valid the JVM will not attempt to close the resource.

--- a/src/test/java/com/yahoo/memory/AllocateDirectMemoryTest.java
+++ b/src/test/java/com/yahoo/memory/AllocateDirectMemoryTest.java
@@ -14,7 +14,7 @@ public class AllocateDirectMemoryTest {
   @Test
   public void simpleAllocateDirect() {
     int longs = 32;
-    try (WritableDirectHandle wh = WritableMemory.allocateDirect(longs << 3)) {
+    try (WritableHandle wh = WritableMemory.allocateDirect(longs << 3)) {
       WritableMemory wMem1 = wh.get();
       for (int i = 0; i<longs; i++) {
         wMem1.putLong(i << 3, i);
@@ -27,7 +27,7 @@ public class AllocateDirectMemoryTest {
   public void simpleMemoryRequestServer() {
     int longs = 32;
     int bytes = longs << 3;
-    try (WritableDirectHandle wh = WritableMemory.allocateDirect(bytes)) {
+    try (WritableHandle wh = WritableMemory.allocateDirect(bytes)) {
       WritableMemory wMem1 = wh.get();
       for (int i = 0; i<longs; i++) {
         wMem1.putLong(i << 3, i);
@@ -49,7 +49,7 @@ public class AllocateDirectMemoryTest {
 
   @Test
   public void checkClose() {
-    try (WritableDirectHandle wdh = WritableMemory.allocateDirect(128)) {
+    try (WritableHandle wdh = WritableMemory.allocateDirect(128)) {
       WritableMemory wmem = wdh.get();
       ResourceState state = wmem.getResourceState();
       state.setInvalid();//intentional before end of scope

--- a/src/test/java/com/yahoo/memory/AllocateDirectWritableMapMemoryTest.java
+++ b/src/test/java/com/yahoo/memory/AllocateDirectWritableMapMemoryTest.java
@@ -46,7 +46,7 @@ public class AllocateDirectWritableMapMemoryTest {
     try (
         WritableMapHandle dstHandle
           = WritableMemory.writableMap(file, 0, bytes, ByteOrder.nativeOrder());
-        WritableDirectHandle srcHandle = WritableMemory.allocateDirect(bytes)) {
+        WritableHandle srcHandle = WritableMemory.allocateDirect(bytes)) {
 
       WritableMemory dstMem = dstHandle.get();
       WritableMemory srcMem = srcHandle.get();

--- a/src/test/java/com/yahoo/memory/ArrayOverflowTest.java
+++ b/src/test/java/com/yahoo/memory/ArrayOverflowTest.java
@@ -13,7 +13,7 @@ import org.testng.annotations.Test;
 @Ignore("Test causes OutOfMemoryError in Travis CI, run only locally")
 public class ArrayOverflowTest {
 
-  private WritableDirectHandle h;
+  private WritableHandle h;
   private WritableMemory memory;
 
   @BeforeClass

--- a/src/test/java/com/yahoo/memory/BaseBufferTest.java
+++ b/src/test/java/com/yahoo/memory/BaseBufferTest.java
@@ -59,7 +59,7 @@ public class BaseBufferTest {
   public void checkCheckValid() {
     WritableMemory wmem;
     Buffer buf;
-    try (WritableDirectHandle hand = WritableMemory.allocateDirect(100)) {
+    try (WritableHandle hand = WritableMemory.allocateDirect(100)) {
       wmem = hand.get();
       buf = wmem.asBuffer();
     }

--- a/src/test/java/com/yahoo/memory/BufferInvariantsTest.java
+++ b/src/test/java/com/yahoo/memory/BufferInvariantsTest.java
@@ -143,7 +143,7 @@ public class BufferInvariantsTest {
 
   @Test
   public void checkLimitsDirect() {
-    try (WritableDirectHandle hand = WritableMemory.allocateDirect(100)) {
+    try (WritableHandle hand = WritableMemory.allocateDirect(100)) {
       WritableMemory wmem = hand.get();
       Buffer buf = wmem.asBuffer();
       buf.setStartPositionEnd(40, 45, 50);
@@ -214,7 +214,7 @@ public class BufferInvariantsTest {
   @Test
   public void testBufDirect() {
     int n = 25;
-    try (WritableDirectHandle whand = WritableMemory.allocateDirect(n)) {
+    try (WritableHandle whand = WritableMemory.allocateDirect(n)) {
     WritableMemory wmem = whand.get();
     WritableBuffer buf = wmem.asWritableBuffer();
     for (byte i = 0; i < n; i++) { buf.putByte(i); }

--- a/src/test/java/com/yahoo/memory/BufferTest.java
+++ b/src/test/java/com/yahoo/memory/BufferTest.java
@@ -21,7 +21,7 @@ public class BufferTest {
   @Test
   public void checkDirectRoundTrip() {
     int n = 1024; //longs
-    try (WritableDirectHandle wh = WritableMemory.allocateDirect(n * 8)) {
+    try (WritableHandle wh = WritableMemory.allocateDirect(n * 8)) {
       WritableMemory wmem = wh.get();
       WritableBuffer wbuf = wmem.asWritableBuffer();
       for (int i = 0; i < n; i++) {
@@ -274,7 +274,7 @@ public class BufferTest {
   public void checkParentUseAfterFree() {
     int bytes = 64 * 8;
     @SuppressWarnings("resource") //intentionally not using try-with-resources here
-    WritableDirectHandle wh = WritableMemory.allocateDirect(bytes);
+    WritableHandle wh = WritableMemory.allocateDirect(bytes);
     WritableMemory wmem = wh.get();
     WritableBuffer wbuf = wmem.asWritableBuffer();
     wh.close();
@@ -287,7 +287,7 @@ public class BufferTest {
   public void checkRegionUseAfterFree() {
     int bytes = 64;
     @SuppressWarnings("resource") //intentionally not using try-with-resources here
-    WritableDirectHandle wh = WritableMemory.allocateDirect(bytes);
+    WritableHandle wh = WritableMemory.allocateDirect(bytes);
     Memory wmem = wh.get();
 
     Buffer reg = wmem.asBuffer().region();

--- a/src/test/java/com/yahoo/memory/CommonBufferTest.java
+++ b/src/test/java/com/yahoo/memory/CommonBufferTest.java
@@ -14,7 +14,7 @@ public class CommonBufferTest {
   @Test
   public void checkSetGet() {
     int memCapacity = 60; //must be at least 60
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh.get();
       WritableBuffer buf = mem.asWritableBuffer();
       assertEquals(buf.getCapacity(), memCapacity);
@@ -116,7 +116,7 @@ public class CommonBufferTest {
   @Test
   public void checkSetGetArrays() {
     int memCapacity = 32;
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh.get();
       WritableBuffer buf = mem.asWritableBuffer();
       assertEquals(buf.getCapacity(), memCapacity);
@@ -213,7 +213,7 @@ public class CommonBufferTest {
   @Test
   public void checkSetGetPartialArraysWithOffset() {
     int memCapacity = 32;
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh.get();
       WritableBuffer buf = mem.asWritableBuffer();
       assertEquals(buf.getCapacity(), memCapacity);
@@ -307,7 +307,7 @@ public class CommonBufferTest {
   @Test
   public void checkSetClearMemoryRegions() {
     int memCapacity = 64; //must be 64
-    try (WritableDirectHandle wrh1 = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh1 = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh1.get();
       WritableBuffer buf = mem.asWritableBuffer();
       assertEquals(buf.getCapacity(), memCapacity);
@@ -396,7 +396,7 @@ public class CommonBufferTest {
   @Test
   public void checkToHexStringAllMem() {
     int memCapacity = 48; //must be 48
-    try (WritableDirectHandle wrh1 = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh1 = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh1.get();
       WritableBuffer buf = mem.asWritableBuffer();
       assertEquals(buf.getCapacity(), memCapacity);

--- a/src/test/java/com/yahoo/memory/CommonMemoryTest.java
+++ b/src/test/java/com/yahoo/memory/CommonMemoryTest.java
@@ -20,7 +20,7 @@ public class CommonMemoryTest {
   @Test
   public void checkSetGet() {
     int memCapacity = 16; //must be at least 8
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh.get();
       assertEquals(mem.getCapacity(), memCapacity);
       setGetTests(mem);
@@ -72,7 +72,7 @@ public class CommonMemoryTest {
   @Test
   public void checkSetGetArrays() {
     int memCapacity = 32;
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh.get();
       assertEquals(memCapacity, mem.getCapacity());
       setGetArraysTests(mem);
@@ -152,7 +152,7 @@ public class CommonMemoryTest {
   @Test
   public void checkSetGetPartialArraysWithOffset() {
     int memCapacity = 32;
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh.get();
       assertEquals(memCapacity, mem.getCapacity());
       setGetPartialArraysWithOffsetTests(mem);
@@ -229,7 +229,7 @@ public class CommonMemoryTest {
   @Test
   public void checkSetClearIsBits() {
     int memCapacity = 8;
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh.get();
       assertEquals(memCapacity, mem.getCapacity());
       mem.clear();
@@ -270,7 +270,7 @@ public class CommonMemoryTest {
   @Test
   public void checkAtomicMethods() {
     int memCapacity = 8;
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh.get();
       assertEquals(mem.getCapacity(), memCapacity);
       atomicMethodTests(mem);
@@ -297,7 +297,7 @@ public class CommonMemoryTest {
   @Test
   public void checkSetClearMemoryRegions() {
     int memCapacity = 64; //must be 64
-    try (WritableDirectHandle wrh1 = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh1 = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh1.get();
 
       setClearMemoryRegionsTests(mem); //requires println enabled to visually check
@@ -368,7 +368,7 @@ public class CommonMemoryTest {
   @Test
   public void checkToHexStringAllMem() {
     int memCapacity = 48; //must be 48
-    try (WritableDirectHandle wrh1 = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh1 = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh1.get();
       toHexStringAllMemTests(mem); //requires println enabled to visually check
     }

--- a/src/test/java/com/yahoo/memory/CopyMemoryOverlapTest.java
+++ b/src/test/java/com/yahoo/memory/CopyMemoryOverlapTest.java
@@ -75,7 +75,7 @@ public class CopyMemoryOverlapTest {
     println("CopyUp       : " + copyUp);
     println("Backing longs: " + backingLongs + "\t bytes: " + backingBytes);
 
-    try (WritableDirectHandle backHandle = WritableMemory.allocateDirect(backingBytes)) {
+    try (WritableHandle backHandle = WritableMemory.allocateDirect(backingBytes)) {
       WritableMemory backingMem = backHandle.get();
       fill(backingMem); //fill mem with 0 thru copyLongs -1
       //listMem(backingMem, "Original");
@@ -115,7 +115,7 @@ public class CopyMemoryOverlapTest {
     println("CopyUp       : " + copyUp);
     println("Backing longs: " + backingLongs + "\t bytes: " + backingBytes);
 
-    try (WritableDirectHandle backHandle = WritableMemory.allocateDirect(backingBytes)) {
+    try (WritableHandle backHandle = WritableMemory.allocateDirect(backingBytes)) {
       WritableMemory backingMem = backHandle.get();
       fill(backingMem); //fill mem with 0 thru copyLongs -1
       //listMem(backingMem, "Original");

--- a/src/test/java/com/yahoo/memory/CopyMemoryTest.java
+++ b/src/test/java/com/yahoo/memory/CopyMemoryTest.java
@@ -42,7 +42,7 @@ public class CopyMemoryTest {
   public void directWSource() {
     int k1 = 1 << 20; //longs
     int k2 = 2 * k1;
-    try (WritableDirectHandle wrh = genWRH(k1, false)) {
+    try (WritableHandle wrh = genWRH(k1, false)) {
       WritableMemory srcMem = wrh.get();
       WritableMemory dstMem = genMem(k2, true);
       srcMem.copyTo(0, dstMem, k1 << 3, k1 << 3);
@@ -54,7 +54,7 @@ public class CopyMemoryTest {
   public void directROSource() {
     int k1 = 1 << 20; //longs
     int k2 = 2 * k1;
-    try (WritableDirectHandle wrh = genWRH(k1, false)) {
+    try (WritableHandle wrh = genWRH(k1, false)) {
       Memory srcMem = wrh.get();
       WritableMemory dstMem = genMem(k2, true);
       srcMem.copyTo(0, dstMem, k1 << 3, k1 << 3);
@@ -91,7 +91,7 @@ public class CopyMemoryTest {
   public void directROSrcRegion() {
     int k1 = 1 << 20; //longs
     //gen baseMem of k1 longs w data, direct
-    try (WritableDirectHandle wrh = genWRH(k1, false)) {
+    try (WritableHandle wrh = genWRH(k1, false)) {
       Memory baseMem = wrh.get();
       //gen src region of k1/2 longs, off= k1/2
       Memory srcReg = baseMem.region((k1/2) << 3, (k1/2) << 3);
@@ -134,8 +134,8 @@ public class CopyMemoryTest {
     }
   }
 
-  private static WritableDirectHandle genWRH(int longs, boolean empty) {
-    WritableDirectHandle wrh = WritableMemory.allocateDirect(longs << 3);
+  private static WritableHandle genWRH(int longs, boolean empty) {
+    WritableHandle wrh = WritableMemory.allocateDirect(longs << 3);
     WritableMemory mem = wrh.get();
     if (empty) {
       mem.clear();

--- a/src/test/java/com/yahoo/memory/MemoryTest.java
+++ b/src/test/java/com/yahoo/memory/MemoryTest.java
@@ -21,7 +21,7 @@ public class MemoryTest {
   @Test
   public void checkDirectRoundTrip() {
     int n = 1024; //longs
-    try (WritableDirectHandle wh = WritableMemory.allocateDirect(n * 8)) {
+    try (WritableHandle wh = WritableMemory.allocateDirect(n * 8)) {
       WritableMemory mem = wh.get();
       for (int i = 0; i < n; i++) {
         mem.putLong(i * 8, i);
@@ -246,7 +246,7 @@ public class MemoryTest {
   public void checkParentUseAfterFree() {
     int bytes = 64 * 8;
     @SuppressWarnings("resource") //intentionally not using try-with-resouces here
-    WritableDirectHandle wh = WritableMemory.allocateDirect(bytes);
+    WritableHandle wh = WritableMemory.allocateDirect(bytes);
     WritableMemory wmem = wh.get();
     wh.close();
     //with -ea assert: Memory not valid.
@@ -258,7 +258,7 @@ public class MemoryTest {
   public void checkRegionUseAfterFree() {
     int bytes = 64;
     @SuppressWarnings("resource") //intentionally not using try-with-resouces here
-    WritableDirectHandle wh = WritableMemory.allocateDirect(bytes);
+    WritableHandle wh = WritableMemory.allocateDirect(bytes);
     Memory wmem = wh.get();
     Memory region = wmem.region(0L, bytes);
     wh.close();
@@ -271,8 +271,8 @@ public class MemoryTest {
   @Test
   public void checkMonitorDirectStats() {
     int bytes = 1024;
-    WritableDirectHandle wh1 = WritableMemory.allocateDirect(bytes);
-    WritableDirectHandle wh2 = WritableMemory.allocateDirect(bytes);
+    WritableHandle wh1 = WritableMemory.allocateDirect(bytes);
+    WritableHandle wh2 = WritableMemory.allocateDirect(bytes);
     assertEquals(Memory.getCurrentDirectMemoryAllocations(), 2L);
     assertEquals(Memory.getCurrentDirectMemoryAllocated(), 2 * bytes);
 

--- a/src/test/java/com/yahoo/memory/MemoryWriteToTest.java
+++ b/src/test/java/com/yahoo/memory/MemoryWriteToTest.java
@@ -38,7 +38,7 @@ public class MemoryWriteToTest {
 
   @Test
   public void testOffHeap() throws IOException {
-    try (WritableDirectHandle handle =
+    try (WritableHandle handle =
         WritableMemory.allocateDirect((CompareAndCopy.UNSAFE_COPY_MEMORY_THRESHOLD * 5) + 10)) {
       WritableMemory mem = handle.get();
       testWriteTo(mem.region(0, 0));

--- a/src/test/java/com/yahoo/memory/WritableBufferImplTest.java
+++ b/src/test/java/com/yahoo/memory/WritableBufferImplTest.java
@@ -22,7 +22,7 @@ public class WritableBufferImplTest {
   public void checkNativeCapacityAndClose() {
     int memCapacity = 64;
     @SuppressWarnings("resource") //intentionally not using try-with-resouces here
-    WritableDirectHandle wmh = WritableMemory.allocateDirect(memCapacity);
+    WritableHandle wmh = WritableMemory.allocateDirect(memCapacity);
     WritableMemory wmem = wmh.get();
     WritableBuffer wbuf = wmem.asWritableBuffer();
     assertEquals(wbuf.getCapacity(), memCapacity);
@@ -183,7 +183,7 @@ public class WritableBufferImplTest {
   @Test
   public void checkNativeBaseBound() {
     int memCapacity = 64;
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory wmem = wrh.get();
       WritableBuffer wbuf = wmem.asWritableBuffer();
       wbuf.toHexString("Force Assertion Error", memCapacity, 8);
@@ -195,7 +195,7 @@ public class WritableBufferImplTest {
   @Test
   public void checkNativeSrcArrayBound() {
     long memCapacity = 64;
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory wmem = wrh.get();
       WritableBuffer wbuf = wmem.asWritableBuffer();
       byte[] srcArray = { 1, -2, 3, -4 };
@@ -209,7 +209,7 @@ public class WritableBufferImplTest {
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void checkRegionBounds() {
     int memCapacity = 64;
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory wmem = wrh.get();
       WritableBuffer wbuf = wmem.asWritableBuffer();
       wbuf.writableRegion(1, 64); //wrong!
@@ -322,7 +322,7 @@ public class WritableBufferImplTest {
     int memCapacity = 64;
     WritableBuffer mem = WritableMemory.allocate(memCapacity).asWritableBuffer();
     assertFalse(mem.isDirect());
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem2 = wrh.get();
       WritableBuffer wbuf = mem2.asWritableBuffer();
       assertTrue(wbuf.isDirect());
@@ -379,9 +379,9 @@ public class WritableBufferImplTest {
     byte[] arr2 = new byte[] {0, 1, 2, 4};
     byte[] arr3 = new byte[] {0, 1, 2, 3, 4};
 
-    try (WritableDirectHandle h1 = WritableMemory.allocateDirect(4);
-        WritableDirectHandle h2 = WritableMemory.allocateDirect(4);
-        WritableDirectHandle h3 = WritableMemory.allocateDirect(5))
+    try (WritableHandle h1 = WritableMemory.allocateDirect(4);
+        WritableHandle h2 = WritableMemory.allocateDirect(4);
+        WritableHandle h3 = WritableMemory.allocateDirect(5))
     {
       WritableMemory mem1 = h1.get();
       mem1.putByteArray(0, arr1, 0, 4);

--- a/src/test/java/com/yahoo/memory/WritableDirectCopyTest.java
+++ b/src/test/java/com/yahoo/memory/WritableDirectCopyTest.java
@@ -21,7 +21,7 @@ public class WritableDirectCopyTest {
   public void checkCopyWithinNativeSmall() {
     int memCapacity = 64;
     int half = memCapacity/2;
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh.get();
       mem.clear();
 
@@ -43,7 +43,7 @@ public class WritableDirectCopyTest {
     int memCapLongs = memCapacity / 8;
     int halfBytes = memCapacity / 2;
     int halfLongs = memCapLongs / 2;
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh.get();
       mem.clear();
 
@@ -62,7 +62,7 @@ public class WritableDirectCopyTest {
   @Test
   public void checkCopyWithinNativeOverlap() {
     int memCapacity = 64;
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh.get();
       mem.clear();
       //println(mem.toHexString("Clear 64", 0, memCapacity));
@@ -78,7 +78,7 @@ public class WritableDirectCopyTest {
   @Test
   public void checkCopyWithinNativeSrcBound() {
     int memCapacity = 64;
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh.get();
       mem.copyTo(32, mem, 32, 33);  //hit source bound check
       fail("Did Not Catch Assertion Error: source bound");
@@ -91,7 +91,7 @@ public class WritableDirectCopyTest {
   @Test
   public void checkCopyWithinNativeDstBound() {
     int memCapacity = 64;
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh.get();
       mem.copyTo(0, mem, 32, 33);  //hit dst bound check
       fail("Did Not Catch Assertion Error: dst bound");
@@ -105,8 +105,8 @@ public class WritableDirectCopyTest {
   public void checkCopyCrossNativeSmall() {
     int memCapacity = 64;
 
-    try (WritableDirectHandle wrh1 = WritableMemory.allocateDirect(memCapacity);
-        WritableDirectHandle wrh2 = WritableMemory.allocateDirect(memCapacity))
+    try (WritableHandle wrh1 = WritableMemory.allocateDirect(memCapacity);
+        WritableHandle wrh2 = WritableMemory.allocateDirect(memCapacity))
     {
       WritableMemory mem1 = wrh1.get();
       WritableMemory mem2 = wrh2.get();
@@ -130,8 +130,8 @@ public class WritableDirectCopyTest {
     int memCapacity = (2<<20) + 64;
     int memCapLongs = memCapacity / 8;
 
-    try (WritableDirectHandle wrh1 = WritableMemory.allocateDirect(memCapacity);
-        WritableDirectHandle wrh2 = WritableMemory.allocateDirect(memCapacity))
+    try (WritableHandle wrh1 = WritableMemory.allocateDirect(memCapacity);
+        WritableHandle wrh2 = WritableMemory.allocateDirect(memCapacity))
     {
       WritableMemory mem1 = wrh1.get();
       WritableMemory mem2 = wrh2.get();
@@ -152,7 +152,7 @@ public class WritableDirectCopyTest {
   @Test
   public void checkCopyCrossNativeAndByteArray() {
     int memCapacity = 64;
-    try (WritableDirectHandle wrh1 = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh1 = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem1 = wrh1.get();
 
       for (int i= 0; i < mem1.getCapacity(); i++) {
@@ -173,7 +173,7 @@ public class WritableDirectCopyTest {
   public void checkCopyCrossRegionsSameNative() {
     int memCapacity = 128;
 
-    try (WritableDirectHandle wrh1 = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh1 = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem1 = wrh1.get();
 
       for (int i= 0; i < mem1.getCapacity(); i++) {
@@ -199,7 +199,7 @@ public class WritableDirectCopyTest {
   @Test
   public void checkCopyCrossNativeArrayAndHierarchicalRegions() {
     int memCapacity = 64;
-    try (WritableDirectHandle wrh1 = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh1 = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem1 = wrh1.get();
 
       for (int i= 0; i < mem1.getCapacity(); i++) { //fill with numbers

--- a/src/test/java/com/yahoo/memory/WritableMemoryImplTest.java
+++ b/src/test/java/com/yahoo/memory/WritableMemoryImplTest.java
@@ -23,7 +23,7 @@ public class WritableMemoryImplTest {
   public void checkNativeCapacityAndClose() {
     int memCapacity = 64;
     @SuppressWarnings("resource") //intentionally not using try-with-resouces here
-    WritableDirectHandle wmh = WritableMemory.allocateDirect(memCapacity);
+    WritableHandle wmh = WritableMemory.allocateDirect(memCapacity);
     WritableMemory mem = wmh.get();
     assertEquals(memCapacity, mem.getCapacity());
 
@@ -183,7 +183,7 @@ public class WritableMemoryImplTest {
   @Test
   public void checkNativeBaseBound() {
     int memCapacity = 64;
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh.get();
       mem.toHexString("Force Assertion Error", memCapacity, 8);
     } catch (IllegalArgumentException e) {
@@ -194,7 +194,7 @@ public class WritableMemoryImplTest {
   @Test
   public void checkNativeSrcArrayBound() {
     long memCapacity = 64;
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh.get();
       byte[] srcArray = { 1, -2, 3, -4 };
       mem.putByteArray(0L, srcArray, 0, 5);
@@ -215,7 +215,7 @@ public class WritableMemoryImplTest {
   public void checkCopyWithinNativeSmall() {
     int memCapacity = 64;
     int half = memCapacity/2;
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh.get();
       mem.clear();
 
@@ -237,7 +237,7 @@ public class WritableMemoryImplTest {
     int memCapLongs = memCapacity / 8;
     int halfBytes = memCapacity / 2;
     int halfLongs = memCapLongs / 2;
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh.get();
       mem.clear();
 
@@ -256,7 +256,7 @@ public class WritableMemoryImplTest {
   @Test
   public void checkCopyWithinNativeSrcBound() {
     int memCapacity = 64;
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh.get();
       mem.copyTo(32, mem, 32, 33);  //hit source bound check
       fail("Did Not Catch Assertion Error: source bound");
@@ -269,7 +269,7 @@ public class WritableMemoryImplTest {
   @Test
   public void checkCopyWithinNativeDstBound() {
     int memCapacity = 64;
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh.get();
       mem.copyTo(0, mem, 32, 33);  //hit dst bound check
       fail("Did Not Catch Assertion Error: dst bound");
@@ -283,8 +283,8 @@ public class WritableMemoryImplTest {
   public void checkCopyCrossNativeSmall() {
     int memCapacity = 64;
 
-    try (WritableDirectHandle wrh1 = WritableMemory.allocateDirect(memCapacity);
-        WritableDirectHandle wrh2 = WritableMemory.allocateDirect(memCapacity))
+    try (WritableHandle wrh1 = WritableMemory.allocateDirect(memCapacity);
+        WritableHandle wrh2 = WritableMemory.allocateDirect(memCapacity))
     {
       WritableMemory mem1 = wrh1.get();
       WritableMemory mem2 = wrh2.get();
@@ -308,8 +308,8 @@ public class WritableMemoryImplTest {
     int memCapacity = (2<<20) + 64;
     int memCapLongs = memCapacity / 8;
 
-    try (WritableDirectHandle wrh1 = WritableMemory.allocateDirect(memCapacity);
-        WritableDirectHandle wrh2 = WritableMemory.allocateDirect(memCapacity))
+    try (WritableHandle wrh1 = WritableMemory.allocateDirect(memCapacity);
+        WritableHandle wrh2 = WritableMemory.allocateDirect(memCapacity))
     {
       WritableMemory mem1 = wrh1.get();
       WritableMemory mem2 = wrh2.get();
@@ -330,7 +330,7 @@ public class WritableMemoryImplTest {
   @Test
   public void checkCopyCrossNativeAndByteArray() {
     int memCapacity = 64;
-    try (WritableDirectHandle wrh1 = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh1 = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem1 = wrh1.get();
 
       for (int i= 0; i < mem1.getCapacity(); i++) {
@@ -351,7 +351,7 @@ public class WritableMemoryImplTest {
   public void checkCopyCrossRegionsSameNative() {
     int memCapacity = 128;
 
-    try (WritableDirectHandle wrh1 = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh1 = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem1 = wrh1.get();
 
       for (int i= 0; i < mem1.getCapacity(); i++) {
@@ -377,7 +377,7 @@ public class WritableMemoryImplTest {
   @Test
   public void checkCopyCrossNativeArrayAndHierarchicalRegions() {
     int memCapacity = 64;
-    try (WritableDirectHandle wrh1 = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh1 = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem1 = wrh1.get();
 
       for (int i= 0; i < mem1.getCapacity(); i++) { //fill with numbers
@@ -407,7 +407,7 @@ public class WritableMemoryImplTest {
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void checkRegionBounds() {
     int memCapacity = 64;
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh.get();
       mem.writableRegion(1, 64);
     }
@@ -519,7 +519,7 @@ public class WritableMemoryImplTest {
     int memCapacity = 64;
     WritableMemory mem = WritableMemory.allocate(memCapacity);
     assertFalse(mem.isDirect());
-    try (WritableDirectHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
+    try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       mem = wrh.get();
       assertTrue(mem.isDirect());
       wrh.close();
@@ -581,9 +581,9 @@ public class WritableMemoryImplTest {
     byte[] arr2 = new byte[] {0, 1, 2, 4};
     byte[] arr3 = new byte[] {0, 1, 2, 3, 4};
 
-    try (WritableDirectHandle h1 = WritableMemory.allocateDirect(4);
-        WritableDirectHandle h2 = WritableMemory.allocateDirect(4);
-        WritableDirectHandle h3 = WritableMemory.allocateDirect(5))
+    try (WritableHandle h1 = WritableMemory.allocateDirect(4);
+        WritableHandle h2 = WritableMemory.allocateDirect(4);
+        WritableHandle h3 = WritableMemory.allocateDirect(5))
     {
       WritableMemory mem1 = h1.get();
       mem1.putByteArray(0, arr1, 0, 4);

--- a/src/test/java/com/yahoo/memory/ZeroCapacityTest.java
+++ b/src/test/java/com/yahoo/memory/ZeroCapacityTest.java
@@ -28,7 +28,7 @@ public class ZeroCapacityTest {
     Memory mem2 = Memory.wrap(ByteBuffer.allocate(0));
     Memory mem3 = Memory.wrap(ByteBuffer.allocateDirect(0));
     Memory reg = mem3.region(0, 0);
-    try (WritableDirectHandle wmem = WritableMemory.allocateDirect(0)) {
+    try (WritableHandle wmem = WritableMemory.allocateDirect(0)) {
 
     }
   }


### PR DESCRIPTION
 - Made API less specific about the returned empty memory;
 - Hidden `WritableDirectHandle` from the API
 - Added `WritableMemory.wrap(byte[], BO)` and `wrap(byte[], int, int, BO)`