### PR TITLE
OriginMemory is now final in BaseWritableBufferImpl. Several changes

### DIFF
--- a/src/main/java/com/yahoo/memory/BaseWritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/BaseWritableBufferImpl.java
@@ -39,13 +39,25 @@ abstract class BaseWritableBufferImpl extends WritableBuffer {
   final Object unsafeObj; //Array objects are held here.
   final long cumBaseOffset; //Holds the cumulative offset to the start of data.
   final boolean localReadOnly;
+  final BaseWritableMemoryImpl originMemory;
 
-  BaseWritableBufferImpl(final ResourceState state, final boolean localReadOnly) {
+  //Static variable for cases where byteBuf/array sizes are zero
+  final static WritableBufferImpl ZERO_SIZE_BUFFER;
+
+  static {
+    final ResourceState state = new ResourceState(new byte[0], Prim.BYTE, 0);
+    ZERO_SIZE_BUFFER = new WritableBufferImpl(state, true, null);
+  }
+
+  //called from one of the Endian-sensitive WritableBufferImpls
+  BaseWritableBufferImpl(final ResourceState state, final boolean localReadOnly,
+      final BaseWritableMemoryImpl originMemory) {
     super(state.getCapacity());
     this.state = state;
     unsafeObj = state.getUnsafeObject();
     cumBaseOffset = state.getCumBaseOffset();
     this.localReadOnly = localReadOnly;
+    this.originMemory = originMemory;
   }
 
   //PRIMITIVE getXXX() and getXXXArray() XXX

--- a/src/main/java/com/yahoo/memory/BaseWritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/BaseWritableMemoryImpl.java
@@ -36,14 +36,19 @@ import java.nio.channels.WritableByteChannel;
  * Contains methods which are agnostic to the byte order.
  */
 abstract class BaseWritableMemoryImpl extends WritableMemory {
-
-
-
   final ResourceState state;
   final Object unsafeObj; //Array objects are held here.
   final long capacity;
   final long cumBaseOffset; //Holds the cumulative offset to the start of data.
   final boolean localReadOnly;
+
+  //Static variable for cases where byteBuf/array/direct sizes are zero
+  final static WritableMemoryImpl ZERO_SIZE_MEMORY;
+
+  static {
+    final ResourceState state = new ResourceState(new byte[0], Prim.BYTE, 0);
+    ZERO_SIZE_MEMORY = new WritableMemoryImpl(state, true);
+  }
 
   BaseWritableMemoryImpl(final ResourceState state, final boolean localReadOnly) {
     unsafeObj = state.getUnsafeObject();

--- a/src/main/java/com/yahoo/memory/CompareAndCopy.java
+++ b/src/main/java/com/yahoo/memory/CompareAndCopy.java
@@ -25,6 +25,8 @@ final class CompareAndCopy {
    */
   static final int UNSAFE_COPY_THRESHOLD = 1024 * 1024;
 
+  private CompareAndCopy() { }
+
   static int compare(
       final ResourceState state1, final long offsetBytes1, final long lengthBytes1,
       final ResourceState state2, final long offsetBytes2, final long lengthBytes2) {

--- a/src/main/java/com/yahoo/memory/Ints.java
+++ b/src/main/java/com/yahoo/memory/Ints.java
@@ -8,6 +8,8 @@ package com.yahoo.memory;
 /** Equivalent of Guava's Ints. */
 final class Ints {
 
+  private Ints() {}
+
   static int checkedCast(final long v) {
     final int result = (int) v;
     if (result != v) {
@@ -16,6 +18,4 @@ final class Ints {
       return result;
     }
   }
-
-  private Ints() {}
 }

--- a/src/main/java/com/yahoo/memory/JDK7Compatible.java
+++ b/src/main/java/com/yahoo/memory/JDK7Compatible.java
@@ -7,6 +7,8 @@ package com.yahoo.memory;
 
 final class JDK7Compatible {
 
+  private JDK7Compatible() {}
+
   public static long getAndAddLong(final Object obj, final long address, final long increment) {
     long retVal;
     do {
@@ -24,6 +26,4 @@ final class JDK7Compatible {
 
     return retVal;
   }
-
-  private JDK7Compatible() {}
 }

--- a/src/main/java/com/yahoo/memory/NioBits.java
+++ b/src/main/java/com/yahoo/memory/NioBits.java
@@ -76,6 +76,8 @@ final class NioBits {
     }
   }
 
+  private NioBits() { }
+
   static long getDirectAllocationsCount() {
     try {
       final long count = nioBitsCount.get();

--- a/src/main/java/com/yahoo/memory/Utf8.java
+++ b/src/main/java/com/yahoo/memory/Utf8.java
@@ -28,6 +28,8 @@ import java.nio.CharBuffer;
  */
 final class Utf8 {
 
+  private Utf8() { }
+
   //Decode
   static final int getCharsFromUtf8(final long offsetBytes, final int utf8LengthBytes,
       final Appendable dst, final ResourceState state)

--- a/src/main/java/com/yahoo/memory/Util.java
+++ b/src/main/java/com/yahoo/memory/Util.java
@@ -14,6 +14,8 @@ import java.util.Random;
  */
 public final class Util {
 
+  private Util() { }
+
   /**
    * Searches a range of the specified array of longs for the specified value using the binary
    * search algorithm. The range must be sorted method) prior to making this call.

--- a/src/main/java/com/yahoo/memory/WritableBuffer.java
+++ b/src/main/java/com/yahoo/memory/WritableBuffer.java
@@ -5,8 +5,6 @@
 
 package com.yahoo.memory;
 
-import static com.yahoo.memory.WritableBufferImpl.ZERO_SIZE_BUFFER;
-
 import java.nio.ByteBuffer;
 
 /**
@@ -36,14 +34,10 @@ public abstract class WritableBuffer extends Buffer {
   }
 
   static WritableBuffer wrapBB(final ByteBuffer byteBuf, final boolean localReadOnly) {
-    if (byteBuf.capacity() == 0) { return ZERO_SIZE_BUFFER; }
-    final ResourceState state = new ResourceState(byteBuf.isReadOnly());//sets resourceIsReadOnly
-    state.putByteBuffer(byteBuf); //sets resourceOrder
-    AccessByteBuffer.wrap(state);
-    final boolean ro = state.isResourceReadOnly() || localReadOnly;
-    final BaseWritableBufferImpl impl = new WritableBufferImpl(state, ro);
-    impl.setStartPositionEnd(0, byteBuf.position(), byteBuf.limit());
-    return impl;
+    final WritableMemory wmem = WritableMemory.wrapBB(byteBuf, localReadOnly);
+    final WritableBuffer wbuf = wmem.asWritableBuffer();
+    wbuf.setStartPositionEnd(0, byteBuf.position(), byteBuf.limit());
+    return wbuf;
   }
 
   //MAP XXX

--- a/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
@@ -41,18 +41,11 @@ import java.io.IOException;
  */
 
 /**
- * Implementation of WritableMemory
+ * Implementation of WritableMemory for Native Endian ByteOrder.
  * @author Roman Leventov
  * @author Lee Rhodes
  */
 class WritableMemoryImpl extends BaseWritableMemoryImpl {
-
-  //Static variable for cases where byteBuf/array/direct sizes are zero
-  final static WritableMemoryImpl ZERO_SIZE_MEMORY;
-
-  static {
-    ZERO_SIZE_MEMORY = new WritableMemoryImpl(new ResourceState(new byte[0], Prim.BYTE, 0), true);
-  }
 
   WritableMemoryImpl(final ResourceState state, final boolean localReadOnly) {
     super(state, localReadOnly);
@@ -99,11 +92,10 @@ class WritableMemoryImpl extends BaseWritableMemoryImpl {
     checkValid();
     final WritableBufferImpl wbuf;
     if (capacity == 0) {
-      wbuf = WritableBufferImpl.ZERO_SIZE_BUFFER;
+      wbuf = BaseWritableBufferImpl.ZERO_SIZE_BUFFER;
     } else {
-      wbuf = new WritableBufferImpl(state, localReadOnly);
+      wbuf = new WritableBufferImpl(state, localReadOnly, this);
       wbuf.setAndCheckStartPositionEnd(0, 0, capacity);
-      wbuf.originMemory = this;
     }
     return wbuf;
   }

--- a/src/test/java/com/yahoo/memory/BaseBufferTest.java
+++ b/src/test/java/com/yahoo/memory/BaseBufferTest.java
@@ -63,12 +63,7 @@ public class BaseBufferTest {
       wmem = hand.get();
       buf = wmem.asBuffer();
     }
-    try {
-      @SuppressWarnings("unused")
-      Memory mem = buf.asMemory();
-      fail();
-    } catch (IllegalStateException e) {
-      //ok
-    }
+    @SuppressWarnings("unused")
+    Memory mem = buf.asMemory();
   }
 }

--- a/src/test/java/com/yahoo/memory/ResourceStateTest.java
+++ b/src/test/java/com/yahoo/memory/ResourceStateTest.java
@@ -22,7 +22,7 @@ public class ResourceStateTest {
     ResourceState state = new ResourceState(false);
     assertEquals(state.getResourceOrder(), ByteOrder.nativeOrder());
     if (ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN) {
-      state.putResourceOrder(ByteOrder.BIG_ENDIAN);
+      state.putResourceOrder(ByteOrder.BIG_ENDIAN); //set to opposite
     } else {
       state.putResourceOrder(ByteOrder.LITTLE_ENDIAN);
     }
@@ -112,6 +112,17 @@ public class ResourceStateTest {
     boolean same = state.isSameResource(state);
     assertTrue(same);
   }
+
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void checkValid() {
+    try (WritableHandle wh = WritableMemory.allocateDirect(1024)) {
+      WritableMemory wmem = wh.get();
+      wh.close();
+      ResourceState state = wmem.getResourceState();
+      state.checkValid();
+    }
+  }
+
 
   @Test
   public void printlnTest() {

--- a/src/test/java/com/yahoo/memory/WritableBufferImplTest.java
+++ b/src/test/java/com/yahoo/memory/WritableBufferImplTest.java
@@ -474,11 +474,12 @@ public class WritableBufferImplTest {
   }
 
   @SuppressWarnings("unused")
-  @Test
-  public void checkAsWritableMemory() {
-    WritableMemory wmem = WritableMemory.allocate(8);
-    WritableBuffer wbuf = wmem.asWritableBuffer();
-    WritableMemory wmem2 = wbuf.asWritableMemory();
+  @Test(expectedExceptions = ReadOnlyException.class)
+  public void checkAsWritableMemoryRO() {
+    ByteBuffer bb = ByteBuffer.allocate(64);
+    Buffer buf = Buffer.wrap(bb);
+    WritableBuffer wbuf = (WritableBuffer) buf;
+    WritableMemory wmem = wbuf.asWritableMemory();
   }
 
   @Test


### PR DESCRIPTION
needed to make this work.

Moved ZERO_SIZE_BUFFER/MEMORY to BaseWritable*Impl so it is independent
of endianness. Also moved final static initializer.

Private empty constructors should be at the top of the file where they
can be easily found. Found a few instances where they were at the
bottom.

NioBits, Utf8 and Util needed a private empty ctors.

Removed tests that were no longer valid.