### PR TITLE
Added non-native ordered buffer and memory variants

### DIFF
--- a/src/main/java/com/yahoo/memory/BaseBuffer.java
+++ b/src/main/java/com/yahoo/memory/BaseBuffer.java
@@ -40,7 +40,7 @@ public abstract class BaseBuffer {
    * @param increment the given increment
    * @return BaseBuffer
    */
-  public BaseBuffer incrementPosition(final long increment) {
+  public final BaseBuffer incrementPosition(final long increment) {
     incrementAndAssertPositionForRead(pos, increment);
     return this;
   }
@@ -52,7 +52,7 @@ public abstract class BaseBuffer {
    * @param increment the given increment
    * @return BaseBuffer
    */
-  public BaseBuffer incrementAndCheckPosition(final long increment) {
+  public final BaseBuffer incrementAndCheckPosition(final long increment) {
     incrementAndCheckPositionForRead(pos, increment);
     return this;
   }
@@ -61,7 +61,7 @@ public abstract class BaseBuffer {
    * Gets the end position
    * @return the end position
    */
-  public long getEnd() {
+  public final long getEnd() {
     return end;
   }
 
@@ -69,7 +69,7 @@ public abstract class BaseBuffer {
    * Gets the current position
    * @return the current position
    */
-  public long getPosition() {
+  public final long getPosition() {
     return pos;
   }
 
@@ -77,7 +77,7 @@ public abstract class BaseBuffer {
    * Gets start position
    * @return start position
    */
-  public long getStart() {
+  public final long getStart() {
     return start;
   }
 
@@ -85,7 +85,7 @@ public abstract class BaseBuffer {
    * The number of elements remaining between the current position and the end position
    * @return {@code (end - position)}
    */
-  public long getRemaining()  {
+  public final long getRemaining()  {
     return end - pos;
   }
 
@@ -93,7 +93,7 @@ public abstract class BaseBuffer {
    * Returns true if there are elements remaining between the current position and the end position
    * @return {@code (end - position) > 0}
    */
-  public boolean hasRemaining() {
+  public final boolean hasRemaining() {
     return (end - pos) > 0;
   }
 
@@ -102,7 +102,7 @@ public abstract class BaseBuffer {
    * This does not modify any data.
    * @return BaseBuffer
    */
-  public BaseBuffer resetPosition() {
+  public final BaseBuffer resetPosition() {
     pos = start;
     return this;
   }
@@ -114,7 +114,7 @@ public abstract class BaseBuffer {
    * @param position the given current position.
    * @return BaseBuffer
    */
-  public BaseBuffer setPosition(final long position) {
+  public final BaseBuffer setPosition(final long position) {
     assertInvariants(start, position, end, capacity);
     pos = position;
     return this;
@@ -127,7 +127,7 @@ public abstract class BaseBuffer {
    * @param position the given current position.
    * @return BaseBuffer
    */
-  public BaseBuffer setAndCheckPosition(final long position) {
+  public final BaseBuffer setAndCheckPosition(final long position) {
     checkInvariants(start, position, end, capacity);
     pos = position;
     return this;
@@ -143,7 +143,7 @@ public abstract class BaseBuffer {
    * @return BaseBuffer
    */
   public final BaseBuffer setStartPositionEnd(final long start, final long position,
-        final long end) {
+      final long end) {
     assertInvariants(start, position, end, capacity);
     this.start = start;
     this.end = end;
@@ -161,7 +161,7 @@ public abstract class BaseBuffer {
    * @return BaseBuffer
    */
   public final BaseBuffer setAndCheckStartPositionEnd(final long start, final long position,
-        final long end) {
+      final long end) {
     checkInvariants(start, position, end, capacity);
     this.start = start;
     this.end = end;
@@ -170,14 +170,14 @@ public abstract class BaseBuffer {
   }
 
   //RESTRICTED XXX
-  void incrementAndAssertPositionForRead(final long position, final long increment) {
+  final void incrementAndAssertPositionForRead(final long position, final long increment) {
     assertValid();
     final long newPos = position + increment;
     assertInvariants(start, newPos, end, capacity);
     pos = newPos;
   }
 
-  void incrementAndAssertPositionForWrite(final long position, final long increment) {
+  final void incrementAndAssertPositionForWrite(final long position, final long increment) {
     assertValid();
     assert !isLocalReadOnly() : "Buffer is read-only.";
     final long newPos = position + increment;
@@ -185,21 +185,25 @@ public abstract class BaseBuffer {
     pos = newPos;
   }
 
-  void incrementAndCheckPositionForRead(final long pos, final long increment) {
+  final void incrementAndCheckPositionForRead(final long pos, final long increment) {
     checkValid();
     final long newPos = pos + increment;
     checkInvariants(start, newPos, end, capacity);
     this.pos = newPos;
   }
 
-  void incrementAndCheckPositionForWrite(final long pos, final long increment) {
+  final void incrementAndCheckPositionForWrite(final long pos, final long increment) {
+    checkValidForWrite();
+    final long newPos = pos + increment;
+    checkInvariants(start, newPos, end, capacity);
+    this.pos = newPos;
+  }
+
+  final void checkValidForWrite() {
     checkValid();
     if (isLocalReadOnly()) {
       throw new ReadOnlyException("Buffer is read-only.");
     }
-    final long newPos = pos + increment;
-    checkInvariants(start, newPos, end, capacity);
-    this.pos = newPos;
   }
 
   /**

--- a/src/main/java/com/yahoo/memory/BaseWritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/BaseWritableBufferImpl.java
@@ -9,6 +9,10 @@ import static com.yahoo.memory.UnsafeUtil.ARRAY_BOOLEAN_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_BOOLEAN_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_BYTE_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_BYTE_INDEX_SCALE;
+import static com.yahoo.memory.UnsafeUtil.ARRAY_CHAR_INDEX_SCALE;
+import static com.yahoo.memory.UnsafeUtil.ARRAY_INT_INDEX_SCALE;
+import static com.yahoo.memory.UnsafeUtil.ARRAY_LONG_INDEX_SCALE;
+import static com.yahoo.memory.UnsafeUtil.ARRAY_SHORT_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.LS;
 import static com.yahoo.memory.UnsafeUtil.assertBounds;
 import static com.yahoo.memory.UnsafeUtil.checkBounds;
@@ -62,63 +66,108 @@ abstract class BaseWritableBufferImpl extends WritableBuffer {
 
   //PRIMITIVE getXXX() and getXXXArray() XXX
   @Override
-  public boolean getBoolean() {
+  public final boolean getBoolean() {
     final long pos = getPosition();
     incrementAndAssertPositionForRead(pos, ARRAY_BOOLEAN_INDEX_SCALE);
     return unsafe.getBoolean(unsafeObj, cumBaseOffset + pos);
   }
 
   @Override
-  public boolean getBoolean(final long offsetBytes) {
+  public final boolean getBoolean(final long offsetBytes) {
     assertValidAndBoundsForRead(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE);
     return unsafe.getBoolean(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
   @Override
-  public void getBooleanArray(final boolean[] dstArray, final int dstOffset,
+  public final void getBooleanArray(final boolean[] dstArray, final int dstOffsetBooleans,
       final int lengthBooleans) {
     final long pos = getPosition();
     final long copyBytes = lengthBooleans;
     incrementAndCheckPositionForRead(pos, copyBytes);
-    checkBounds(dstOffset, lengthBooleans, dstArray.length);
+    checkBounds(dstOffsetBooleans, lengthBooleans, dstArray.length);
     CompareAndCopy.copyMemoryCheckingDifferentObject(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
-            ARRAY_BOOLEAN_BASE_OFFSET + dstOffset,
+            ARRAY_BOOLEAN_BASE_OFFSET + dstOffsetBooleans,
             copyBytes);
   }
 
   @Override
-  public byte getByte() {
+  public final byte getByte() {
     final long pos = getPosition();
     incrementAndAssertPositionForRead(pos, ARRAY_BYTE_INDEX_SCALE);
     return unsafe.getByte(unsafeObj, cumBaseOffset + pos);
   }
 
   @Override
-  public byte getByte(final long offsetBytes) {
+  public final byte getByte(final long offsetBytes) {
     assertValidAndBoundsForRead(offsetBytes, ARRAY_BYTE_INDEX_SCALE);
     return unsafe.getByte(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
   @Override
-  public void getByteArray(final byte[] dstArray, final int dstOffset, final int lengthBytes) {
+  public final void getByteArray(final byte[] dstArray, final int dstOffsetBytes,
+      final int lengthBytes) {
     final long pos = getPosition();
     final long copyBytes = lengthBytes;
     incrementAndCheckPositionForRead(pos, copyBytes);
-    checkBounds(dstOffset, lengthBytes, dstArray.length);
+    checkBounds(dstOffsetBytes, lengthBytes, dstArray.length);
     CompareAndCopy.copyMemoryCheckingDifferentObject(
             unsafeObj,
             cumBaseOffset + pos,
             dstArray,
-            ARRAY_BYTE_BASE_OFFSET + dstOffset,
+            ARRAY_BYTE_BASE_OFFSET + dstOffsetBytes,
             copyBytes);
+  }
+
+  final char getNativeOrderedChar() {
+    final long pos = getPosition();
+    incrementAndAssertPositionForRead(pos, ARRAY_CHAR_INDEX_SCALE);
+    return unsafe.getChar(unsafeObj, cumBaseOffset + pos);
+  }
+
+  final char getNativeOrderedChar(final long offsetBytes) {
+    assertValidAndBoundsForRead(offsetBytes, ARRAY_CHAR_INDEX_SCALE);
+    return unsafe.getChar(unsafeObj, cumBaseOffset + offsetBytes);
+  }
+
+  final int getNativeOrderedInt() {
+    final long pos = getPosition();
+    incrementAndAssertPositionForRead(pos, ARRAY_INT_INDEX_SCALE);
+    return unsafe.getInt(unsafeObj, cumBaseOffset + pos);
+  }
+
+  final int getNativeOrderedInt(final long offsetBytes) {
+    assertValidAndBoundsForRead(offsetBytes, ARRAY_INT_INDEX_SCALE);
+    return unsafe.getInt(unsafeObj, cumBaseOffset + offsetBytes);
+  }
+
+  final long getNativeOrderedLong() {
+    final long pos = getPosition();
+    incrementAndAssertPositionForRead(pos, ARRAY_LONG_INDEX_SCALE);
+    return unsafe.getLong(unsafeObj, cumBaseOffset + pos);
+  }
+
+  final long getNativeOrderedLong(final long offsetBytes) {
+    assertValidAndBoundsForRead(offsetBytes, ARRAY_LONG_INDEX_SCALE);
+    return unsafe.getLong(unsafeObj, cumBaseOffset + offsetBytes);
+  }
+
+  final short getNativeOrderedShort() {
+    final long pos = getPosition();
+    incrementAndAssertPositionForRead(pos, ARRAY_SHORT_INDEX_SCALE);
+    return unsafe.getShort(unsafeObj, cumBaseOffset + pos);
+  }
+
+  final short getNativeOrderedShort(final long offsetBytes) {
+    assertValidAndBoundsForRead(offsetBytes, ARRAY_SHORT_INDEX_SCALE);
+    return unsafe.getShort(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
   //OTHER PRIMITIVE READ METHODS: copyTo, compareTo XXX
   @Override
-  public int compareTo(final long thisOffsetBytes, final long thisLengthBytes,
+  public final int compareTo(final long thisOffsetBytes, final long thisLengthBytes,
       final Buffer thatBuf, final long thatOffsetBytes, final long thatLengthBytes) {
     return CompareAndCopy.compare(state, thisOffsetBytes, thisLengthBytes,
         thatBuf.getResourceState(), thatOffsetBytes, thatLengthBytes);
@@ -131,61 +180,61 @@ abstract class BaseWritableBufferImpl extends WritableBuffer {
 
   //OTHER READ METHODS XXX
   @Override
-  public void checkValidAndBounds(final long offsetBytes, final long lengthBytes) {
+  public final void checkValidAndBounds(final long offsetBytes, final long lengthBytes) {
     checkValid();
     checkBounds(offsetBytes, lengthBytes, capacity);
   }
 
   @Override
-  public long getCapacity() {
+  public final long getCapacity() {
     assertValid();
     return capacity;
   }
 
   @Override
-  public long getCumulativeOffset() {
+  public final long getCumulativeOffset() {
     assertValid();
     return cumBaseOffset;
   }
 
   @Override
-  public long getRegionOffset() {
+  public final long getRegionOffset() {
     assertValid();
     return state.getRegionOffset();
   }
 
   @Override
-  public boolean hasArray() {
+  public final boolean hasArray() {
     assertValid();
     return unsafeObj != null;
   }
 
   @Override
-  public boolean hasByteBuffer() {
+  public final boolean hasByteBuffer() {
     assertValid();
     return state.getByteBuffer() != null;
   }
 
   @Override
-  public boolean isDirect() {
+  public final boolean isDirect() {
     assertValid();
     return state.isDirect();
   }
 
   @Override
-  public boolean isResourceReadOnly() {
+  public final boolean isResourceReadOnly() {
     assertValid();
     return state.isResourceReadOnly();
   }
 
   @Override
-  boolean isLocalReadOnly() {
+  final boolean isLocalReadOnly() {
     assertValid();
     return localReadOnly;
   }
 
   @Override
-  public boolean isSameResource(final Buffer that) {
+  public final boolean isSameResource(final Buffer that) {
     if (that == null) { return false; }
     checkValid();
     that.checkValid();
@@ -193,23 +242,24 @@ abstract class BaseWritableBufferImpl extends WritableBuffer {
   }
 
   @Override
-  public boolean isValid() {
+  public final boolean isValid() {
     return state.isValid();
   }
 
   @Override
-  public ByteOrder getResourceOrder() {
+  public final ByteOrder getResourceOrder() {
     assertValid();
     return state.getResourceOrder();
   }
 
   @Override
-  public boolean isSwapBytes() {
+  public final boolean isSwapBytes() {
     return state.isSwapBytes();
   }
 
   @Override
-  public String toHexString(final String header, final long offsetBytes, final int lengthBytes) {
+  public final String toHexString(final String header, final long offsetBytes,
+      final int lengthBytes) {
     checkValid();
     final String klass = this.getClass().getSimpleName();
     final String s1 = String.format("(..., %d, %d)", offsetBytes, lengthBytes);
@@ -224,86 +274,131 @@ abstract class BaseWritableBufferImpl extends WritableBuffer {
 
   //PRIMITIVE putXXX() and putXXXArray() XXX
   @Override
-  public void putBoolean(final boolean value) {
+  public final void putBoolean(final boolean value) {
     final long pos = getPosition();
     incrementAndAssertPositionForWrite(pos, ARRAY_BOOLEAN_INDEX_SCALE);
     unsafe.putBoolean(unsafeObj, cumBaseOffset + pos, value);
   }
 
   @Override
-  public void putBoolean(final long offsetBytes, final boolean value) {
+  public final void putBoolean(final long offsetBytes, final boolean value) {
     assertValidAndBoundsForWrite(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE);
     unsafe.putBoolean(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
   @Override
-  public void putBooleanArray(final boolean[] srcArray, final int srcOffset,
+  public final void putBooleanArray(final boolean[] srcArray, final int srcOffsetBooleans,
       final int lengthBooleans) {
     final long pos = getPosition();
     final long copyBytes = lengthBooleans;
     incrementAndCheckPositionForWrite(pos, copyBytes);
-    checkBounds(srcOffset, lengthBooleans, srcArray.length);
+    checkBounds(srcOffsetBooleans, lengthBooleans, srcArray.length);
     CompareAndCopy.copyMemoryCheckingDifferentObject(
             srcArray,
-            ARRAY_BOOLEAN_BASE_OFFSET + srcOffset,
+            ARRAY_BOOLEAN_BASE_OFFSET + srcOffsetBooleans,
             unsafeObj,
             cumBaseOffset + pos,
             copyBytes);
   }
 
   @Override
-  public void putByte(final byte value) {
+  public final void putByte(final byte value) {
     final long pos = getPosition();
     incrementAndAssertPositionForWrite(pos, ARRAY_BYTE_INDEX_SCALE);
     unsafe.putByte(unsafeObj, cumBaseOffset + pos, value);
   }
 
   @Override
-  public void putByte(final long offsetBytes, final byte value) {
+  public final void putByte(final long offsetBytes, final byte value) {
     assertValidAndBoundsForWrite(offsetBytes, ARRAY_BYTE_INDEX_SCALE);
     unsafe.putByte(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
   @Override
-  public void putByteArray(final byte[] srcArray, final int srcOffset, final int lengthBytes) {
+  public final void putByteArray(final byte[] srcArray, final int srcOffsetBytes,
+      final int lengthBytes) {
     final long pos = getPosition();
     final long copyBytes = lengthBytes;
     incrementAndCheckPositionForWrite(pos, copyBytes);
-    checkBounds(srcOffset, lengthBytes, srcArray.length);
+    checkBounds(srcOffsetBytes, lengthBytes, srcArray.length);
     CompareAndCopy.copyMemoryCheckingDifferentObject(
             srcArray,
-            ARRAY_BYTE_BASE_OFFSET + srcOffset,
+            ARRAY_BYTE_BASE_OFFSET + srcOffsetBytes,
             unsafeObj,
             cumBaseOffset + pos,
             copyBytes);
   }
 
+  final void putNativeOrderedChar(final char value) {
+    final long pos = getPosition();
+    incrementAndAssertPositionForWrite(pos, ARRAY_CHAR_INDEX_SCALE);
+    unsafe.putChar(unsafeObj, cumBaseOffset + pos, value);
+  }
+
+  final void putNativeOrderedChar(final long offsetBytes, final char value) {
+    assertValidAndBoundsForWrite(offsetBytes, ARRAY_CHAR_INDEX_SCALE);
+    unsafe.putChar(unsafeObj, cumBaseOffset + offsetBytes, value);
+  }
+
+  final void putNativeOrderedInt(final int value) {
+    final long pos = getPosition();
+    incrementAndAssertPositionForWrite(pos, ARRAY_INT_INDEX_SCALE);
+    unsafe.putInt(unsafeObj, cumBaseOffset + pos, value);
+  }
+
+  final void putNativeOrderedInt(final long offsetBytes, final int value) {
+    assertValidAndBoundsForWrite(offsetBytes, ARRAY_INT_INDEX_SCALE);
+    unsafe.putInt(unsafeObj, cumBaseOffset + offsetBytes, value);
+  }
+
+  final void putNativeOrderedLong(final long value) {
+    final long pos = getPosition();
+    incrementAndAssertPositionForWrite(pos, ARRAY_LONG_INDEX_SCALE);
+    unsafe.putLong(unsafeObj, cumBaseOffset + pos, value);
+  }
+
+  final void putNativeOrderedLong(final long offsetBytes, final long value) {
+    assertValidAndBoundsForWrite(offsetBytes, ARRAY_LONG_INDEX_SCALE);
+    unsafe.putLong(unsafeObj, cumBaseOffset + offsetBytes, value);
+  }
+
+  final void putNativeOrderedShort(final short value) {
+    final long pos = getPosition();
+    incrementAndAssertPositionForWrite(pos, ARRAY_SHORT_INDEX_SCALE);
+    unsafe.putShort(unsafeObj, cumBaseOffset + pos, value);
+  }
+
+  final void putNativeOrderedShort(final long offsetBytes, final short value) {
+    assertValidAndBoundsForWrite(offsetBytes, ARRAY_SHORT_INDEX_SCALE);
+    unsafe.putShort(unsafeObj, cumBaseOffset + offsetBytes, value);
+  }
+
   //OTHER XXX
   @Override
-  public Object getArray() {
+  public final Object getArray() {
     assertValid();
     return unsafeObj;
   }
 
   @Override
-  public ByteBuffer getByteBuffer() {
+  public final ByteBuffer getByteBuffer() {
     assertValid();
     return state.getByteBuffer();
   }
 
   @Override
-  public void clear() {
+  public final void clear() {
     fill((byte)0);
   }
 
   @Override
-  public void fill(final byte value) {
+  public final void fill(final byte value) {
     checkValidForWrite();
     long pos = getPosition();
     long len = getEnd() - pos;
     checkInvariants(getStart(), pos + len, getEnd(), getCapacity());
     while (len > 0) {
-      final long chunk = Math.min(len, CompareAndCopy.UNSAFE_COPY_THRESHOLD);
+      final long chunk = Math.min(len, CompareAndCopy.UNSAFE_COPY_THRESHOLD_BYTES);
       unsafe.setMemory(unsafeObj, cumBaseOffset + pos, chunk, value);
       pos += chunk;
       len -= chunk;
@@ -317,28 +412,21 @@ abstract class BaseWritableBufferImpl extends WritableBuffer {
   }
 
   @Override
-  void assertValid() {
+  final void assertValid() {
     assert state.isValid() : "Buffer not valid.";
   }
 
   @Override
-  void checkValid() {
+  final void checkValid() {
     state.checkValid();
   }
 
-  void checkValidForWrite() {
-    checkValid();
-    if (isResourceReadOnly()) {
-      throw new ReadOnlyException("Buffer is read-only.");
-    }
-  }
-
-  void assertValidAndBoundsForRead(final long offsetBytes, final long lengthBytes) {
+  final void assertValidAndBoundsForRead(final long offsetBytes, final long lengthBytes) {
     assertValid();
     assertBounds(offsetBytes, lengthBytes, capacity);
   }
 
-  void assertValidAndBoundsForWrite(final long offsetBytes, final long lengthBytes) {
+  final void assertValidAndBoundsForWrite(final long offsetBytes, final long lengthBytes) {
     assertValid();
     assertBounds(offsetBytes, lengthBytes, capacity);
     assert !localReadOnly : "Buffer is read-only.";

--- a/src/main/java/com/yahoo/memory/BaseWritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/BaseWritableMemoryImpl.java
@@ -9,6 +9,10 @@ import static com.yahoo.memory.UnsafeUtil.ARRAY_BOOLEAN_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_BOOLEAN_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_BYTE_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_BYTE_INDEX_SCALE;
+import static com.yahoo.memory.UnsafeUtil.ARRAY_CHAR_INDEX_SCALE;
+import static com.yahoo.memory.UnsafeUtil.ARRAY_INT_INDEX_SCALE;
+import static com.yahoo.memory.UnsafeUtil.ARRAY_LONG_INDEX_SCALE;
+import static com.yahoo.memory.UnsafeUtil.ARRAY_SHORT_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.LS;
 import static com.yahoo.memory.UnsafeUtil.assertBounds;
 import static com.yahoo.memory.UnsafeUtil.checkBounds;
@@ -58,64 +62,101 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
     this.localReadOnly = localReadOnly;
   }
 
+  static BaseWritableMemoryImpl newInstance(final ResourceState state,
+      final boolean localReadOnly) {
+    if (state.getCapacity() == 0) { return WritableMemoryImpl.ZERO_SIZE_MEMORY; }
+    if (state.getResourceOrder() == ByteOrder.nativeOrder()) {
+      return new WritableMemoryImpl(state, localReadOnly);
+    } else {
+      return new NonNativeWritableMemoryImpl(state, localReadOnly);
+    }
+  }
+
   ///PRIMITIVE getXXX() and getXXXArray() XXX
   @Override
-  public boolean getBoolean(final long offsetBytes) {
+  public final boolean getBoolean(final long offsetBytes) {
     assertValidAndBoundsForRead(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE);
     return unsafe.getBoolean(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
   @Override
-  public void getBooleanArray(final long offsetBytes, final boolean[] dstArray,
-      final int dstOffset, final int lengthBooleans) {
+  public final void getBooleanArray(final long offsetBytes, final boolean[] dstArray,
+      final int dstOffsetBooleans, final int lengthBooleans) {
     final long copyBytes = lengthBooleans;
     checkValidAndBounds(offsetBytes, copyBytes);
-    checkBounds(dstOffset, lengthBooleans, dstArray.length);
+    checkBounds(dstOffsetBooleans, lengthBooleans, dstArray.length);
     CompareAndCopy.copyMemoryCheckingDifferentObject(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
-        ARRAY_BOOLEAN_BASE_OFFSET + dstOffset,
+        ARRAY_BOOLEAN_BASE_OFFSET + dstOffsetBooleans,
         copyBytes);
   }
 
   @Override
-  public byte getByte(final long offsetBytes) {
+  public final byte getByte(final long offsetBytes) {
     assertValidAndBoundsForRead(offsetBytes, ARRAY_BYTE_INDEX_SCALE);
     return unsafe.getByte(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
   @Override
-  public void getByteArray(final long offsetBytes, final byte[] dstArray, final int dstOffset,
-      final int lengthBytes) {
+  public final void getByteArray(final long offsetBytes, final byte[] dstArray,
+      final int dstOffsetBytes, final int lengthBytes) {
     final long copyBytes = lengthBytes;
     checkValidAndBounds(offsetBytes, copyBytes);
-    checkBounds(dstOffset, lengthBytes, dstArray.length);
+    checkBounds(dstOffsetBytes, lengthBytes, dstArray.length);
     CompareAndCopy.copyMemoryCheckingDifferentObject(
         unsafeObj,
         cumBaseOffset + offsetBytes,
         dstArray,
-        ARRAY_BYTE_BASE_OFFSET + dstOffset,
+        ARRAY_BYTE_BASE_OFFSET + dstOffsetBytes,
         copyBytes);
+  }
+
+  @Override
+  public final int getCharsFromUtf8(final long offsetBytes, final int utf8LengthBytes,
+      final Appendable dst) throws IOException, Utf8CodingException {
+    checkValidAndBounds(offsetBytes, utf8LengthBytes);
+    return Utf8.getCharsFromUtf8(offsetBytes, utf8LengthBytes, dst, state);
+  }
+
+  final char getNativeOrderedChar(final long offsetBytes) {
+    assertValidAndBoundsForRead(offsetBytes, ARRAY_CHAR_INDEX_SCALE);
+    return unsafe.getChar(unsafeObj, cumBaseOffset + offsetBytes);
+  }
+
+  final int getNativeOrderedInt(final long offsetBytes) {
+    assertValidAndBoundsForRead(offsetBytes, ARRAY_INT_INDEX_SCALE);
+    return unsafe.getInt(unsafeObj, cumBaseOffset + offsetBytes);
+  }
+
+  final long getNativeOrderedLong(final long offsetBytes) {
+    assertValidAndBoundsForRead(offsetBytes, ARRAY_LONG_INDEX_SCALE);
+    return unsafe.getLong(unsafeObj, cumBaseOffset + offsetBytes);
+  }
+
+  final short getNativeOrderedShort(final long offsetBytes) {
+    assertValidAndBoundsForRead(offsetBytes, ARRAY_SHORT_INDEX_SCALE);
+    return unsafe.getShort(unsafeObj, cumBaseOffset + offsetBytes);
   }
 
   //OTHER PRIMITIVE READ METHODS: compareTo, copyTo, equals XXX
   @Override
-  public int compareTo(final long thisOffsetBytes, final long thisLengthBytes,
+  public final int compareTo(final long thisOffsetBytes, final long thisLengthBytes,
       final Memory thatMem, final long thatOffsetBytes, final long thatLengthBytes) {
     return CompareAndCopy.compare(state, thisOffsetBytes, thisLengthBytes,
         thatMem.getResourceState(), thatOffsetBytes, thatLengthBytes);
   }
 
   @Override
-  public void copyTo(final long srcOffsetBytes, final WritableMemory destination,
+  public final void copyTo(final long srcOffsetBytes, final WritableMemory destination,
       final long dstOffsetBytes, final long lengthBytes) {
     CompareAndCopy.copy(state, srcOffsetBytes, destination.getResourceState(),
         dstOffsetBytes, lengthBytes);
   }
 
   @Override
-  public void writeTo(final long offsetBytes, final long lengthBytes,
+  public final void writeTo(final long offsetBytes, final long lengthBytes,
       final WritableByteChannel out) throws IOException {
     checkValidAndBounds(offsetBytes, lengthBytes);
     if (unsafeObj instanceof byte[]) {
@@ -130,81 +171,81 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
   }
 
   @Override
-  public boolean equals(final Object that) {
+  public final boolean equals(final Object that) {
     if (this == that) { return true; }
     return (that instanceof Memory)
         ? CompareAndCopy.equals(state, ((Memory)that).getResourceState()) : false;
   }
 
   @Override
-  public boolean equalTo(final long thisOffsetBytes, final Memory that,
+  public final boolean equalTo(final long thisOffsetBytes, final Memory that,
       final long thatOffsetBytes, final long lengthBytes) {
     return CompareAndCopy.equals(state, thisOffsetBytes, that.getResourceState(),
         thatOffsetBytes, lengthBytes);
   }
 
   @Override
-  public int hashCode() {
+  public final int hashCode() {
     return CompareAndCopy.hashCode(state);
   }
 
   //OTHER READ METHODS XXX
   @Override
-  public void checkValidAndBounds(final long offsetBytes, final long lengthBytes) {
+  public final void checkValidAndBounds(final long offsetBytes, final long lengthBytes) {
     checkValid();
     checkBounds(offsetBytes, lengthBytes, capacity);
   }
 
   @Override
-  public long getCapacity() {
+  public final long getCapacity() {
     assertValid();
     return capacity;
   }
 
   @Override
-  public long getCumulativeOffset(final long offsetBytes) {
+  public final long getCumulativeOffset(final long offsetBytes) {
     assertValid();
     return cumBaseOffset + offsetBytes;
   }
 
   @Override
-  public long getRegionOffset(final long offsetBytes) {
+  public final long getRegionOffset(final long offsetBytes) {
     assertValid();
     return state.getRegionOffset() + offsetBytes;
   }
 
   @Override
-  public ByteOrder getResourceOrder() {
+  public final ByteOrder getResourceOrder() {
     assertValid();
     return state.getResourceOrder();
   }
 
   @Override
-  public boolean hasArray() {
+  public final boolean hasArray() {
     assertValid();
     return unsafeObj != null;
   }
 
   @Override
-  public boolean hasByteBuffer() {
+  public final boolean hasByteBuffer() {
     assertValid();
     return state.getByteBuffer() != null;
   }
 
   @Override
-  public boolean isDirect() {
+  public final boolean isDirect() {
     assertValid();
     return state.isDirect();
   }
 
   @Override
-  public boolean isResourceReadOnly() {
+  public final boolean isResourceReadOnly() {
     assertValid();
     return state.isResourceReadOnly();
   }
 
   @Override
-  public boolean isSameResource(final Memory that) {
+  public final boolean isSameResource(final Memory that) {
     if (that == null) { return false; }
     checkValid();
     ((BaseWritableMemoryImpl) that).checkValid();
@@ -212,18 +253,19 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
   }
 
   @Override
-  public boolean isValid() {
+  public final boolean isValid() {
     return state.isValid();
   }
 
   @Override
-  public boolean isSwapBytes() {
+  public final boolean isSwapBytes() {
     assertValid();
     return state.isSwapBytes();
   }
 
   @Override
-  public String toHexString(final String header, final long offsetBytes, final int lengthBytes) {
+  public final String toHexString(final String header, final long offsetBytes,
+      final int lengthBytes) {
     checkValid();
     final String klass = this.getClass().getSimpleName();
     final String s1 = String.format("(..., %d, %d)", offsetBytes, lengthBytes);
@@ -238,20 +280,20 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
 
   //PRIMITIVE putXXX() and putXXXArray() implementations XXX
   @Override
-  public void putBoolean(final long offsetBytes, final boolean value) {
+  public final void putBoolean(final long offsetBytes, final boolean value) {
     assertValidAndBoundsForWrite(offsetBytes, ARRAY_BOOLEAN_INDEX_SCALE);
     unsafe.putBoolean(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
   @Override
-  public void putBooleanArray(final long offsetBytes, final boolean[] srcArray, final int srcOffset,
-      final int lengthBooleans) {
+  public final void putBooleanArray(final long offsetBytes, final boolean[] srcArray,
+      final int srcOffsetBooleans, final int lengthBooleans) {
     final long copyBytes = lengthBooleans;
     checkValidAndBoundsForWrite(offsetBytes, copyBytes);
-    checkBounds(srcOffset, lengthBooleans, srcArray.length);
+    checkBounds(srcOffsetBooleans, lengthBooleans, srcArray.length);
     CompareAndCopy.copyMemoryCheckingDifferentObject(
         srcArray,
-        ARRAY_BOOLEAN_BASE_OFFSET + srcOffset,
+        ARRAY_BOOLEAN_BASE_OFFSET + srcOffsetBooleans,
         unsafeObj,
         cumBaseOffset + offsetBytes,
         copyBytes
@@ -259,51 +301,77 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
   }
 
   @Override
-  public void putByte(final long offsetBytes, final byte value) {
+  public final void putByte(final long offsetBytes, final byte value) {
     assertValidAndBoundsForWrite(offsetBytes, ARRAY_BYTE_INDEX_SCALE);
     unsafe.putByte(unsafeObj, cumBaseOffset + offsetBytes, value);
   }
 
   @Override
-  public void putByteArray(final long offsetBytes, final byte[] srcArray, final int srcOffset,
-      final int lengthBytes) {
+  public final void putByteArray(final long offsetBytes, final byte[] srcArray,
+      final int srcOffsetBytes, final int lengthBytes) {
     final long copyBytes = lengthBytes;
     checkValidAndBoundsForWrite(offsetBytes, copyBytes);
-    checkBounds(srcOffset, lengthBytes, srcArray.length);
+    checkBounds(srcOffsetBytes, lengthBytes, srcArray.length);
     CompareAndCopy.copyMemoryCheckingDifferentObject(
         srcArray,
-        ARRAY_BYTE_BASE_OFFSET + srcOffset,
+        ARRAY_BYTE_BASE_OFFSET + srcOffsetBytes,
         unsafeObj,
         cumBaseOffset + offsetBytes,
         copyBytes
     );
   }
 
+  @Override
+  public final long putCharsToUtf8(final long offsetBytes, final CharSequence src) {
+    checkValid();
+    return Utf8.putCharsToUtf8(offsetBytes, src, state);
+  }
+
+  final void putNativeOrderedChar(final long offsetBytes, final char value) {
+    assertValidAndBoundsForWrite(offsetBytes, ARRAY_CHAR_INDEX_SCALE);
+    unsafe.putChar(unsafeObj, cumBaseOffset + offsetBytes, value);
+  }
+
+  final void putNativeOrderedInt(final long offsetBytes, final int value) {
+    assertValidAndBoundsForWrite(offsetBytes, ARRAY_INT_INDEX_SCALE);
+    unsafe.putInt(unsafeObj, cumBaseOffset + offsetBytes, value);
+  }
+
+  final void putNativeOrderedLong(final long offsetBytes, final long value) {
+    assertValidAndBoundsForWrite(offsetBytes, ARRAY_LONG_INDEX_SCALE);
+    unsafe.putLong(unsafeObj, cumBaseOffset + offsetBytes, value);
+  }
+
+  final void putNativeOrderedShort(final long offsetBytes, final short value) {
+    assertValidAndBoundsForWrite(offsetBytes, ARRAY_SHORT_INDEX_SCALE);
+    unsafe.putShort(unsafeObj, cumBaseOffset + offsetBytes, value);
+  }
+
   //OTHER WRITE METHODS XXX
   @Override
-  public Object getArray() {
+  public final Object getArray() {
     assertValid();
     return unsafeObj;
   }
 
   @Override
-  public ByteBuffer getByteBuffer() {
+  public final ByteBuffer getByteBuffer() {
     assertValid();
     return state.getByteBuffer();
   }
 
   @Override
-  public void clear() {
+  public final void clear() {
     fill(0, capacity, (byte) 0);
   }
 
   @Override
-  public void clear(final long offsetBytes, final long lengthBytes) {
+  public final void clear(final long offsetBytes, final long lengthBytes) {
     fill(offsetBytes, lengthBytes, (byte) 0);
   }
 
   @Override
-  public void clearBits(final long offsetBytes, final byte bitMask) {
+  public final void clearBits(final long offsetBytes, final byte bitMask) {
     assertValidAndBoundsForWrite(offsetBytes, ARRAY_BYTE_INDEX_SCALE);
     final long cumBaseOff = cumBaseOffset + offsetBytes;
     int value = unsafe.getByte(unsafeObj, cumBaseOff) & 0XFF;
@@ -312,15 +380,15 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
   }
 
   @Override
-  public void fill(final byte value) {
+  public final void fill(final byte value) {
     fill(0, capacity, value);
   }
 
   @Override
-  public void fill(long offsetBytes, long lengthBytes, final byte value) {
+  public final void fill(long offsetBytes, long lengthBytes, final byte value) {
     checkValidAndBoundsForWrite(offsetBytes, lengthBytes);
     while (lengthBytes > 0) {
-      final long chunk = Math.min(lengthBytes, CompareAndCopy.UNSAFE_COPY_THRESHOLD);
+      final long chunk = Math.min(lengthBytes, CompareAndCopy.UNSAFE_COPY_THRESHOLD_BYTES);
       unsafe.setMemory(unsafeObj, cumBaseOffset + offsetBytes, chunk, value);
       offsetBytes += chunk;
       lengthBytes -= chunk;
@@ -328,7 +396,7 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
   }
 
   @Override
-  public void setBits(final long offsetBytes, final byte bitMask) {
+  public final void setBits(final long offsetBytes, final byte bitMask) {
     assertValidAndBoundsForWrite(offsetBytes, ARRAY_BYTE_INDEX_SCALE);
     final long myOffset = cumBaseOffset + offsetBytes;
     final byte value = unsafe.getByte(unsafeObj, myOffset);
@@ -337,7 +405,7 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
 
   //OTHER XXX
   @Override
-  public MemoryRequestServer getMemoryRequestServer() { //only applicable to writable
+  public final MemoryRequestServer getMemoryRequestServer() { //only applicable to writable
     assertValid();
     return state.getMemoryRequestServer();
   }
@@ -359,7 +427,7 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
     // or file-backed WritableByteChannel implementations with direct ByteBuffer argument could
     // be subject of the same safepoint problems as in Unsafe.copyMemory and Unsafe.setMemory.
     while (lengthBytes > 0) {
-      final int chunk = (int) Math.min(CompareAndCopy.UNSAFE_COPY_THRESHOLD, lengthBytes);
+      final int chunk = (int) Math.min(CompareAndCopy.UNSAFE_COPY_THRESHOLD_BYTES, lengthBytes);
       final ByteBuffer bufToWrite = AccessByteBuffer.getDummyDirectByteBuffer(addr, chunk);
       writeFully(bufToWrite, out);
       addr += chunk;
@@ -391,30 +459,30 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
   }
 
   @Override
-  ResourceState getResourceState() {
+  final ResourceState getResourceState() {
     return state;
   }
 
-  void assertValid() {
+  private void assertValid() {
     assert state.isValid() : "Memory not valid.";
   }
 
-  void checkValid() {
+  final void checkValid() {
     state.checkValid();
   }
 
-  void assertValidAndBoundsForRead(final long offsetBytes, final long lengthBytes) {
+  final void assertValidAndBoundsForRead(final long offsetBytes, final long lengthBytes) {
     assertValid();
     assertBounds(offsetBytes, lengthBytes, capacity);
   }
 
-  void assertValidAndBoundsForWrite(final long offsetBytes, final long lengthBytes) {
+  final void assertValidAndBoundsForWrite(final long offsetBytes, final long lengthBytes) {
     assertValid();
     assertBounds(offsetBytes, lengthBytes, capacity);
     assert !localReadOnly : "Memory is read-only.";
   }
 
-  void checkValidAndBoundsForWrite(final long offsetBytes, final long lengthBytes) {
+  final void checkValidAndBoundsForWrite(final long offsetBytes, final long lengthBytes) {
     checkValid();
     checkBounds(offsetBytes, lengthBytes, capacity);
     if (localReadOnly) {

--- a/src/main/java/com/yahoo/memory/Buffer.java
+++ b/src/main/java/com/yahoo/memory/Buffer.java
@@ -86,7 +86,7 @@ public abstract class Buffer extends BaseBuffer {
   //PRIMITIVE getXXX() and getXXXArray() //XXX
   /**
    * Gets the boolean value at the current position.
-   * Increments the position by <i>Boolean.BYTES</i>.
+   * Increments the position by 1.
    * @return the boolean at the current position
    */
   public abstract boolean getBoolean();
@@ -101,12 +101,13 @@ public abstract class Buffer extends BaseBuffer {
 
   /**
    * Gets the boolean array at the current position.
-   * Increments the position by <i>Boolean.BYTES * (lengthBooleans - dstOffset)</i>.
+   * Increments the position by <i>lengthBooleans - dstOffsetBooleans</i>.
    * @param dstArray The preallocated destination array.
-   * @param dstOffset offset in array units
+   * @param dstOffsetBooleans offset in array units
    * @param lengthBooleans number of array units to transfer
    */
-  public abstract void getBooleanArray(boolean[] dstArray, int dstOffset, int lengthBooleans);
+  public abstract void getBooleanArray(boolean[] dstArray, int dstOffsetBooleans,
+      int lengthBooleans);
 
   /**
    * Gets the byte value at the current position.
@@ -125,16 +126,16 @@ public abstract class Buffer extends BaseBuffer {
 
   /**
    * Gets the byte array at the current position.
-   * Increments the position by <i>Byte.BYTES * (lengthBytes - dstOffset)</i>.
+   * Increments the position by <i>Byte.BYTES * (lengthBytes - dstOffsetBytes)</i>.
    * @param dstArray The preallocated destination array.
-   * @param dstOffset offset in array units
+   * @param dstOffsetBytes offset in array units
    * @param lengthBytes number of array units to transfer
    */
-  public abstract void getByteArray(byte[] dstArray, int dstOffset, int lengthBytes);
+  public abstract void getByteArray(byte[] dstArray, int dstOffsetBytes, int lengthBytes);
 
   /**
    * Gets the char value at the current position.
-   * Increments the position by <i>Char.BYTES</i>.
+   * Increments the position by <i>Character.BYTES</i>.
    * @return the char at the current position
    */
   public abstract char getChar();
@@ -149,12 +150,12 @@ public abstract class Buffer extends BaseBuffer {
 
   /**
    * Gets the char array at the current position.
-   * Increments the position by <i>Char.BYTES * (lengthChars - dstOffset)</i>.
+   * Increments the position by <i>Character.BYTES * (lengthChars - dstOffsetChars)</i>.
    * @param dstArray The preallocated destination array.
-   * @param dstOffset offset in array units
+   * @param dstOffsetChars offset in array units
    * @param lengthChars number of array units to transfer
    */
-  public abstract void getCharArray(char[] dstArray, int dstOffset, int lengthChars);
+  public abstract void getCharArray(char[] dstArray, int dstOffsetChars, int lengthChars);
 
   /**
    * Gets the double value at the current position.
@@ -173,12 +174,12 @@ public abstract class Buffer extends BaseBuffer {
 
   /**
    * Gets the double array at the current position.
-   * Increments the position by <i>Double.BYTES * (lengthDoubles - dstOffset)</i>.
+   * Increments the position by <i>Double.BYTES * (lengthDoubles - dstOffsetDoubles)</i>.
    * @param dstArray The preallocated destination array.
-   * @param dstOffset offset in array units
+   * @param dstOffsetDoubles offset in array units
    * @param lengthDoubles number of array units to transfer
    */
-  public abstract void getDoubleArray(double[] dstArray, int dstOffset, int lengthDoubles);
+  public abstract void getDoubleArray(double[] dstArray, int dstOffsetDoubles, int lengthDoubles);
 
   /**
    * Gets the float value at the current position.
@@ -197,16 +198,16 @@ public abstract class Buffer extends BaseBuffer {
 
   /**
    * Gets the float array at the current position.
-   * Increments the position by <i>Float.BYTES * (lengthFloats - dstOffset)</i>.
+   * Increments the position by <i>Float.BYTES * (lengthFloats - dstOffsetFloats)</i>.
    * @param dstArray The preallocated destination array.
-   * @param dstOffset offset in array units
+   * @param dstOffsetFloats offset in array units
    * @param lengthFloats number of array units to transfer
    */
-  public abstract void getFloatArray(float[] dstArray, int dstOffset, int lengthFloats);
+  public abstract void getFloatArray(float[] dstArray, int dstOffsetFloats, int lengthFloats);
 
   /**
    * Gets the int value at the current position.
-   * Increments the position by <i>Int.BYTES</i>.
+   * Increments the position by <i>Integer.BYTES</i>.
    * @return the int at the current position
    */
   public abstract int getInt();
@@ -221,12 +222,12 @@ public abstract class Buffer extends BaseBuffer {
 
   /**
    * Gets the int array at the current position.
-   * Increments the position by <i>Int.BYTES * (lengthInts - dstOffset)</i>.
+   * Increments the position by <i>Integer.BYTES * (lengthInts - dstOffsetInts)</i>.
    * @param dstArray The preallocated destination array.
-   * @param dstOffset offset in array units
+   * @param dstOffsetInts offset in array units
    * @param lengthInts number of array units to transfer
    */
-  public abstract void getIntArray(int[] dstArray, int dstOffset, int lengthInts);
+  public abstract void getIntArray(int[] dstArray, int dstOffsetInts, int lengthInts);
 
   /**
    * Gets the long value at the current position.
@@ -245,12 +246,12 @@ public abstract class Buffer extends BaseBuffer {
 
   /**
    * Gets the long array at the current position.
-   * Increments the position by <i>Long.BYTES * (lengthLongs - dstOffset)</i>.
+   * Increments the position by <i>Long.BYTES * (lengthLongs - dstOffsetLongs)</i>.
    * @param dstArray The preallocated destination array.
-   * @param dstOffset offset in array units
+   * @param dstOffsetLongs offset in array units
    * @param lengthLongs number of array units to transfer
    */
-  public abstract void getLongArray(long[] dstArray, int dstOffset, int lengthLongs);
+  public abstract void getLongArray(long[] dstArray, int dstOffsetLongs, int lengthLongs);
 
   /**
    * Gets the short value at the current position.
@@ -269,12 +270,12 @@ public abstract class Buffer extends BaseBuffer {
 
   /**
    * Gets the short array at the current position.
-   * Increments the position by <i>Short.BYTES * (lengthShorts - dstOffset)</i>.
+   * Increments the position by <i>Short.BYTES * (lengthShorts - dstOffsetShorts)</i>.
    * @param dstArray The preallocated destination array.
-   * @param dstOffset offset in array units
+   * @param dstOffsetShorts offset in array units
    * @param lengthShorts number of array units to transfer
    */
-  public abstract void getShortArray(short[] dstArray, int dstOffset, int lengthShorts);
+  public abstract void getShortArray(short[] dstArray, int dstOffsetShorts, int lengthShorts);
 
   //OTHER PRIMITIVE READ METHODS: copyTo, compareTo XXX
   /**

--- a/src/main/java/com/yahoo/memory/CompareAndCopy.java
+++ b/src/main/java/com/yahoo/memory/CompareAndCopy.java
@@ -5,6 +5,12 @@
 
 package com.yahoo.memory;
 
+import static com.yahoo.memory.UnsafeUtil.CHAR_SHIFT;
+import static com.yahoo.memory.UnsafeUtil.DOUBLE_SHIFT;
+import static com.yahoo.memory.UnsafeUtil.FLOAT_SHIFT;
+import static com.yahoo.memory.UnsafeUtil.INT_SHIFT;
+import static com.yahoo.memory.UnsafeUtil.LONG_SHIFT;
+import static com.yahoo.memory.UnsafeUtil.SHORT_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.checkBounds;
 import static com.yahoo.memory.UnsafeUtil.unsafe;
 
@@ -21,9 +27,9 @@ final class CompareAndCopy {
    * https://bugs.openjdk.java.net/browse/JDK-8141491), but not in JDK 8, so the Memory library
    * should keep having this boilerplate as long as it supports Java 8.
    *
-   * <p>A reference to this can be found in <i>java.nio.Bits.java</i>.</p>
+   * <p>A reference to this can be found in {@link java.nio.Bits}.</p>
    */
-  static final int UNSAFE_COPY_THRESHOLD = 1024 * 1024;
+  static final int UNSAFE_COPY_THRESHOLD_BYTES = 1024 * 1024;
 
   private CompareAndCopy() { }
 
@@ -73,23 +79,21 @@ final class CompareAndCopy {
     if ((arr1 == arr2) && (cumOff1 == cumOff2)) { return true; }
 
     while (lengthBytes >= Long.BYTES) {
-      final int chunk = (int) Math.min(lengthBytes, UNSAFE_COPY_THRESHOLD);
+      final int chunk = (int) Math.min(lengthBytes, UNSAFE_COPY_THRESHOLD_BYTES);
       // int-counted loop to avoid safepoint polls (otherwise why we chunk by
       // UNSAFE_COPY_MEMORY_THRESHOLD)
       int i = 0;
       for (; i <= (chunk - Long.BYTES); i += Long.BYTES) {
         final long v1 = unsafe.getLong(arr1, cumOff1 + i);
         final long v2 = unsafe.getLong(arr2, cumOff2 + i);
-        if (v1 == v2) { continue; }
-        else { return false; }
+        if (v1 != v2) { return false; }
       }
       lengthBytes -= i;
       cumOff1 += i;
       cumOff2 += i;
     }
     //check the remainder bytes, if any
-    return (lengthBytes == 0)
-        ? true : equalsByBytes(arr1, cumOff1, arr2, cumOff2, (int) lengthBytes);
+    return (lengthBytes == 0) || equalsByBytes(arr1, cumOff1, arr2, cumOff2, (int) lengthBytes);
   }
 
   //use only for short runs
@@ -99,8 +103,7 @@ final class CompareAndCopy {
     for (int i = 0; i < lenBytes; i++) {
       final int v1 = unsafe.getByte(arr1, cumOff1 + i);
       final int v2 = unsafe.getByte(arr2, cumOff2 + i);
-      if (v1 == v2) { continue; }
-      else { return false; }
+      if (v1 != v2) { return false; }
     }
     return true;
   }
@@ -112,7 +115,7 @@ final class CompareAndCopy {
     final Object arr = state.getUnsafeObject(); //could be null
     int result = 1;
     while (lenBytes >= Long.BYTES) {
-      final int chunk = (int) Math.min(lenBytes, UNSAFE_COPY_THRESHOLD);
+      final int chunk = (int) Math.min(lenBytes, UNSAFE_COPY_THRESHOLD_BYTES);
       // int-counted loop to avoid safepoint polls (otherwise why we chunk by
       // UNSAFE_COPY_MEMORY_THRESHOLD)
       int i = 0;
@@ -208,16 +211,353 @@ final class CompareAndCopy {
    * @param dstUnsafeObj The destination array object, it may be null
    * @param dstAdd The cumulative destination offset
    * @param lengthBytes The length to be copied in bytes
-   * @see #UNSAFE_COPY_THRESHOLD
+   * @see #UNSAFE_COPY_THRESHOLD_BYTES
    */
   private static void copyNonOverlappingMemoryWithChunking(final Object srcUnsafeObj,
       long srcAdd, final Object dstUnsafeObj, long dstAdd, long lengthBytes) {
     while (lengthBytes > 0) {
-      final long chunk = Math.min(lengthBytes, UNSAFE_COPY_THRESHOLD);
+      final long chunk = Math.min(lengthBytes, UNSAFE_COPY_THRESHOLD_BYTES);
       unsafe.copyMemory(srcUnsafeObj, srcAdd, dstUnsafeObj, dstAdd, chunk);
       lengthBytes -= chunk;
       srcAdd += chunk;
       dstAdd += chunk;
+    }
+  }
+
+  static void getNonNativeChars(final Object unsafeObj, final long cumBaseOffset,
+      final long offsetBytes, long copyBytes, final char[] dstArray, int dstOffsetChars,
+      int lengthChars) {
+    checkBounds(dstOffsetChars, lengthChars, dstArray.length);
+    long cumulativeOffsetBytes = cumBaseOffset + offsetBytes;
+    while (copyBytes > UNSAFE_COPY_THRESHOLD_BYTES) {
+      final long chunkBytes = Math.min(copyBytes, UNSAFE_COPY_THRESHOLD_BYTES);
+      final int chunkChars = (int) (chunkBytes >> CHAR_SHIFT);
+      getCharArrayChunk(unsafeObj, cumulativeOffsetBytes, dstArray, dstOffsetChars, chunkChars);
+      cumulativeOffsetBytes += chunkBytes;
+      dstOffsetChars += chunkChars;
+      copyBytes -= chunkBytes;
+      lengthChars -= chunkChars;
+    }
+    getCharArrayChunk(unsafeObj, cumulativeOffsetBytes, dstArray, dstOffsetChars, lengthChars);
+  }
+
+  private static void getCharArrayChunk(final Object unsafeObj, final long cumulativeOffsetBytes,
+      final char[] dstArray, final int dstOffsetChars, final int lengthChars) {
+    // JDK 9 adds native intrinsics for such bulk non-native ordered primitive memory copy.
+    // TODO use them when the library adds support for JDK 9
+    // int-counted loop to avoid safepoint polls
+    for (int i = 0; i < lengthChars; i++) {
+      dstArray[dstOffsetChars + i] = Character.reverseBytes(
+          unsafe.getChar(unsafeObj, cumulativeOffsetBytes + (((long) i) << CHAR_SHIFT)));
+    }
+  }
+
+  static void getNonNativeDoubles(final Object unsafeObj, final long cumBaseOffset,
+      final long offsetBytes, long copyBytes, final double[] dstArray, int dstOffsetDoubles,
+      int lengthDoubles) {
+    checkBounds(dstOffsetDoubles, lengthDoubles, dstArray.length);
+    long cumulativeOffsetBytes = cumBaseOffset + offsetBytes;
+    while (copyBytes > UNSAFE_COPY_THRESHOLD_BYTES) {
+      final long chunkBytes = Math.min(copyBytes, UNSAFE_COPY_THRESHOLD_BYTES);
+      final int chunkDoubles = (int) (chunkBytes >> DOUBLE_SHIFT);
+      getDoubleArrayChunk(unsafeObj, cumulativeOffsetBytes,
+          dstArray, dstOffsetDoubles, chunkDoubles);
+      cumulativeOffsetBytes += chunkBytes;
+      dstOffsetDoubles += chunkDoubles;
+      copyBytes -= chunkBytes;
+      lengthDoubles -= chunkDoubles;
+    }
+    getDoubleArrayChunk(unsafeObj, cumulativeOffsetBytes,
+        dstArray, dstOffsetDoubles, lengthDoubles);
+  }
+
+  private static void getDoubleArrayChunk(final Object unsafeObj, final long cumulativeOffsetBytes,
+      final double[] dstArray, final int dstOffsetDoubles, final int lengthDoubles) {
+    // JDK 9 adds native intrinsics for such bulk non-native ordered primitive memory copy.
+    // TODO use them when the library adds support for JDK 9
+    // int-counted loop to avoid safepoint polls
+    for (int i = 0; i < lengthDoubles; i++) {
+      dstArray[dstOffsetDoubles + i] = Double.longBitsToDouble(Long.reverseBytes(
+          unsafe.getLong(unsafeObj, cumulativeOffsetBytes + (((long) i) << DOUBLE_SHIFT))));
+    }
+  }
+
+  static void getNonNativeFloats(final Object unsafeObj, final long cumBaseOffset,
+      final long offsetBytes, long copyBytes, final float[] dstArray, int dstOffsetFloats,
+      int lengthFloats) {
+    checkBounds(dstOffsetFloats, lengthFloats, dstArray.length);
+    long cumulativeOffsetBytes = cumBaseOffset + offsetBytes;
+    while (copyBytes > UNSAFE_COPY_THRESHOLD_BYTES) {
+      final long chunkBytes = Math.min(copyBytes, UNSAFE_COPY_THRESHOLD_BYTES);
+      final int chunkFloats = (int) (chunkBytes >> FLOAT_SHIFT);
+      getFloatArrayChunk(unsafeObj, cumulativeOffsetBytes, dstArray, dstOffsetFloats, chunkFloats);
+      cumulativeOffsetBytes += chunkBytes;
+      dstOffsetFloats += chunkFloats;
+      copyBytes -= chunkBytes;
+      lengthFloats -= chunkFloats;
+    }
+    getFloatArrayChunk(unsafeObj, cumulativeOffsetBytes, dstArray, dstOffsetFloats, lengthFloats);
+  }
+
+  private static void getFloatArrayChunk(final Object unsafeObj, final long cumulativeOffsetBytes,
+      final float[] dstArray, final int dstOffsetFloats, final int lengthFloats) {
+    // JDK 9 adds native intrinsics for such bulk non-native ordered primitive memory copy.
+    // TODO use them when the library adds support for JDK 9
+    // int-counted loop to avoid safepoint polls
+    for (int i = 0; i < lengthFloats; i++) {
+      dstArray[dstOffsetFloats + i] = Float.intBitsToFloat(Integer.reverseBytes(
+          unsafe.getInt(unsafeObj, cumulativeOffsetBytes + (((long) i) << FLOAT_SHIFT))));
+    }
+  }
+
+  static void getNonNativeInts(final Object unsafeObj, final long cumBaseOffset,
+      final long offsetBytes, long copyBytes, final int[] dstArray, int dstOffsetInts,
+      int lengthInts) {
+    checkBounds(dstOffsetInts, lengthInts, dstArray.length);
+    long cumulativeOffsetBytes = cumBaseOffset + offsetBytes;
+    while (copyBytes > UNSAFE_COPY_THRESHOLD_BYTES) {
+      final long chunkBytes = Math.min(copyBytes, UNSAFE_COPY_THRESHOLD_BYTES);
+      final int chunkInts = (int) (chunkBytes >> INT_SHIFT);
+      getIntArrayChunk(unsafeObj, cumulativeOffsetBytes, dstArray, dstOffsetInts, chunkInts);
+      cumulativeOffsetBytes += chunkBytes;
+      dstOffsetInts += chunkInts;
+      copyBytes -= chunkBytes;
+      lengthInts -= chunkInts;
+    }
+    getIntArrayChunk(unsafeObj, cumulativeOffsetBytes, dstArray, dstOffsetInts, lengthInts);
+  }
+
+  private static void getIntArrayChunk(final Object unsafeObj, final long cumulativeOffsetBytes,
+      final int[] dstArray, final int dstOffsetInts, final int lengthInts) {
+    // JDK 9 adds native intrinsics for such bulk non-native ordered primitive memory copy.
+    // TODO use them when the library adds support for JDK 9
+    // int-counted loop to avoid safepoint polls
+    for (int i = 0; i < lengthInts; i++) {
+      dstArray[dstOffsetInts + i] = Integer.reverseBytes(
+          unsafe.getInt(unsafeObj, cumulativeOffsetBytes + (((long) i) << INT_SHIFT)));
+    }
+  }
+
+  static void getNonNativeLongs(final Object unsafeObj, final long cumBaseOffset,
+      final long offsetBytes, long copyBytes, final long[] dstArray, int dstOffsetLongs,
+      int lengthLongs) {
+    checkBounds(dstOffsetLongs, lengthLongs, dstArray.length);
+    long cumulativeOffsetBytes = cumBaseOffset + offsetBytes;
+    while (copyBytes > UNSAFE_COPY_THRESHOLD_BYTES) {
+      final long chunkBytes = Math.min(copyBytes, UNSAFE_COPY_THRESHOLD_BYTES);
+      final int chunkLongs = (int) (chunkBytes >> LONG_SHIFT);
+      getLongArrayChunk(unsafeObj, cumulativeOffsetBytes, dstArray, dstOffsetLongs, chunkLongs);
+      cumulativeOffsetBytes += chunkBytes;
+      dstOffsetLongs += chunkLongs;
+      copyBytes -= chunkBytes;
+      lengthLongs -= chunkLongs;
+    }
+    getLongArrayChunk(unsafeObj, cumulativeOffsetBytes, dstArray, dstOffsetLongs, lengthLongs);
+  }
+
+  private static void getLongArrayChunk(final Object unsafeObj, final long cumulativeOffsetBytes,
+      final long[] dstArray, final int dstOffsetLongs, final int lengthLongs) {
+    // JDK 9 adds native intrinsics for such bulk non-native ordered primitive memory copy.
+    // TODO use them when the library adds support for JDK 9
+    // int-counted loop to avoid safepoint polls
+    for (int i = 0; i < lengthLongs; i++) {
+      dstArray[dstOffsetLongs + i] = Long.reverseBytes(
+          unsafe.getLong(unsafeObj, cumulativeOffsetBytes + (((long) i) << LONG_SHIFT)));
+    }
+  }
+
+  static void getNonNativeShorts(final Object unsafeObj, final long cumBaseOffset,
+      final long offsetBytes, long copyBytes, final short[] dstArray, int dstOffsetShorts,
+      int lengthShorts) {
+    checkBounds(dstOffsetShorts, lengthShorts, dstArray.length);
+    long cumulativeOffsetBytes = cumBaseOffset + offsetBytes;
+    while (copyBytes > UNSAFE_COPY_THRESHOLD_BYTES) {
+      final long chunkBytes = Math.min(copyBytes, UNSAFE_COPY_THRESHOLD_BYTES);
+      final int chunkShorts = (int) (chunkBytes >> SHORT_SHIFT);
+      getShortArrayChunk(unsafeObj, cumulativeOffsetBytes, dstArray, dstOffsetShorts, chunkShorts);
+      cumulativeOffsetBytes += chunkBytes;
+      dstOffsetShorts += chunkShorts;
+      copyBytes -= chunkBytes;
+      lengthShorts -= chunkShorts;
+    }
+    getShortArrayChunk(unsafeObj, cumulativeOffsetBytes, dstArray, dstOffsetShorts, lengthShorts);
+  }
+
+  private static void getShortArrayChunk(final Object unsafeObj, final long cumulativeOffsetBytes,
+      final short[] dstArray, final int dstOffsetShorts, final int lengthShorts) {
+    // JDK 9 adds native intrinsics for such bulk non-native ordered primitive memory copy.
+    // TODO use them when the library adds support for JDK 9
+    // int-counted loop to avoid safepoint polls
+    for (int i = 0; i < lengthShorts; i++) {
+      dstArray[dstOffsetShorts + i] = Short.reverseBytes(
+          unsafe.getShort(unsafeObj, cumulativeOffsetBytes + (((long) i) << SHORT_SHIFT)));
+    }
+  }
+
+  static void putNonNativeChars(final char[] srcArray, int srcOffsetChars, int lengthChars,
+      long copyBytes, final Object unsafeObj, final long cumBaseOffset, final long offsetBytes) {
+    checkBounds(srcOffsetChars, lengthChars, srcArray.length);
+    long cumulativeOffsetBytes = cumBaseOffset + offsetBytes;
+    while (copyBytes > UNSAFE_COPY_THRESHOLD_BYTES) {
+      final long chunkBytes = Math.min(copyBytes, UNSAFE_COPY_THRESHOLD_BYTES);
+      final int chunkChars = (int) (chunkBytes >> CHAR_SHIFT);
+      putCharArrayChunk(srcArray, srcOffsetChars, chunkChars, unsafeObj, cumulativeOffsetBytes);
+      cumulativeOffsetBytes += chunkBytes;
+      srcOffsetChars += chunkChars;
+      copyBytes -= chunkBytes;
+      lengthChars -= chunkChars;
+    }
+    putCharArrayChunk(srcArray, srcOffsetChars, lengthChars, unsafeObj, cumulativeOffsetBytes);
+  }
+
+  private static void putCharArrayChunk(final char[] srcArray, final int srcOffsetChars,
+      final int lengthChars, final Object unsafeObj, final long cumulativeOffsetBytes) {
+    // JDK 9 adds native intrinsics for such bulk non-native ordered primitive memory copy.
+    // TODO use them when the library adds support for JDK 9
+    // int-counted loop to avoid safepoint polls
+    for (int i = 0; i < lengthChars; i++) {
+      unsafe.putChar(unsafeObj, cumulativeOffsetBytes + (((long) i) << CHAR_SHIFT),
+          Character.reverseBytes(srcArray[srcOffsetChars + i]));
+    }
+  }
+
+  static void putNonNativeDoubles(final double[] srcArray, int srcOffsetDoubles,
+      int lengthDoubles, long copyBytes, final Object unsafeObj, final long cumBaseOffset,
+      final long offsetBytes) {
+    checkBounds(srcOffsetDoubles, lengthDoubles, srcArray.length);
+    long cumulativeOffsetBytes = cumBaseOffset + offsetBytes;
+    while (copyBytes > UNSAFE_COPY_THRESHOLD_BYTES) {
+      final long chunkBytes = Math.min(copyBytes, UNSAFE_COPY_THRESHOLD_BYTES);
+      final int chunkDoubles = (int) (chunkBytes >> DOUBLE_SHIFT);
+      putDoubleArrayChunk(srcArray, srcOffsetDoubles, chunkDoubles,
+          unsafeObj, cumulativeOffsetBytes);
+      cumulativeOffsetBytes += chunkBytes;
+      srcOffsetDoubles += chunkDoubles;
+      copyBytes -= chunkBytes;
+      lengthDoubles -= chunkDoubles;
+    }
+    putDoubleArrayChunk(srcArray, srcOffsetDoubles, lengthDoubles,
+        unsafeObj, cumulativeOffsetBytes);
+  }
+
+  private static void putDoubleArrayChunk(final double[] srcArray, final int srcOffsetDoubles,
+      final int lengthDoubles, final Object unsafeObj, final long cumulativeOffsetBytes) {
+    // JDK 9 adds native intrinsics for such bulk non-native ordered primitive memory copy.
+    // TODO use them when the library adds support for JDK 9
+    // int-counted loop to avoid safepoint polls
+    for (int i = 0; i < lengthDoubles; i++) {
+      unsafe.putLong(unsafeObj, cumulativeOffsetBytes + (((long) i) << DOUBLE_SHIFT),
+          Long.reverseBytes(Double.doubleToRawLongBits(srcArray[srcOffsetDoubles + i])));
+    }
+  }
+
+  static void putNonNativeFloats(final float[] srcArray, int srcOffsetFloats,
+      int lengthFloats, long copyBytes, final Object unsafeObj, final long cumBaseOffset,
+      final long offsetBytes) {
+    checkBounds(srcOffsetFloats, lengthFloats, srcArray.length);
+    long cumulativeOffsetBytes = cumBaseOffset + offsetBytes;
+    while (copyBytes > UNSAFE_COPY_THRESHOLD_BYTES) {
+      final long chunkBytes = Math.min(copyBytes, UNSAFE_COPY_THRESHOLD_BYTES);
+      final int chunkFloats = (int) (chunkBytes >> FLOAT_SHIFT);
+      putFloatArrayChunk(srcArray, srcOffsetFloats, chunkFloats, unsafeObj, cumulativeOffsetBytes);
+      cumulativeOffsetBytes += chunkBytes;
+      srcOffsetFloats += chunkFloats;
+      copyBytes -= chunkBytes;
+      lengthFloats -= chunkFloats;
+    }
+    putFloatArrayChunk(srcArray, srcOffsetFloats, lengthFloats, unsafeObj, cumulativeOffsetBytes);
+  }
+
+  private static void putFloatArrayChunk(final float[] srcArray, final int srcOffsetFloats,
+      final int lengthFloats, final Object unsafeObj, final long cumulativeOffsetBytes) {
+    // JDK 9 adds native intrinsics for such bulk non-native ordered primitive memory copy.
+    // TODO use them when the library adds support for JDK 9
+    // int-counted loop to avoid safepoint polls
+    for (int i = 0; i < lengthFloats; i++) {
+      unsafe.putInt(unsafeObj, cumulativeOffsetBytes + (((long) i) << FLOAT_SHIFT),
+          Integer.reverseBytes(Float.floatToRawIntBits(srcArray[srcOffsetFloats + i])));
+    }
+  }
+
+  static void putNonNativeInts(final int[] srcArray, int srcOffsetInts, int lengthInts,
+      long copyBytes, final Object unsafeObj, final long cumBaseOffset, final long offsetBytes) {
+    checkBounds(srcOffsetInts, lengthInts, srcArray.length);
+    long cumulativeOffsetBytes = cumBaseOffset + offsetBytes;
+    while (copyBytes > UNSAFE_COPY_THRESHOLD_BYTES) {
+      final long chunkBytes = Math.min(copyBytes, UNSAFE_COPY_THRESHOLD_BYTES);
+      final int chunkInts = (int) (chunkBytes >> INT_SHIFT);
+      putIntArrayChunk(srcArray, srcOffsetInts, chunkInts, unsafeObj, cumulativeOffsetBytes);
+      cumulativeOffsetBytes += chunkBytes;
+      srcOffsetInts += chunkInts;
+      copyBytes -= chunkBytes;
+      lengthInts -= chunkInts;
+    }
+    putIntArrayChunk(srcArray, srcOffsetInts, lengthInts, unsafeObj, cumulativeOffsetBytes);
+  }
+
+  private static void putIntArrayChunk(final int[] srcArray, final int srcOffsetInts,
+      final int lengthInts, final Object unsafeObj, final long cumulativeOffsetBytes) {
+    // JDK 9 adds native intrinsics for such bulk non-native ordered primitive memory copy.
+    // TODO use them when the library adds support for JDK 9
+    // int-counted loop to avoid safepoint polls
+    for (int i = 0; i < lengthInts; i++) {
+      unsafe.putInt(unsafeObj, cumulativeOffsetBytes + (((long) i) << INT_SHIFT),
+          Integer.reverseBytes(srcArray[srcOffsetInts + i]));
+    }
+  }
+
+  static void putNonNativeLongs(final long[] srcArray, int srcOffsetLongs, int lengthLongs,
+      long copyBytes, final Object unsafeObj, final long cumBaseOffset, final long offsetBytes) {
+    checkBounds(srcOffsetLongs, lengthLongs, srcArray.length);
+    long cumulativeOffsetBytes = cumBaseOffset + offsetBytes;
+    while (copyBytes > UNSAFE_COPY_THRESHOLD_BYTES) {
+      final long chunkBytes = Math.min(copyBytes, UNSAFE_COPY_THRESHOLD_BYTES);
+      final int chunkLongs = (int) (chunkBytes >> LONG_SHIFT);
+      putLongArrayChunk(srcArray, srcOffsetLongs, chunkLongs, unsafeObj, cumulativeOffsetBytes);
+      cumulativeOffsetBytes += chunkBytes;
+      srcOffsetLongs += chunkLongs;
+      copyBytes -= chunkBytes;
+      lengthLongs -= chunkLongs;
+    }
+    putLongArrayChunk(srcArray, srcOffsetLongs, lengthLongs, unsafeObj, cumulativeOffsetBytes);
+  }
+
+  private static void putLongArrayChunk(final long[] srcArray, final int srcOffsetLongs,
+      final int lengthLongs, final Object unsafeObj, final long cumulativeOffsetBytes) {
+    // JDK 9 adds native intrinsics for such bulk non-native ordered primitive memory copy.
+    // TODO use them when the library adds support for JDK 9
+    // int-counted loop to avoid safepoint polls
+    for (int i = 0; i < lengthLongs; i++) {
+      unsafe.putLong(unsafeObj, cumulativeOffsetBytes + (((long) i) << LONG_SHIFT),
+          Long.reverseBytes(srcArray[srcOffsetLongs + i]));
+    }
+  }
+
+  static void putNonNativeShorts(final short[] srcArray, int srcOffsetShorts,
+      int lengthShorts, long copyBytes, final Object unsafeObj, final long cumBaseOffset,
+      final long offsetBytes) {
+    checkBounds(srcOffsetShorts, lengthShorts, srcArray.length);
+    long cumulativeOffsetBytes = cumBaseOffset + offsetBytes;
+    while (copyBytes > UNSAFE_COPY_THRESHOLD_BYTES) {
+      final long chunkBytes = Math.min(copyBytes, UNSAFE_COPY_THRESHOLD_BYTES);
+      final int chunkShorts = (int) (chunkBytes >> SHORT_SHIFT);
+      putShortArrayChunk(srcArray, srcOffsetShorts, chunkShorts, unsafeObj, cumulativeOffsetBytes);
+      cumulativeOffsetBytes += chunkBytes;
+      srcOffsetShorts += chunkShorts;
+      copyBytes -= chunkBytes;
+      lengthShorts -= chunkShorts;
+    }
+    putShortArrayChunk(srcArray, srcOffsetShorts, lengthShorts, unsafeObj, cumulativeOffsetBytes);
+  }
+
+  private static void putShortArrayChunk(final short[] srcArray, final int srcOffsetShorts,
+      final int lengthShorts, final Object unsafeObj, final long cumulativeOffsetBytes) {
+    // JDK 9 adds native intrinsics for such bulk non-native ordered primitive memory copy.
+    // TODO use them when the library adds support for JDK 9
+    // int-counted loop to avoid safepoint polls
+    for (int i = 0; i < lengthShorts; i++) {
+      unsafe.putShort(unsafeObj, cumulativeOffsetBytes + (((long) i) << SHORT_SHIFT),
+          Short.reverseBytes(srcArray[srcOffsetShorts + i]));
     }
   }
 }

--- a/src/main/java/com/yahoo/memory/JDK7Compatible.java
+++ b/src/main/java/com/yahoo/memory/JDK7Compatible.java
@@ -9,7 +9,7 @@ final class JDK7Compatible {
 
   private JDK7Compatible() {}
 
-  public static long getAndAddLong(final Object obj, final long address, final long increment) {
+  static long getAndAddLong(final Object obj, final long address, final long increment) {
     long retVal;
     do {
       retVal = UnsafeUtil.unsafe.getLongVolatile(obj, address);
@@ -18,7 +18,7 @@ final class JDK7Compatible {
     return retVal;
   }
 
-  public static long getAndSetLong(final Object obj, final long address, final long value) {
+  static long getAndSetLong(final Object obj, final long address, final long value) {
     long retVal;
     do {
       retVal = UnsafeUtil.unsafe.getLongVolatile(obj, address);

--- a/src/main/java/com/yahoo/memory/MapHandle.java
+++ b/src/main/java/com/yahoo/memory/MapHandle.java
@@ -27,7 +27,7 @@ public class MapHandle implements Map, Handle {
   @SuppressWarnings("resource") //called from memory. state: RRO, cap, BO
   static MapHandle map(final ResourceState state, final File file, final long fileOffset) {
     final AllocateDirectMap dirMap = AllocateDirectMap.map(state, file, fileOffset);
-    final BaseWritableMemoryImpl wMem = new WritableMemoryImpl(state, true);
+    final BaseWritableMemoryImpl wMem = BaseWritableMemoryImpl.newInstance(state, true);
     return new MapHandle(dirMap, wMem);
   }
 

--- a/src/main/java/com/yahoo/memory/Memory.java
+++ b/src/main/java/com/yahoo/memory/Memory.java
@@ -115,7 +115,8 @@ public abstract class Memory {
    * @return Memory for read operations
    */
   public static Memory wrap(final boolean[] arr) {
-    return WritableMemoryImpl.newInstance(new ResourceState(arr, Prim.BOOLEAN, arr.length), true);
+    return BaseWritableMemoryImpl.newInstance(new ResourceState(arr, Prim.BOOLEAN, arr.length),
+        true);
   }
 
   /**
@@ -155,7 +156,7 @@ public abstract class Memory {
     final ResourceState state = new ResourceState(arr, Prim.BYTE, lengthBytes);
     state.putRegionOffset(offsetBytes);
     state.putResourceOrder(byteOrder);
-    return WritableMemoryImpl.newInstance(state, true);
+    return BaseWritableMemoryImpl.newInstance(state, true);
   }
 
   /**
@@ -165,7 +166,7 @@ public abstract class Memory {
    * @return Memory for read operations
    */
   public static Memory wrap(final char[] arr) {
-    return WritableMemoryImpl.newInstance(new ResourceState(arr, Prim.CHAR, arr.length), true);
+    return BaseWritableMemoryImpl.newInstance(new ResourceState(arr, Prim.CHAR, arr.length), true);
   }
 
   /**
@@ -175,7 +176,7 @@ public abstract class Memory {
    * @return Memory for read operations
    */
   public static Memory wrap(final short[] arr) {
-    return WritableMemoryImpl.newInstance(new ResourceState(arr, Prim.SHORT, arr.length), true);
+    return BaseWritableMemoryImpl.newInstance(new ResourceState(arr, Prim.SHORT, arr.length), true);
   }
 
   /**
@@ -185,7 +186,7 @@ public abstract class Memory {
    * @return Memory for read operations
    */
   public static Memory wrap(final int[] arr) {
-    return WritableMemoryImpl.newInstance(new ResourceState(arr, Prim.INT, arr.length), true);
+    return BaseWritableMemoryImpl.newInstance(new ResourceState(arr, Prim.INT, arr.length), true);
   }
 
   /**
@@ -195,7 +196,7 @@ public abstract class Memory {
    * @return Memory for read operations
    */
   public static Memory wrap(final long[] arr) {
-    return WritableMemoryImpl.newInstance(new ResourceState(arr, Prim.LONG, arr.length), true);
+    return BaseWritableMemoryImpl.newInstance(new ResourceState(arr, Prim.LONG, arr.length), true);
   }
 
   /**
@@ -205,7 +206,7 @@ public abstract class Memory {
    * @return Memory for read operations
    */
   public static Memory wrap(final float[] arr) {
-    return WritableMemoryImpl.newInstance(new ResourceState(arr, Prim.FLOAT, arr.length), true);
+    return BaseWritableMemoryImpl.newInstance(new ResourceState(arr, Prim.FLOAT, arr.length), true);
   }
 
   /**
@@ -215,7 +216,8 @@ public abstract class Memory {
    * @return Memory for read operations
    */
   public static Memory wrap(final double[] arr) {
-    return WritableMemoryImpl.newInstance(new ResourceState(arr, Prim.DOUBLE, arr.length), true);
+    return BaseWritableMemoryImpl.newInstance(new ResourceState(arr, Prim.DOUBLE, arr.length),
+        true);
   }
 
   //PRIMITIVE getXXX() and getXXXArray() XXX
@@ -230,10 +232,10 @@ public abstract class Memory {
    * Gets the boolean array at the given offset
    * @param offsetBytes offset bytes relative to this Memory start
    * @param dstArray The preallocated destination array.
-   * @param dstOffset offset in array units
+   * @param dstOffsetBooleans offset in array units
    * @param lengthBooleans number of array units to transfer
    */
-  public abstract void getBooleanArray(long offsetBytes, boolean[] dstArray, int dstOffset,
+  public abstract void getBooleanArray(long offsetBytes, boolean[] dstArray, int dstOffsetBooleans,
       int lengthBooleans);
 
   /**
@@ -247,10 +249,10 @@ public abstract class Memory {
    * Gets the byte array at the given offset
    * @param offsetBytes offset bytes relative to this Memory start
    * @param dstArray The preallocated destination array.
-   * @param dstOffset offset in array units
+   * @param dstOffsetBytes offset in array units
    * @param lengthBytes number of array units to transfer
    */
-  public abstract void getByteArray(long offsetBytes, byte[] dstArray, int dstOffset,
+  public abstract void getByteArray(long offsetBytes, byte[] dstArray, int dstOffsetBytes,
       int lengthBytes);
 
   /**
@@ -264,10 +266,10 @@ public abstract class Memory {
    * Gets the char array at the given offset
    * @param offsetBytes offset bytes relative to this Memory start
    * @param dstArray The preallocated destination array.
-   * @param dstOffset offset in array units
+   * @param dstOffsetChars offset in array units
    * @param lengthChars number of array units to transfer
    */
-  public abstract void getCharArray(long offsetBytes, char[] dstArray, int dstOffset,
+  public abstract void getCharArray(long offsetBytes, char[] dstArray, int dstOffsetChars,
       int lengthChars);
 
   /**
@@ -304,7 +306,7 @@ public abstract class Memory {
    * @return the number of characters decoded.
    * @throws Utf8CodingException in case of malformed or illegal UTF-8 input
    */
-  public int getCharsFromUtf8(final long offsetBytes, final int utf8LengthBytes,
+  public final int getCharsFromUtf8(final long offsetBytes, final int utf8LengthBytes,
       final StringBuilder dst) throws Utf8CodingException {
     try {
       // Ensure that we do at most one resize of internal StringBuilder's char array
@@ -326,10 +328,10 @@ public abstract class Memory {
    * Gets the double array at the given offset
    * @param offsetBytes offset bytes relative to this Memory start
    * @param dstArray The preallocated destination array.
-   * @param dstOffset offset in array units
+   * @param dstOffsetDoubles offset in array units
    * @param lengthDoubles number of array units to transfer
    */
-  public abstract void getDoubleArray(long offsetBytes, double[] dstArray, int dstOffset,
+  public abstract void getDoubleArray(long offsetBytes, double[] dstArray, int dstOffsetDoubles,
       int lengthDoubles);
 
   /**
@@ -343,10 +345,10 @@ public abstract class Memory {
    * Gets the float array at the given offset
    * @param offsetBytes offset bytes relative to this Memory start
    * @param dstArray The preallocated destination array.
-   * @param dstOffset offset in array units
+   * @param dstOffsetFloats offset in array units
    * @param lengthFloats number of array units to transfer
    */
-  public abstract void getFloatArray(long offsetBytes, float[] dstArray, int dstOffset,
+  public abstract void getFloatArray(long offsetBytes, float[] dstArray, int dstOffsetFloats,
       int lengthFloats);
 
   /**
@@ -360,10 +362,10 @@ public abstract class Memory {
    * Gets the int array at the given offset
    * @param offsetBytes offset bytes relative to this Memory start
    * @param dstArray The preallocated destination array.
-   * @param dstOffset offset in array units
+   * @param dstOffsetInts offset in array units
    * @param lengthInts number of array units to transfer
    */
-  public abstract void getIntArray(long offsetBytes, int[] dstArray, int dstOffset,
+  public abstract void getIntArray(long offsetBytes, int[] dstArray, int dstOffsetInts,
       int lengthInts);
 
   /**
@@ -377,10 +379,10 @@ public abstract class Memory {
    * Gets the long array at the given offset
    * @param offsetBytes offset bytes relative to this Memory start
    * @param dstArray The preallocated destination array.
-   * @param dstOffset offset in array units
+   * @param dstOffsetLongs offset in array units
    * @param lengthLongs number of array units to transfer
    */
-  public abstract void getLongArray(long offsetBytes, long[] dstArray, int dstOffset,
+  public abstract void getLongArray(long offsetBytes, long[] dstArray, int dstOffsetLongs,
       int lengthLongs);
 
   /**
@@ -394,10 +396,10 @@ public abstract class Memory {
    * Gets the short array at the given offset
    * @param offsetBytes offset bytes relative to this Memory start
    * @param dstArray The preallocated destination array.
-   * @param dstOffset offset in array units
+   * @param dstOffsetShorts offset in array units
    * @param lengthShorts number of array units to transfer
    */
-  public abstract void getShortArray(long offsetBytes, short[] dstArray, int dstOffset,
+  public abstract void getShortArray(long offsetBytes, short[] dstArray, int dstOffsetShorts,
       int lengthShorts);
 
   //OTHER PRIMITIVE READ METHODS: compareTo, copyTo XXX

--- a/src/main/java/com/yahoo/memory/NonNativeWritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/NonNativeWritableBufferImpl.java
@@ -5,21 +5,14 @@
 
 package com.yahoo.memory;
 
-import static com.yahoo.memory.UnsafeUtil.ARRAY_CHAR_BASE_OFFSET;
-import static com.yahoo.memory.UnsafeUtil.ARRAY_DOUBLE_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_DOUBLE_INDEX_SCALE;
-import static com.yahoo.memory.UnsafeUtil.ARRAY_FLOAT_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_FLOAT_INDEX_SCALE;
-import static com.yahoo.memory.UnsafeUtil.ARRAY_INT_BASE_OFFSET;
-import static com.yahoo.memory.UnsafeUtil.ARRAY_LONG_BASE_OFFSET;
-import static com.yahoo.memory.UnsafeUtil.ARRAY_SHORT_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.CHAR_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.DOUBLE_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.FLOAT_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.INT_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.LONG_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.SHORT_SHIFT;
-import static com.yahoo.memory.UnsafeUtil.checkBounds;
 import static com.yahoo.memory.UnsafeUtil.unsafe;
 
 import java.nio.ByteOrder;
@@ -38,19 +31,19 @@ import java.nio.ByteOrder;
  */
 
 /**
- * Implementation of {@link WritableBuffer} for native endian byte order. Non-native variant is
- * {@link NonNativeWritableBufferImpl}.
+ * Implementation of {@link WritableBuffer} for non-native endian byte order. Native variant is
+ * {@link WritableBufferImpl}.
  * @author Roman Leventov
  * @author Lee Rhodes
  */
-final class WritableBufferImpl extends BaseWritableBufferImpl {
+final class NonNativeWritableBufferImpl extends BaseWritableBufferImpl {
 
-  WritableBufferImpl(final ResourceState state, final boolean localReadOnly,
+  NonNativeWritableBufferImpl(final ResourceState state, final boolean localReadOnly,
       final BaseWritableMemoryImpl originMemory) {
     super(state, localReadOnly, originMemory);
-    if (state.getResourceOrder() != ByteOrder.nativeOrder()) {
+    if (state.getResourceOrder() == ByteOrder.nativeOrder()) {
       throw new IllegalStateException(
-          "Expected native ordered state. This should be a bug in the Memory library.");
+          "Expected non-native ordered state. This should be a bug in the Memory library.");
     }
   }
 
@@ -68,8 +61,8 @@ final class WritableBufferImpl extends BaseWritableBufferImpl {
   private WritableBuffer writableDuplicateImpl(final boolean localReadOnly) {
     checkValid();
     if (capacity == 0) { return ZERO_SIZE_BUFFER; }
-    final WritableBufferImpl wBufImpl =
-        new WritableBufferImpl(state, localReadOnly, originMemory);
+    final NonNativeWritableBufferImpl wBufImpl =
+        new NonNativeWritableBufferImpl(state, localReadOnly, originMemory);
     wBufImpl.setStartPositionEnd(getStart(), getPosition(), getEnd());
     return wBufImpl;
   }
@@ -96,8 +89,8 @@ final class WritableBufferImpl extends BaseWritableBufferImpl {
     final ResourceState newState = state.copy();
     newState.putRegionOffset(newState.getRegionOffset() + offsetBytes);
     newState.putCapacity(capacityBytes);
-    final WritableBufferImpl wBufImpl =
-        new WritableBufferImpl(newState, localReadOnly, originMemory);
+    final NonNativeWritableBufferImpl wBufImpl =
+        new NonNativeWritableBufferImpl(newState, localReadOnly, originMemory);
     wBufImpl.setStartPositionEnd(0L, 0L, capacityBytes);
     return wBufImpl;
   }
@@ -119,12 +112,12 @@ final class WritableBufferImpl extends BaseWritableBufferImpl {
   //PRIMITIVE getXXX() and getXXXArray() XXX
   @Override
   public char getChar() {
-    return getNativeOrderedChar();
+    return Character.reverseBytes(getNativeOrderedChar());
   }
 
   @Override
   public char getChar(final long offsetBytes) {
-    return getNativeOrderedChar(offsetBytes);
+    return Character.reverseBytes(getNativeOrderedChar(offsetBytes));
   }
 
   @Override
@@ -132,26 +125,23 @@ final class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthChars) << CHAR_SHIFT;
     incrementAndCheckPositionForRead(pos, copyBytes);
-    checkBounds(dstOffsetChars, lengthChars, dstArray.length);
-    CompareAndCopy.copyMemoryCheckingDifferentObject(
-            unsafeObj,
-            cumBaseOffset + pos,
-            dstArray,
-            ARRAY_CHAR_BASE_OFFSET + (((long) dstOffsetChars) << CHAR_SHIFT),
-            copyBytes);
+    CompareAndCopy.getNonNativeChars(unsafeObj, cumBaseOffset, pos, copyBytes,
+        dstArray, dstOffsetChars, lengthChars);
   }
 
   @Override
   public double getDouble() {
     final long pos = getPosition();
     incrementAndAssertPositionForRead(pos, ARRAY_DOUBLE_INDEX_SCALE);
-    return unsafe.getDouble(unsafeObj, cumBaseOffset + pos);
+    return Double.longBitsToDouble(
+        Long.reverseBytes(unsafe.getLong(unsafeObj, cumBaseOffset + pos)));
   }
 
   @Override
   public double getDouble(final long offsetBytes) {
     assertValidAndBoundsForRead(offsetBytes, ARRAY_DOUBLE_INDEX_SCALE);
-    return unsafe.getDouble(unsafeObj, cumBaseOffset + offsetBytes);
+    return Double.longBitsToDouble(
+        Long.reverseBytes(unsafe.getLong(unsafeObj, cumBaseOffset + offsetBytes)));
   }
 
   @Override
@@ -160,26 +150,23 @@ final class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthDoubles) << DOUBLE_SHIFT;
     incrementAndCheckPositionForRead(pos, copyBytes);
-    checkBounds(dstOffsetDoubles, lengthDoubles, dstArray.length);
-    CompareAndCopy.copyMemoryCheckingDifferentObject(
-            unsafeObj,
-            cumBaseOffset + pos,
-            dstArray,
-            ARRAY_DOUBLE_BASE_OFFSET + (((long) dstOffsetDoubles) << DOUBLE_SHIFT),
-            copyBytes);
+    CompareAndCopy.getNonNativeDoubles(unsafeObj, cumBaseOffset, pos, copyBytes,
+        dstArray, dstOffsetDoubles, lengthDoubles);
   }
 
   @Override
   public float getFloat() {
     final long pos = getPosition();
     incrementAndAssertPositionForRead(pos, ARRAY_FLOAT_INDEX_SCALE);
-    return unsafe.getFloat(unsafeObj, cumBaseOffset + pos);
+    return Float.intBitsToFloat(
+        Integer.reverseBytes(unsafe.getInt(unsafeObj, cumBaseOffset + pos)));
   }
 
   @Override
   public float getFloat(final long offsetBytes) {
     assertValidAndBoundsForRead(offsetBytes, ARRAY_FLOAT_INDEX_SCALE);
-    return unsafe.getFloat(unsafeObj, cumBaseOffset + offsetBytes);
+    return Float.intBitsToFloat(
+        Integer.reverseBytes(unsafe.getInt(unsafeObj, cumBaseOffset + offsetBytes)));
   }
 
   @Override
@@ -188,23 +175,18 @@ final class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthFloats) << FLOAT_SHIFT;
     incrementAndCheckPositionForRead(pos, copyBytes);
-    checkBounds(dstOffsetFloats, lengthFloats, dstArray.length);
-    CompareAndCopy.copyMemoryCheckingDifferentObject(
-            unsafeObj,
-            cumBaseOffset + pos,
-            dstArray,
-            ARRAY_FLOAT_BASE_OFFSET + (((long) dstOffsetFloats) << FLOAT_SHIFT),
-            copyBytes);
+    CompareAndCopy.getNonNativeFloats(unsafeObj, cumBaseOffset, pos, copyBytes,
+        dstArray, dstOffsetFloats, lengthFloats);
   }
 
   @Override
   public int getInt() {
-    return getNativeOrderedInt();
+    return Integer.reverseBytes(getNativeOrderedInt());
   }
 
   @Override
   public int getInt(final long offsetBytes) {
-    return getNativeOrderedInt(offsetBytes);
+    return Integer.reverseBytes(getNativeOrderedInt(offsetBytes));
   }
 
   @Override
@@ -212,23 +194,18 @@ final class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthInts) << INT_SHIFT;
     incrementAndCheckPositionForRead(pos, copyBytes);
-    checkBounds(dstOffsetInts, lengthInts, dstArray.length);
-    CompareAndCopy.copyMemoryCheckingDifferentObject(
-            unsafeObj,
-            cumBaseOffset + pos,
-            dstArray,
-            ARRAY_INT_BASE_OFFSET + (((long) dstOffsetInts) << INT_SHIFT),
-            copyBytes);
+    CompareAndCopy.getNonNativeInts(unsafeObj, cumBaseOffset, pos, copyBytes,
+        dstArray, dstOffsetInts, lengthInts);
   }
 
   @Override
   public long getLong() {
-    return getNativeOrderedLong();
+    return Long.reverseBytes(getNativeOrderedLong());
   }
 
   @Override
   public long getLong(final long offsetBytes) {
-    return getNativeOrderedLong(offsetBytes);
+    return Long.reverseBytes(getNativeOrderedLong(offsetBytes));
   }
 
   @Override
@@ -236,23 +213,18 @@ final class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthLongs) << LONG_SHIFT;
     incrementAndCheckPositionForRead(pos, copyBytes);
-    checkBounds(dstOffsetLongs, lengthLongs, dstArray.length);
-    CompareAndCopy.copyMemoryCheckingDifferentObject(
-            unsafeObj,
-            cumBaseOffset + pos,
-            dstArray,
-            ARRAY_LONG_BASE_OFFSET + (((long) dstOffsetLongs) << LONG_SHIFT),
-            copyBytes);
+    CompareAndCopy.getNonNativeLongs(unsafeObj, cumBaseOffset, pos, copyBytes,
+        dstArray, dstOffsetLongs, lengthLongs);
   }
 
   @Override
   public short getShort() {
-    return getNativeOrderedShort();
+    return Short.reverseBytes(getNativeOrderedShort());
   }
 
   @Override
   public short getShort(final long offsetBytes) {
-    return getNativeOrderedShort(offsetBytes);
+    return Short.reverseBytes(getNativeOrderedShort(offsetBytes));
   }
 
   @Override
@@ -261,24 +233,19 @@ final class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthShorts) << SHORT_SHIFT;
     incrementAndCheckPositionForRead(pos, copyBytes);
-    checkBounds(dstOffsetShorts, lengthShorts, dstArray.length);
-    CompareAndCopy.copyMemoryCheckingDifferentObject(
-            unsafeObj,
-            cumBaseOffset + pos,
-            dstArray,
-            ARRAY_SHORT_BASE_OFFSET + (((long) dstOffsetShorts) << SHORT_SHIFT),
-            copyBytes);
+    CompareAndCopy.getNonNativeShorts(unsafeObj, cumBaseOffset, pos, copyBytes,
+        dstArray, dstOffsetShorts, lengthShorts);
   }
 
   //PRIMITIVE putXXX() and putXXXArray() XXX
   @Override
   public void putChar(final char value) {
-    putNativeOrderedChar(value);
+    putNativeOrderedChar(Character.reverseBytes(value));
   }
 
   @Override
   public void putChar(final long offsetBytes, final char value) {
-    putNativeOrderedChar(offsetBytes, value);
+    putNativeOrderedChar(offsetBytes, Character.reverseBytes(value));
   }
 
   @Override
@@ -286,26 +253,23 @@ final class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthChars) << CHAR_SHIFT;
     incrementAndCheckPositionForWrite(pos, copyBytes);
-    checkBounds(srcOffsetChars, lengthChars, srcArray.length);
-    CompareAndCopy.copyMemoryCheckingDifferentObject(
-            srcArray,
-            ARRAY_CHAR_BASE_OFFSET + (((long) srcOffsetChars) << CHAR_SHIFT),
-            unsafeObj,
-            cumBaseOffset + pos,
-            copyBytes);
+    CompareAndCopy.putNonNativeChars(srcArray, srcOffsetChars, lengthChars, copyBytes,
+        unsafeObj, cumBaseOffset, pos);
   }
 
   @Override
   public void putDouble(final double value) {
     final long pos = getPosition();
     incrementAndAssertPositionForWrite(pos, ARRAY_DOUBLE_INDEX_SCALE);
-    unsafe.putDouble(unsafeObj, cumBaseOffset + pos, value);
+    unsafe.putLong(unsafeObj, cumBaseOffset + pos,
+        Long.reverseBytes(Double.doubleToRawLongBits(value)));
   }
 
   @Override
   public void putDouble(final long offsetBytes, final double value) {
     assertValidAndBoundsForWrite(offsetBytes, ARRAY_DOUBLE_INDEX_SCALE);
-    unsafe.putDouble(unsafeObj, cumBaseOffset + offsetBytes, value);
+    unsafe.putLong(unsafeObj, cumBaseOffset + offsetBytes,
+        Long.reverseBytes(Double.doubleToRawLongBits(value)));
   }
 
   @Override
@@ -314,26 +278,23 @@ final class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthDoubles) << DOUBLE_SHIFT;
     incrementAndCheckPositionForWrite(pos, copyBytes);
-    checkBounds(srcOffsetDoubles, lengthDoubles, srcArray.length);
-    CompareAndCopy.copyMemoryCheckingDifferentObject(
-            srcArray,
-            ARRAY_DOUBLE_BASE_OFFSET + (((long) srcOffsetDoubles) << DOUBLE_SHIFT),
-            unsafeObj,
-            cumBaseOffset + pos,
-            copyBytes);
+    CompareAndCopy.putNonNativeDoubles(srcArray, srcOffsetDoubles, lengthDoubles, copyBytes,
+        unsafeObj, cumBaseOffset, pos);
   }
 
   @Override
   public void putFloat(final float value) {
     final long pos = getPosition();
     incrementAndAssertPositionForWrite(pos, ARRAY_FLOAT_INDEX_SCALE);
-    unsafe.putFloat(unsafeObj, cumBaseOffset + pos, value);
+    unsafe.putInt(unsafeObj, cumBaseOffset + pos,
+        Integer.reverseBytes(Float.floatToRawIntBits(value)));
   }
 
   @Override
   public void putFloat(final long offsetBytes, final float value) {
     assertValidAndBoundsForWrite(offsetBytes, ARRAY_FLOAT_INDEX_SCALE);
-    unsafe.putFloat(unsafeObj, cumBaseOffset + offsetBytes, value);
+    unsafe.putInt(unsafeObj, cumBaseOffset + offsetBytes,
+        Integer.reverseBytes(Float.floatToRawIntBits(value)));
   }
 
   @Override
@@ -342,23 +303,18 @@ final class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthFloats) << FLOAT_SHIFT;
     incrementAndCheckPositionForWrite(pos, copyBytes);
-    checkBounds(srcOffsetFloats, lengthFloats, srcArray.length);
-    CompareAndCopy.copyMemoryCheckingDifferentObject(
-            srcArray,
-            ARRAY_FLOAT_BASE_OFFSET + (((long) srcOffsetFloats) << FLOAT_SHIFT),
-            unsafeObj,
-            cumBaseOffset + pos,
-            copyBytes);
+    CompareAndCopy.putNonNativeFloats(srcArray, srcOffsetFloats, lengthFloats, copyBytes,
+        unsafeObj, cumBaseOffset, pos);
   }
 
   @Override
   public void putInt(final int value) {
-    putNativeOrderedInt(value);
+    putNativeOrderedInt(Integer.reverseBytes(value));
   }
 
   @Override
   public void putInt(final long offsetBytes, final int value) {
-    putNativeOrderedInt(offsetBytes, value);
+    putNativeOrderedInt(offsetBytes, Integer.reverseBytes(value));
   }
 
   @Override
@@ -366,23 +322,18 @@ final class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthInts) << INT_SHIFT;
     incrementAndCheckPositionForWrite(pos, copyBytes);
-    checkBounds(srcOffsetInts, lengthInts, srcArray.length);
-    CompareAndCopy.copyMemoryCheckingDifferentObject(
-            srcArray,
-            ARRAY_INT_BASE_OFFSET + (((long) srcOffsetInts) << INT_SHIFT),
-            unsafeObj,
-            cumBaseOffset + pos,
-            copyBytes);
+    CompareAndCopy.putNonNativeInts(srcArray, srcOffsetInts, lengthInts, copyBytes,
+        unsafeObj, cumBaseOffset, pos);
   }
 
   @Override
   public void putLong(final long value) {
-    putNativeOrderedLong(value);
+    putNativeOrderedLong(Long.reverseBytes(value));
   }
 
   @Override
   public void putLong(final long offsetBytes, final long value) {
-    putNativeOrderedLong(offsetBytes, value);
+    putNativeOrderedLong(offsetBytes, Long.reverseBytes(value));
   }
 
   @Override
@@ -390,23 +341,18 @@ final class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthLongs) << LONG_SHIFT;
     incrementAndCheckPositionForWrite(pos, copyBytes);
-    checkBounds(srcOffsetLongs, lengthLongs, srcArray.length);
-    CompareAndCopy.copyMemoryCheckingDifferentObject(
-            srcArray,
-            ARRAY_LONG_BASE_OFFSET + (((long) srcOffsetLongs) << LONG_SHIFT),
-            unsafeObj,
-            cumBaseOffset + pos,
-            copyBytes);
+    CompareAndCopy.putNonNativeLongs(srcArray, srcOffsetLongs, lengthLongs, copyBytes,
+        unsafeObj, cumBaseOffset, pos);
   }
 
   @Override
   public void putShort(final short value) {
-    putNativeOrderedShort(value);
+    putNativeOrderedShort(Short.reverseBytes(value));
   }
 
   @Override
   public void putShort(final long offsetBytes, final short value) {
-    putNativeOrderedShort(offsetBytes, value);
+    putNativeOrderedShort(offsetBytes, Short.reverseBytes(value));
   }
 
   @Override
@@ -415,12 +361,7 @@ final class WritableBufferImpl extends BaseWritableBufferImpl {
     final long pos = getPosition();
     final long copyBytes = ((long) lengthShorts) << SHORT_SHIFT;
     incrementAndCheckPositionForWrite(pos, copyBytes);
-    checkBounds(srcOffsetShorts, lengthShorts, srcArray.length);
-    CompareAndCopy.copyMemoryCheckingDifferentObject(
-            srcArray,
-            ARRAY_SHORT_BASE_OFFSET + (((long) srcOffsetShorts) << SHORT_SHIFT),
-            unsafeObj,
-            cumBaseOffset + pos,
-            copyBytes);
+    CompareAndCopy.putNonNativeShorts(srcArray, srcOffsetShorts, lengthShorts, copyBytes,
+        unsafeObj, cumBaseOffset, pos);
   }
 }

--- a/src/main/java/com/yahoo/memory/NonNativeWritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/NonNativeWritableMemoryImpl.java
@@ -5,12 +5,9 @@
 
 package com.yahoo.memory;
 
-import static com.yahoo.memory.UnsafeUtil.ARRAY_CHAR_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_DOUBLE_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_FLOAT_INDEX_SCALE;
-import static com.yahoo.memory.UnsafeUtil.ARRAY_INT_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_LONG_INDEX_SCALE;
-import static com.yahoo.memory.UnsafeUtil.ARRAY_SHORT_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.CHAR_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.DOUBLE_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.FLOAT_SHIFT;

--- a/src/main/java/com/yahoo/memory/NonNativeWritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/NonNativeWritableMemoryImpl.java
@@ -5,17 +5,11 @@
 
 package com.yahoo.memory;
 
-import static com.yahoo.memory.UnsafeUtil.ARRAY_CHAR_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_CHAR_INDEX_SCALE;
-import static com.yahoo.memory.UnsafeUtil.ARRAY_DOUBLE_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_DOUBLE_INDEX_SCALE;
-import static com.yahoo.memory.UnsafeUtil.ARRAY_FLOAT_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_FLOAT_INDEX_SCALE;
-import static com.yahoo.memory.UnsafeUtil.ARRAY_INT_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_INT_INDEX_SCALE;
-import static com.yahoo.memory.UnsafeUtil.ARRAY_LONG_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_LONG_INDEX_SCALE;
-import static com.yahoo.memory.UnsafeUtil.ARRAY_SHORT_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_SHORT_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.CHAR_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.DOUBLE_SHIFT;
@@ -23,11 +17,9 @@ import static com.yahoo.memory.UnsafeUtil.FLOAT_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.INT_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.LONG_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.SHORT_SHIFT;
-import static com.yahoo.memory.UnsafeUtil.checkBounds;
 import static com.yahoo.memory.UnsafeUtil.unsafe;
 
 import java.nio.ByteOrder;
-import java.time.OffsetDateTime;
 
 /*
  * Developer notes: The heavier methods, such as put/get arrays, duplicate, region, clear, fill,
@@ -42,18 +34,18 @@ import java.time.OffsetDateTime;
  */
 
 /**
- * Implementation of {@link WritableMemory} for native endian byte order. Non-native variant is
- * {@link NonNativeWritableMemoryImpl}.
+ * Implementation of {@link WritableMemory} for non-native endian byte order. Native variant is
+ * {@link WritableMemoryImpl}.
  * @author Roman Leventov
  * @author Lee Rhodes
  */
-final class WritableMemoryImpl extends BaseWritableMemoryImpl {
+final class NonNativeWritableMemoryImpl extends BaseWritableMemoryImpl {
 
-  WritableMemoryImpl(final ResourceState state, final boolean localReadOnly) {
+  NonNativeWritableMemoryImpl(final ResourceState state, final boolean localReadOnly) {
     super(state, localReadOnly);
-    if (state.getResourceOrder() != ByteOrder.nativeOrder()) {
+    if (state.getResourceOrder() == ByteOrder.nativeOrder()) {
       throw new IllegalStateException(
-          "Expected native ordered state. This should be a bug in the Memory library.");
+          "Expected non-native ordered state. This should be a bug in the Memory library.");
     }
   }
 
@@ -71,11 +63,11 @@ final class WritableMemoryImpl extends BaseWritableMemoryImpl {
   private WritableMemory writableRegionImpl(final long offsetBytes, final long capacityBytes,
       final boolean localReadOnly) {
     checkValidAndBounds(offsetBytes, capacityBytes);
-    if (capacityBytes == 0) { return ZERO_SIZE_MEMORY; }
+    if (capacityBytes == 0) { return WritableMemoryImpl.ZERO_SIZE_MEMORY; }
     final ResourceState newState = state.copy();
     newState.putRegionOffset(newState.getRegionOffset() + offsetBytes);
     newState.putCapacity(capacityBytes);
-    return new WritableMemoryImpl(newState, localReadOnly);
+    return new NonNativeWritableMemoryImpl(newState, localReadOnly);
   }
 
   //BUFFER XXX
@@ -91,11 +83,11 @@ final class WritableMemoryImpl extends BaseWritableMemoryImpl {
 
   private WritableBuffer asWritableBufferImpl(final boolean localReadOnly) {
     checkValid();
-    final WritableBufferImpl wbuf;
+    final BaseWritableBufferImpl wbuf;
     if (capacity == 0) {
       wbuf = BaseWritableBufferImpl.ZERO_SIZE_BUFFER;
     } else {
-      wbuf = new WritableBufferImpl(state, localReadOnly, this);
+      wbuf = new NonNativeWritableBufferImpl(state, localReadOnly, this);
       wbuf.setAndCheckStartPositionEnd(0, 0, capacity);
     }
     return wbuf;
@@ -104,7 +96,7 @@ final class WritableMemoryImpl extends BaseWritableMemoryImpl {
   ///PRIMITIVE getXXX() and getXXXArray() XXX
   @Override
   public char getChar(final long offsetBytes) {
-    return getNativeOrderedChar(offsetBytes);
+    return Character.reverseBytes(getNativeOrderedChar(offsetBytes));
   }
 
   @Override
@@ -112,58 +104,45 @@ final class WritableMemoryImpl extends BaseWritableMemoryImpl {
       final int lengthChars) {
     final long copyBytes = ((long) lengthChars) << CHAR_SHIFT;
     checkValidAndBounds(offsetBytes, copyBytes);
-    checkBounds(dstOffsetChars, lengthChars, dstArray.length);
-    CompareAndCopy.copyMemoryCheckingDifferentObject(
-        unsafeObj,
-        cumBaseOffset + offsetBytes,
-        dstArray,
-        ARRAY_CHAR_BASE_OFFSET + (((long) dstOffsetChars) << CHAR_SHIFT),
-        copyBytes);
+    CompareAndCopy.getNonNativeChars(unsafeObj, cumBaseOffset, offsetBytes, copyBytes,
+        dstArray, dstOffsetChars, lengthChars);
   }
 
   @Override
   public double getDouble(final long offsetBytes) {
     assertValidAndBoundsForRead(offsetBytes, ARRAY_DOUBLE_INDEX_SCALE);
-    return unsafe.getDouble(unsafeObj, cumBaseOffset + offsetBytes);
+    return Double.longBitsToDouble(
+        Long.reverseBytes(unsafe.getLong(unsafeObj, cumBaseOffset + offsetBytes)));
   }
 
   @Override
-  public void getDoubleArray(final long offsetBytes, final double[] dstArray, final int dstOffsetDoubles,
-      final int lengthDoubles) {
+  public void getDoubleArray(final long offsetBytes, final double[] dstArray,
+      final int dstOffsetDoubles, final int lengthDoubles) {
     final long copyBytes = ((long) lengthDoubles) << DOUBLE_SHIFT;
     checkValidAndBounds(offsetBytes, copyBytes);
-    checkBounds(dstOffsetDoubles, lengthDoubles, dstArray.length);
-    CompareAndCopy.copyMemoryCheckingDifferentObject(
-        unsafeObj,
-        cumBaseOffset + offsetBytes,
-        dstArray,
-        ARRAY_DOUBLE_BASE_OFFSET + (((long) dstOffsetDoubles) << DOUBLE_SHIFT),
-        copyBytes);
+    CompareAndCopy.getNonNativeDoubles(unsafeObj, cumBaseOffset, offsetBytes, copyBytes,
+        dstArray, dstOffsetDoubles, lengthDoubles);
   }
 
   @Override
   public float getFloat(final long offsetBytes) {
     assertValidAndBoundsForRead(offsetBytes, ARRAY_FLOAT_INDEX_SCALE);
-    return unsafe.getFloat(unsafeObj, cumBaseOffset + offsetBytes);
+    return Float.intBitsToFloat(
+        Integer.reverseBytes(unsafe.getInt(unsafeObj, cumBaseOffset + offsetBytes)));
   }
 
   @Override
-  public void getFloatArray(final long offsetBytes, final float[] dstArray, final int dstOffsetFloats,
-      final int lengthFloats) {
+  public void getFloatArray(final long offsetBytes, final float[] dstArray,
+      final int dstOffsetFloats, final int lengthFloats) {
     final long copyBytes = ((long) lengthFloats) << FLOAT_SHIFT;
     checkValidAndBounds(offsetBytes, copyBytes);
-    checkBounds(dstOffsetFloats, lengthFloats, dstArray.length);
-    CompareAndCopy.copyMemoryCheckingDifferentObject(
-        unsafeObj,
-        cumBaseOffset + offsetBytes,
-        dstArray,
-        ARRAY_FLOAT_BASE_OFFSET + (((long) dstOffsetFloats) << FLOAT_SHIFT),
-        copyBytes);
+    CompareAndCopy.getNonNativeFloats(unsafeObj, cumBaseOffset, offsetBytes, copyBytes,
+        dstArray, dstOffsetFloats, lengthFloats);
   }
 
   @Override
   public int getInt(final long offsetBytes) {
-    return getNativeOrderedInt(offsetBytes);
+    return Integer.reverseBytes(getNativeOrderedInt(offsetBytes));
   }
 
   @Override
@@ -171,57 +150,42 @@ final class WritableMemoryImpl extends BaseWritableMemoryImpl {
       final int lengthInts) {
     final long copyBytes = ((long) lengthInts) << INT_SHIFT;
     checkValidAndBounds(offsetBytes, copyBytes);
-    checkBounds(dstOffsetInts, lengthInts, dstArray.length);
-    CompareAndCopy.copyMemoryCheckingDifferentObject(
-        unsafeObj,
-        cumBaseOffset + offsetBytes,
-        dstArray,
-        ARRAY_INT_BASE_OFFSET + (((long) dstOffsetInts) << INT_SHIFT),
-        copyBytes);
+    CompareAndCopy.getNonNativeInts(unsafeObj, cumBaseOffset, offsetBytes, copyBytes,
+        dstArray, dstOffsetInts, lengthInts);
   }
 
   @Override
   public long getLong(final long offsetBytes) {
-    return getNativeOrderedLong(offsetBytes);
+    return Long.reverseBytes(getNativeOrderedLong(offsetBytes));
   }
 
   @Override
-  public void getLongArray(final long offsetBytes, final long[] dstArray, final int dstOffsetLongs,
-      final int lengthLongs) {
+  public void getLongArray(final long offsetBytes, final long[] dstArray,
+      final int dstOffsetLongs, final int lengthLongs) {
     final long copyBytes = ((long) lengthLongs) << LONG_SHIFT;
     checkValidAndBounds(offsetBytes, copyBytes);
-    checkBounds(dstOffsetLongs, lengthLongs, dstArray.length);
-    CompareAndCopy.copyMemoryCheckingDifferentObject(
-        unsafeObj,
-        cumBaseOffset + offsetBytes,
-        dstArray,
-        ARRAY_LONG_BASE_OFFSET + (((long) dstOffsetLongs) << LONG_SHIFT),
-        copyBytes);
+    CompareAndCopy.getNonNativeLongs(unsafeObj, cumBaseOffset, offsetBytes, copyBytes,
+        dstArray, dstOffsetLongs, lengthLongs);
   }
 
   @Override
   public short getShort(final long offsetBytes) {
-    return getNativeOrderedShort(offsetBytes);
+    return Short.reverseBytes(getNativeOrderedShort(offsetBytes));
   }
 
   @Override
-  public void getShortArray(final long offsetBytes, final short[] dstArray, final int dstOffsetShorts,
-      final int lengthShorts) {
+  public void getShortArray(final long offsetBytes, final short[] dstArray,
+      final int dstOffsetShorts, final int lengthShorts) {
     final long copyBytes = ((long) lengthShorts) << SHORT_SHIFT;
     checkValidAndBounds(offsetBytes, copyBytes);
-    checkBounds(dstOffsetShorts, lengthShorts, dstArray.length);
-    CompareAndCopy.copyMemoryCheckingDifferentObject(
-        unsafeObj,
-        cumBaseOffset + offsetBytes,
-        dstArray,
-        ARRAY_SHORT_BASE_OFFSET + (((long) dstOffsetShorts) << SHORT_SHIFT),
-        copyBytes);
+    CompareAndCopy.getNonNativeShorts(unsafeObj, cumBaseOffset, offsetBytes, copyBytes,
+        dstArray, dstOffsetShorts, lengthShorts);
   }
 
   //PRIMITIVE putXXX() and putXXXArray() implementations XXX
   @Override
   public void putChar(final long offsetBytes, final char value) {
-    putNativeOrderedChar(offsetBytes, value);
+    putNativeOrderedChar(offsetBytes, Character.reverseBytes(value));
   }
 
   @Override
@@ -229,61 +193,45 @@ final class WritableMemoryImpl extends BaseWritableMemoryImpl {
       final int lengthChars) {
     final long copyBytes = ((long) lengthChars) << CHAR_SHIFT;
     checkValidAndBoundsForWrite(offsetBytes, copyBytes);
-    checkBounds(srcOffsetChars, lengthChars, srcArray.length);
-    CompareAndCopy.copyMemoryCheckingDifferentObject(
-        srcArray,
-        ARRAY_CHAR_BASE_OFFSET + (((long) srcOffsetChars) << CHAR_SHIFT),
-        unsafeObj,
-        cumBaseOffset + offsetBytes,
-        copyBytes
-    );
+    CompareAndCopy.putNonNativeChars(srcArray, srcOffsetChars, lengthChars, copyBytes,
+        unsafeObj, cumBaseOffset, offsetBytes);
   }
 
   @Override
   public void putDouble(final long offsetBytes, final double value) {
     assertValidAndBoundsForWrite(offsetBytes, ARRAY_DOUBLE_INDEX_SCALE);
-    unsafe.putDouble(unsafeObj, cumBaseOffset + offsetBytes, value);
+    unsafe.putLong(unsafeObj, cumBaseOffset + offsetBytes,
+        Long.reverseBytes(Double.doubleToRawLongBits(value)));
   }
 
   @Override
-  public void putDoubleArray(final long offsetBytes, final double[] srcArray, final int srcOffsetDoubles,
-      final int lengthDoubles) {
+  public void putDoubleArray(final long offsetBytes, final double[] srcArray,
+      final int srcOffsetDoubles, final int lengthDoubles) {
     final long copyBytes = ((long) lengthDoubles) << DOUBLE_SHIFT;
     checkValidAndBoundsForWrite(offsetBytes, copyBytes);
-    checkBounds(srcOffsetDoubles, lengthDoubles, srcArray.length);
-    CompareAndCopy.copyMemoryCheckingDifferentObject(
-        srcArray,
-        ARRAY_DOUBLE_BASE_OFFSET + (((long) srcOffsetDoubles) << DOUBLE_SHIFT),
-        unsafeObj,
-        cumBaseOffset + offsetBytes,
-        copyBytes
-    );
+    CompareAndCopy.putNonNativeDoubles(srcArray, srcOffsetDoubles, lengthDoubles, copyBytes,
+        unsafeObj, cumBaseOffset, offsetBytes);
   }
 
   @Override
   public void putFloat(final long offsetBytes, final float value) {
     assertValidAndBoundsForWrite(offsetBytes, ARRAY_FLOAT_INDEX_SCALE);
-    unsafe.putFloat(unsafeObj, cumBaseOffset + offsetBytes, value);
+    unsafe.putInt(unsafeObj, cumBaseOffset + offsetBytes,
+        Integer.reverseBytes(Float.floatToRawIntBits(value)));
   }
 
   @Override
-  public void putFloatArray(final long offsetBytes, final float[] srcArray, final int srcOffsetFloats,
-      final int lengthFloats) {
+  public void putFloatArray(final long offsetBytes, final float[] srcArray,
+      final int srcOffsetFloats, final int lengthFloats) {
     final long copyBytes = ((long) lengthFloats) << FLOAT_SHIFT;
     checkValidAndBoundsForWrite(offsetBytes, copyBytes);
-    checkBounds(srcOffsetFloats, lengthFloats, srcArray.length);
-    CompareAndCopy.copyMemoryCheckingDifferentObject(
-        srcArray,
-        ARRAY_FLOAT_BASE_OFFSET + (((long) srcOffsetFloats) << FLOAT_SHIFT),
-        unsafeObj,
-        cumBaseOffset + offsetBytes,
-        copyBytes
-    );
+    CompareAndCopy.putNonNativeFloats(srcArray, srcOffsetFloats, lengthFloats, copyBytes,
+        unsafeObj, cumBaseOffset, offsetBytes);
   }
 
   @Override
   public void putInt(final long offsetBytes, final int value) {
-    putNativeOrderedInt(offsetBytes, value);
+    putNativeOrderedInt(offsetBytes, Integer.reverseBytes(value));
   }
 
   @Override
@@ -291,19 +239,13 @@ final class WritableMemoryImpl extends BaseWritableMemoryImpl {
       final int lengthInts) {
     final long copyBytes = ((long) lengthInts) << INT_SHIFT;
     checkValidAndBoundsForWrite(offsetBytes, copyBytes);
-    checkBounds(srcOffsetInts, lengthInts, srcArray.length);
-    CompareAndCopy.copyMemoryCheckingDifferentObject(
-        srcArray,
-        ARRAY_INT_BASE_OFFSET + (((long) srcOffsetInts) << INT_SHIFT),
-        unsafeObj,
-        cumBaseOffset + offsetBytes,
-        copyBytes
-    );
+    CompareAndCopy.putNonNativeInts(srcArray, srcOffsetInts, lengthInts, copyBytes,
+        unsafeObj, cumBaseOffset, offsetBytes);
   }
 
   @Override
   public void putLong(final long offsetBytes, final long value) {
-    putNativeOrderedLong(offsetBytes, value);
+    putNativeOrderedLong(offsetBytes, Long.reverseBytes(value));
   }
 
   @Override
@@ -311,34 +253,22 @@ final class WritableMemoryImpl extends BaseWritableMemoryImpl {
       final int lengthLongs) {
     final long copyBytes = ((long) lengthLongs) << LONG_SHIFT;
     checkValidAndBoundsForWrite(offsetBytes, copyBytes);
-    checkBounds(srcOffsetLongs, lengthLongs, srcArray.length);
-    CompareAndCopy.copyMemoryCheckingDifferentObject(
-        srcArray,
-        ARRAY_LONG_BASE_OFFSET + (((long) srcOffsetLongs) << LONG_SHIFT),
-        unsafeObj,
-        cumBaseOffset + offsetBytes,
-        copyBytes
-    );
+    CompareAndCopy.putNonNativeLongs(srcArray, srcOffsetLongs, lengthLongs, copyBytes,
+        unsafeObj, cumBaseOffset, offsetBytes);
   }
 
   @Override
   public void putShort(final long offsetBytes, final short value) {
-    putNativeOrderedShort(offsetBytes, value);
+    putNativeOrderedShort(offsetBytes, Short.reverseBytes(value));
   }
 
   @Override
-  public void putShortArray(final long offsetBytes, final short[] srcArray, final int srcOffsetShorts,
-      final int lengthShorts) {
+  public void putShortArray(final long offsetBytes, final short[] srcArray,
+      final int srcOffsetShorts, final int lengthShorts) {
     final long copyBytes = ((long) lengthShorts) << SHORT_SHIFT;
     checkValidAndBoundsForWrite(offsetBytes, copyBytes);
-    checkBounds(srcOffsetShorts, lengthShorts, srcArray.length);
-    CompareAndCopy.copyMemoryCheckingDifferentObject(
-        srcArray,
-        ARRAY_SHORT_BASE_OFFSET + (((long) srcOffsetShorts) << SHORT_SHIFT),
-        unsafeObj,
-        cumBaseOffset + offsetBytes,
-        copyBytes
-    );
+    CompareAndCopy.putNonNativeShorts(srcArray, srcOffsetShorts, lengthShorts, copyBytes,
+        unsafeObj, cumBaseOffset, offsetBytes);
   }
 
   //Atomic Write Methods XXX
@@ -346,27 +276,34 @@ final class WritableMemoryImpl extends BaseWritableMemoryImpl {
   public long getAndAddLong(final long offsetBytes, final long delta) { //JDK 8+
     assertValidAndBoundsForWrite(offsetBytes, ARRAY_LONG_INDEX_SCALE);
     final long addr = cumBaseOffset + offsetBytes;
-    if (UnsafeUtil.JDK8_OR_ABOVE) {
-      return unsafe.getAndAddLong(unsafeObj, addr, delta);
-    } else {
-      return JDK7Compatible.getAndAddLong(unsafeObj, addr, delta);
-    }
+    long oldValReverseBytes, oldVal, newValReverseBytes;
+    do {
+      oldValReverseBytes = unsafe.getLongVolatile(unsafeObj, addr);
+      oldVal = Long.reverseBytes(oldValReverseBytes);
+      newValReverseBytes = Long.reverseBytes(oldVal + delta);
+    } while (!unsafe.compareAndSwapLong(unsafeObj, addr, oldValReverseBytes, newValReverseBytes));
+
+    return oldVal;
   }
 
   @Override
   public long getAndSetLong(final long offsetBytes, final long newValue) { //JDK 8+
     assertValidAndBoundsForWrite(offsetBytes, ARRAY_LONG_INDEX_SCALE);
     final long addr = cumBaseOffset + offsetBytes;
-    if (UnsafeUtil.JDK8_OR_ABOVE) {
-      return unsafe.getAndSetLong(unsafeObj, addr, newValue);
-    } else {
-      return JDK7Compatible.getAndSetLong(unsafeObj, addr, newValue);
-    }
+    final long newValueReverseBytes = Long.reverseBytes(newValue);
+    long oldValReverseBytes, oldVal;
+    do {
+      oldValReverseBytes = unsafe.getLongVolatile(unsafeObj, addr);
+      oldVal = Long.reverseBytes(oldValReverseBytes);
+    } while (!unsafe.compareAndSwapLong(unsafeObj, addr, oldValReverseBytes, newValueReverseBytes));
+
+    return oldVal;
   }
 
   @Override
   public boolean compareAndSwapLong(final long offsetBytes, final long expect, final long update) {
     assertValidAndBoundsForWrite(offsetBytes, ARRAY_LONG_INDEX_SCALE);
-    return unsafe.compareAndSwapLong(unsafeObj, cumBaseOffset + offsetBytes, expect, update);
+    return unsafe.compareAndSwapLong(unsafeObj, cumBaseOffset + offsetBytes,
+        Long.reverseBytes(expect), Long.reverseBytes(update));
   }
 }

--- a/src/main/java/com/yahoo/memory/WritableBuffer.java
+++ b/src/main/java/com/yahoo/memory/WritableBuffer.java
@@ -112,7 +112,7 @@ public abstract class WritableBuffer extends Buffer {
   //PRIMITIVE putXXX() and putXXXArray() XXX
   /**
    * Puts the boolean value at the current position.
-   * Increments the position by <i>Boolean.BYTES</i>.
+   * Increments the position by 1.
    * @param value the value to put
    */
   public abstract void putBoolean(boolean value);
@@ -127,12 +127,13 @@ public abstract class WritableBuffer extends Buffer {
 
   /**
    * Puts the boolean array at the current position.
-   * Increments the position by <i>Boolean.BYTES * (lengthBooleans - srcOffset)</i>.
+   * Increments the position by <i>lengthBooleans - srcOffsetBooleans</i>.
    * @param srcArray The source array.
-   * @param srcOffset offset in array units
+   * @param srcOffsetBooleans offset in array units
    * @param lengthBooleans number of array units to transfer
    */
-  public abstract void putBooleanArray(boolean[] srcArray, int srcOffset, int lengthBooleans);
+  public abstract void putBooleanArray(boolean[] srcArray, int srcOffsetBooleans,
+      int lengthBooleans);
 
   /**
    * Puts the byte value at the current position.
@@ -151,16 +152,16 @@ public abstract class WritableBuffer extends Buffer {
 
   /**
    * Puts the byte array at the current position.
-   * Increments the position by <i>Byte.BYTES * (lengthBytes - srcOffset)</i>.
+   * Increments the position by <i>Byte.BYTES * (lengthBytes - srcOffsetBytes)</i>.
    * @param srcArray The source array.
-   * @param srcOffset offset in array units
+   * @param srcOffsetBytes offset in array units
    * @param lengthBytes number of array units to transfer
    */
-  public abstract void putByteArray(byte[] srcArray, int srcOffset, int lengthBytes);
+  public abstract void putByteArray(byte[] srcArray, int srcOffsetBytes, int lengthBytes);
 
   /**
    * Puts the char value at the current position.
-   * Increments the position by <i>Char.BYTES</i>.
+   * Increments the position by <i>Character.BYTES</i>.
    * @param value the value to put
    */
   public abstract void putChar(char value);
@@ -175,12 +176,12 @@ public abstract class WritableBuffer extends Buffer {
 
   /**
    * Puts the char array at the current position.
-   * Increments the position by <i>Char.BYTES * (lengthChars - srcOffset)</i>.
+   * Increments the position by <i>Character.BYTES * (lengthChars - srcOffsetChars)</i>.
    * @param srcArray The source array.
-   * @param srcOffset offset in array units
+   * @param srcOffsetChars offset in array units
    * @param lengthChars number of array units to transfer
    */
-  public abstract void putCharArray(char[] srcArray, int srcOffset, int lengthChars);
+  public abstract void putCharArray(char[] srcArray, int srcOffsetChars, int lengthChars);
 
   /**
    * Puts the double value at the current position.
@@ -199,12 +200,12 @@ public abstract class WritableBuffer extends Buffer {
 
   /**
    * Puts the double array at the current position.
-   * Increments the position by <i>Double.BYTES * (lengthDoubles - srcOffset)</i>.
+   * Increments the position by <i>Double.BYTES * (lengthDoubles - srcOffsetDoubles)</i>.
    * @param srcArray The source array.
-   * @param srcOffset offset in array units
+   * @param srcOffsetDoubles offset in array units
    * @param lengthDoubles number of array units to transfer
    */
-  public abstract void putDoubleArray(double[] srcArray, int srcOffset, int lengthDoubles);
+  public abstract void putDoubleArray(double[] srcArray, int srcOffsetDoubles, int lengthDoubles);
 
   /**
    * Puts the float value at the current position.
@@ -223,16 +224,16 @@ public abstract class WritableBuffer extends Buffer {
 
   /**
    * Puts the float array at the current position.
-   * Increments the position by <i>Float.BYTES * (lengthFloats - srcOffset)</i>.
+   * Increments the position by <i>Float.BYTES * (lengthFloats - srcOffsetFloats)</i>.
    * @param srcArray The source array.
-   * @param srcOffset offset in array units
+   * @param srcOffsetFloats offset in array units
    * @param lengthFloats number of array units to transfer
    */
-  public abstract void putFloatArray(float[] srcArray, int srcOffset, int lengthFloats);
+  public abstract void putFloatArray(float[] srcArray, int srcOffsetFloats, int lengthFloats);
 
   /**
    * Puts the int value at the current position.
-   * Increments the position by <i>Int.BYTES</i>.
+   * Increments the position by <i>Integer.BYTES</i>.
    * @param value the value to put
    */
   public abstract void putInt(int value);
@@ -247,12 +248,12 @@ public abstract class WritableBuffer extends Buffer {
 
   /**
    * Puts the int array at the current position.
-   * Increments the position by <i>Int.BYTES * (lengthInts - srcOffset)</i>.
+   * Increments the position by <i>Integer.BYTES * (lengthInts - srcOffsetInts)</i>.
    * @param srcArray The source array.
-   * @param srcOffset offset in array units
+   * @param srcOffsetInts offset in array units
    * @param lengthInts number of array units to transfer
    */
-  public abstract void putIntArray(int[] srcArray, int srcOffset, int lengthInts);
+  public abstract void putIntArray(int[] srcArray, int srcOffsetInts, int lengthInts);
 
   /**
    * Puts the long value at the current position.
@@ -271,12 +272,12 @@ public abstract class WritableBuffer extends Buffer {
 
   /**
    * Puts the long array at the current position.
-   * Increments the position by <i>Long.BYTES * (lengthLongs - srcOffset)</i>.
+   * Increments the position by <i>Long.BYTES * (lengthLongs - srcOffsetLongs)</i>.
    * @param srcArray The source array.
-   * @param srcOffset offset in array units
+   * @param srcOffsetLongs offset in array units
    * @param lengthLongs number of array units to transfer
    */
-  public abstract void putLongArray(long[] srcArray, int srcOffset, int lengthLongs);
+  public abstract void putLongArray(long[] srcArray, int srcOffsetLongs, int lengthLongs);
 
   /**
    * Puts the short value at the current position.
@@ -295,12 +296,12 @@ public abstract class WritableBuffer extends Buffer {
 
   /**
    * Puts the short array at the current position.
-   * Increments the position by <i>Short.BYTES * (lengthShorts - srcOffset)</i>.
+   * Increments the position by <i>Short.BYTES * (lengthShorts - srcOffsetShorts)</i>.
    * @param srcArray The source array.
-   * @param srcOffset offset in array units
+   * @param srcOffsetShorts offset in array units
    * @param lengthShorts number of array units to transfer
    */
-  public abstract void putShortArray(short[] srcArray, int srcOffset, int lengthShorts);
+  public abstract void putShortArray(short[] srcArray, int srcOffsetShorts, int lengthShorts);
 
   //OTHER WRITE METHODS XXX
   /**
@@ -321,7 +322,8 @@ public abstract class WritableBuffer extends Buffer {
   public abstract void clear();
 
   /**
-   * Fills this Buffer from position to end with the given byte value. The position will be set to end.
+   * Fills this Buffer from position to end with the given byte value. The position will be set to
+   * end.
    * @param value the given byte value
    */
   public abstract void fill(byte value);

--- a/src/main/java/com/yahoo/memory/WritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableBufferImpl.java
@@ -68,8 +68,7 @@ final class WritableBufferImpl extends BaseWritableBufferImpl {
   private WritableBuffer writableDuplicateImpl(final boolean localReadOnly) {
     checkValid();
     if (capacity == 0) { return ZERO_SIZE_BUFFER; }
-    final WritableBufferImpl wBufImpl =
-        new WritableBufferImpl(state, localReadOnly, originMemory);
+    final WritableBufferImpl wBufImpl = new WritableBufferImpl(state, localReadOnly, originMemory);
     wBufImpl.setStartPositionEnd(getStart(), getPosition(), getEnd());
     return wBufImpl;
   }

--- a/src/main/java/com/yahoo/memory/WritableDirectHandle.java
+++ b/src/main/java/com/yahoo/memory/WritableDirectHandle.java
@@ -25,7 +25,7 @@ public final class WritableDirectHandle implements WritableHandle {
   @SuppressWarnings("resource")
   static WritableDirectHandle allocateDirect(final ResourceState state) {
     final AllocateDirect allocatedDirect = AllocateDirect.allocateDirect(state.getCapacity(), state);
-    final WritableMemory wMem = new WritableMemoryImpl(state, false);
+    final WritableMemory wMem = BaseWritableMemoryImpl.newInstance(state, false);
     final WritableDirectHandle handle = new WritableDirectHandle(allocatedDirect, wMem);
     return handle;
   }

--- a/src/main/java/com/yahoo/memory/WritableMapHandle.java
+++ b/src/main/java/com/yahoo/memory/WritableMapHandle.java
@@ -25,7 +25,7 @@ public final class WritableMapHandle extends MapHandle implements WritableMap, W
   @SuppressWarnings("resource") //called from memory. state: RRO, cap, BO
   static WritableMapHandle map(final ResourceState state, final File file, final long fileOffset) {
     final AllocateDirectWritableMap dirMap = AllocateDirectWritableMap.map(state, file, fileOffset);
-    final BaseWritableMemoryImpl wMem = new WritableMemoryImpl(state, false);
+    final BaseWritableMemoryImpl wMem = BaseWritableMemoryImpl.newInstance(state, false);
     return new WritableMapHandle(dirMap, wMem);
   }
 

--- a/src/main/java/com/yahoo/memory/WritableMemory.java
+++ b/src/main/java/com/yahoo/memory/WritableMemory.java
@@ -73,7 +73,7 @@ public abstract class WritableMemory extends Memory {
    * @throws IOException file not found or RuntimeException, etc.
    */
   public static WritableMapHandle map(final File file, final long fileOffsetBytes,
-          final long capacityBytes, final ByteOrder byteOrder) throws IOException {
+      final long capacityBytes, final ByteOrder byteOrder) throws IOException {
     zeroCheck(capacityBytes, "Capacity");
     nullCheck(file, "file is null");
     negativeCheck(fileOffsetBytes, "File offset is negative");
@@ -186,7 +186,7 @@ public abstract class WritableMemory extends Memory {
    */
   public static WritableMemory allocate(final int capacityBytes) {
     final byte[] arr = new byte[capacityBytes];
-    return WritableMemoryImpl.newInstance(new ResourceState(arr, Prim.BYTE, arr.length), false);
+    return BaseWritableMemoryImpl.newInstance(new ResourceState(arr, Prim.BYTE, arr.length), false);
   }
 
   //ACCESS PRIMITIVE HEAP ARRAYS for write XXX
@@ -198,7 +198,8 @@ public abstract class WritableMemory extends Memory {
    * @return WritableMemory for write operations
    */
   public static WritableMemory wrap(final boolean[] arr) {
-    return WritableMemoryImpl.newInstance(new ResourceState(arr, Prim.BOOLEAN, arr.length), false);
+    return BaseWritableMemoryImpl.newInstance(new ResourceState(arr, Prim.BOOLEAN, arr.length),
+        false);
   }
 
   /**
@@ -240,7 +241,7 @@ public abstract class WritableMemory extends Memory {
     final ResourceState state = new ResourceState(arr, Prim.BYTE, lengthBytes);
     state.putRegionOffset(offsetBytes);
     state.putResourceOrder(byteOrder);
-    return WritableMemoryImpl.newInstance(state, false);
+    return BaseWritableMemoryImpl.newInstance(state, false);
   }
 
   /**
@@ -251,7 +252,7 @@ public abstract class WritableMemory extends Memory {
    * @return WritableMemory for write operations
    */
   public static WritableMemory wrap(final char[] arr) {
-    return WritableMemoryImpl.newInstance(new ResourceState(arr, Prim.CHAR, arr.length), false);
+    return BaseWritableMemoryImpl.newInstance(new ResourceState(arr, Prim.CHAR, arr.length), false);
   }
 
   /**
@@ -262,7 +263,8 @@ public abstract class WritableMemory extends Memory {
    * @return WritableMemory for write operations
    */
   public static WritableMemory wrap(final short[] arr) {
-    return WritableMemoryImpl.newInstance(new ResourceState(arr, Prim.SHORT, arr.length), false);
+    return BaseWritableMemoryImpl.newInstance(new ResourceState(arr, Prim.SHORT, arr.length),
+        false);
   }
 
   /**
@@ -273,7 +275,7 @@ public abstract class WritableMemory extends Memory {
    * @return WritableMemory for write operations
    */
   public static WritableMemory wrap(final int[] arr) {
-    return WritableMemoryImpl.newInstance(new ResourceState(arr, Prim.INT, arr.length), false);
+    return BaseWritableMemoryImpl.newInstance(new ResourceState(arr, Prim.INT, arr.length), false);
   }
 
   /**
@@ -284,7 +286,7 @@ public abstract class WritableMemory extends Memory {
    * @return WritableMemory for write operations
    */
   public static WritableMemory wrap(final long[] arr) {
-    return WritableMemoryImpl.newInstance(new ResourceState(arr, Prim.LONG, arr.length), false);
+    return BaseWritableMemoryImpl.newInstance(new ResourceState(arr, Prim.LONG, arr.length), false);
   }
 
   /**
@@ -295,7 +297,8 @@ public abstract class WritableMemory extends Memory {
    * @return WritableMemory for write operations
    */
   public static WritableMemory wrap(final float[] arr) {
-    return WritableMemoryImpl.newInstance(new ResourceState(arr, Prim.FLOAT, arr.length), false);
+    return BaseWritableMemoryImpl.newInstance(new ResourceState(arr, Prim.FLOAT, arr.length),
+        false);
   }
 
   /**
@@ -306,7 +309,8 @@ public abstract class WritableMemory extends Memory {
    * @return WritableMemory for write operations
    */
   public static WritableMemory wrap(final double[] arr) {
-    return WritableMemoryImpl.newInstance(new ResourceState(arr, Prim.DOUBLE, arr.length), false);
+    return BaseWritableMemoryImpl.newInstance(new ResourceState(arr, Prim.DOUBLE, arr.length),
+        false);
   }
   //END OF CONSTRUCTOR-TYPE METHODS
 
@@ -322,10 +326,10 @@ public abstract class WritableMemory extends Memory {
    * Puts the boolean array at the given offset
    * @param offsetBytes offset bytes relative to this <i>WritableMemory</i> start
    * @param srcArray The source array.
-   * @param srcOffset offset in array units
+   * @param srcOffsetBooleans offset in array units
    * @param lengthBooleans number of array units to transfer
    */
-  public abstract void putBooleanArray(long offsetBytes, boolean[] srcArray, int srcOffset,
+  public abstract void putBooleanArray(long offsetBytes, boolean[] srcArray, int srcOffsetBooleans,
           int lengthBooleans);
 
   /**
@@ -339,10 +343,10 @@ public abstract class WritableMemory extends Memory {
    * Puts the byte array at the given offset
    * @param offsetBytes offset bytes relative to this <i>WritableMemory</i> start
    * @param srcArray The source array.
-   * @param srcOffset offset in array units
+   * @param srcOffsetBytes offset in array units
    * @param lengthBytes number of array units to transfer
    */
-  public abstract void putByteArray(long offsetBytes, byte[] srcArray, int srcOffset,
+  public abstract void putByteArray(long offsetBytes, byte[] srcArray, int srcOffsetBytes,
           int lengthBytes);
 
   /**
@@ -356,10 +360,10 @@ public abstract class WritableMemory extends Memory {
    * Puts the char array at the given offset
    * @param offsetBytes offset bytes relative to this <i>WritableMemory</i> start
    * @param srcArray The source array.
-   * @param srcOffset offset in array units
+   * @param srcOffsetChars offset in array units
    * @param lengthChars number of array units to transfer
    */
-  public abstract void putCharArray(long offsetBytes, char[] srcArray, int srcOffset,
+  public abstract void putCharArray(long offsetBytes, char[] srcArray, int srcOffsetChars,
           int lengthChars);
 
   /**
@@ -387,11 +391,11 @@ public abstract class WritableMemory extends Memory {
    * Puts the double array at the given offset
    * @param offsetBytes offset bytes relative to this <i>WritableMemory</i> start
    * @param srcArray The source array.
-   * @param srcOffset offset in array units
+   * @param srcOffsetDoubles offset in array units
    * @param lengthDoubles number of array units to transfer
    */
   public abstract void putDoubleArray(long offsetBytes, double[] srcArray,
-          final int srcOffset, final int lengthDoubles);
+          final int srcOffsetDoubles, final int lengthDoubles);
 
   /**
    * Puts the float value at the given offset
@@ -404,11 +408,11 @@ public abstract class WritableMemory extends Memory {
    * Puts the float array at the given offset
    * @param offsetBytes offset bytes relative to this <i>WritableMemory</i> start
    * @param srcArray The source array.
-   * @param srcOffset offset in array units
+   * @param srcOffsetFloats offset in array units
    * @param lengthFloats number of array units to transfer
    */
   public abstract void putFloatArray(long offsetBytes, float[] srcArray,
-          final int srcOffset, final int lengthFloats);
+          final int srcOffsetFloats, final int lengthFloats);
 
   /**
    * Puts the int value at the given offset
@@ -421,11 +425,11 @@ public abstract class WritableMemory extends Memory {
    * Puts the int array at the given offset
    * @param offsetBytes offset bytes relative to this <i>WritableMemory</i> start
    * @param srcArray The source array.
-   * @param srcOffset offset in array units
+   * @param srcOffsetInts offset in array units
    * @param lengthInts number of array units to transfer
    */
   public abstract void putIntArray(long offsetBytes, int[] srcArray,
-          final int srcOffset, final int lengthInts);
+          final int srcOffsetInts, final int lengthInts);
 
   /**
    * Puts the long value at the given offset
@@ -438,11 +442,11 @@ public abstract class WritableMemory extends Memory {
    * Puts the long array at the given offset
    * @param offsetBytes offset bytes relative to this <i>WritableMemory</i> start
    * @param srcArray The source array.
-   * @param srcOffset offset in array units
+   * @param srcOffsetLongs offset in array units
    * @param lengthLongs number of array units to transfer
    */
   public abstract void putLongArray(long offsetBytes, long[] srcArray,
-          final int srcOffset, final int lengthLongs);
+          final int srcOffsetLongs, final int lengthLongs);
 
   /**
    * Puts the short value at the given offset
@@ -455,11 +459,11 @@ public abstract class WritableMemory extends Memory {
    * Puts the short array at the given offset
    * @param offsetBytes offset bytes relative to this <i>WritableMemory</i> start
    * @param srcArray The source array.
-   * @param srcOffset offset in array units
+   * @param srcOffsetShorts offset in array units
    * @param lengthShorts number of array units to transfer
    */
   public abstract void putShortArray(long offsetBytes, short[] srcArray,
-          final int srcOffset, final int lengthShorts);
+          final int srcOffsetShorts, final int lengthShorts);
 
   //Atomic Methods XXX
   /**

--- a/src/main/java/com/yahoo/memory/WritableMemory.java
+++ b/src/main/java/com/yahoo/memory/WritableMemory.java
@@ -46,8 +46,7 @@ public abstract class WritableMemory extends Memory {
     state.putByteBuffer(byteBuf); //sets resourceOrder
     AccessByteBuffer.wrap(state);
     final boolean ro = state.isResourceReadOnly() || localReadOnly;
-    final BaseWritableMemoryImpl impl = new WritableMemoryImpl(state, ro);
-    return impl;
+    return BaseWritableMemoryImpl.newInstance(state, ro);
   }
 
   //MAP XXX

--- a/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/WritableMemoryImpl.java
@@ -6,17 +6,14 @@
 package com.yahoo.memory;
 
 import static com.yahoo.memory.UnsafeUtil.ARRAY_CHAR_BASE_OFFSET;
-import static com.yahoo.memory.UnsafeUtil.ARRAY_CHAR_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_DOUBLE_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_DOUBLE_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_FLOAT_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_FLOAT_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_INT_BASE_OFFSET;
-import static com.yahoo.memory.UnsafeUtil.ARRAY_INT_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_LONG_BASE_OFFSET;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_LONG_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.ARRAY_SHORT_BASE_OFFSET;
-import static com.yahoo.memory.UnsafeUtil.ARRAY_SHORT_INDEX_SCALE;
 import static com.yahoo.memory.UnsafeUtil.CHAR_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.DOUBLE_SHIFT;
 import static com.yahoo.memory.UnsafeUtil.FLOAT_SHIFT;
@@ -27,7 +24,6 @@ import static com.yahoo.memory.UnsafeUtil.checkBounds;
 import static com.yahoo.memory.UnsafeUtil.unsafe;
 
 import java.nio.ByteOrder;
-import java.time.OffsetDateTime;
 
 /*
  * Developer notes: The heavier methods, such as put/get arrays, duplicate, region, clear, fill,

--- a/src/test/java/com/yahoo/memory/CopyMemoryTest.java
+++ b/src/test/java/com/yahoo/memory/CopyMemoryTest.java
@@ -5,7 +5,7 @@
 
 package com.yahoo.memory;
 
-import static com.yahoo.memory.CompareAndCopy.UNSAFE_COPY_THRESHOLD;
+import static com.yahoo.memory.CompareAndCopy.UNSAFE_COPY_THRESHOLD_BYTES;
 import static org.testng.Assert.assertEquals;
 
 import java.util.concurrent.ThreadLocalRandom;
@@ -103,27 +103,27 @@ public class CopyMemoryTest {
 
   @Test
   public void testOverlappingCopyLeftToRight() {
-    byte[] bytes = new byte[((UNSAFE_COPY_THRESHOLD * 5) / 2) + 1];
+    byte[] bytes = new byte[((UNSAFE_COPY_THRESHOLD_BYTES * 5) / 2) + 1];
     ThreadLocalRandom.current().nextBytes(bytes);
     byte[] referenceBytes = bytes.clone();
     Memory referenceMem = Memory.wrap(referenceBytes);
     WritableMemory mem = WritableMemory.wrap(bytes);
-    long copyLen = UNSAFE_COPY_THRESHOLD * 2;
-    mem.copyTo(0, mem, UNSAFE_COPY_THRESHOLD / 2, copyLen);
-    Assert.assertEquals(0, mem.compareTo(UNSAFE_COPY_THRESHOLD / 2, copyLen, referenceMem, 0,
+    long copyLen = UNSAFE_COPY_THRESHOLD_BYTES * 2;
+    mem.copyTo(0, mem, UNSAFE_COPY_THRESHOLD_BYTES / 2, copyLen);
+    Assert.assertEquals(0, mem.compareTo(UNSAFE_COPY_THRESHOLD_BYTES / 2, copyLen, referenceMem, 0,
         copyLen));
   }
 
   @Test
   public void testOverlappingCopyRightToLeft() {
-    byte[] bytes = new byte[((UNSAFE_COPY_THRESHOLD * 5) / 2) + 1];
+    byte[] bytes = new byte[((UNSAFE_COPY_THRESHOLD_BYTES * 5) / 2) + 1];
     ThreadLocalRandom.current().nextBytes(bytes);
     byte[] referenceBytes = bytes.clone();
     Memory referenceMem = Memory.wrap(referenceBytes);
     WritableMemory mem = WritableMemory.wrap(bytes);
-    long copyLen = UNSAFE_COPY_THRESHOLD * 2;
-    mem.copyTo(UNSAFE_COPY_THRESHOLD / 2, mem, 0, copyLen);
-    Assert.assertEquals(0, mem.compareTo(0, copyLen, referenceMem, UNSAFE_COPY_THRESHOLD / 2,
+    long copyLen = UNSAFE_COPY_THRESHOLD_BYTES * 2;
+    mem.copyTo(UNSAFE_COPY_THRESHOLD_BYTES / 2, mem, 0, copyLen);
+    Assert.assertEquals(0, mem.compareTo(0, copyLen, referenceMem, UNSAFE_COPY_THRESHOLD_BYTES / 2,
         copyLen));
   }
 

--- a/src/test/java/com/yahoo/memory/MemoryWriteToTest.java
+++ b/src/test/java/com/yahoo/memory/MemoryWriteToTest.java
@@ -22,8 +22,8 @@ public class MemoryWriteToTest {
     testWriteTo(createRandomBytesMemory(7));
     testWriteTo(createRandomBytesMemory(1023));
     testWriteTo(createRandomBytesMemory(10_000));
-    testWriteTo(createRandomBytesMemory(CompareAndCopy.UNSAFE_COPY_THRESHOLD * 5));
-    testWriteTo(createRandomBytesMemory((CompareAndCopy.UNSAFE_COPY_THRESHOLD * 5) + 10));
+    testWriteTo(createRandomBytesMemory(CompareAndCopy.UNSAFE_COPY_THRESHOLD_BYTES * 5));
+    testWriteTo(createRandomBytesMemory((CompareAndCopy.UNSAFE_COPY_THRESHOLD_BYTES * 5) + 10));
   }
 
   @Test
@@ -32,21 +32,21 @@ public class MemoryWriteToTest {
     testWriteTo(createRandomIntsMemory(7));
     testWriteTo(createRandomIntsMemory(1023));
     testWriteTo(createRandomIntsMemory(10_000));
-    testWriteTo(createRandomIntsMemory(CompareAndCopy.UNSAFE_COPY_THRESHOLD * 5));
-    testWriteTo(createRandomIntsMemory((CompareAndCopy.UNSAFE_COPY_THRESHOLD * 5) + 10));
+    testWriteTo(createRandomIntsMemory(CompareAndCopy.UNSAFE_COPY_THRESHOLD_BYTES * 5));
+    testWriteTo(createRandomIntsMemory((CompareAndCopy.UNSAFE_COPY_THRESHOLD_BYTES * 5) + 10));
   }
 
   @Test
   public void testOffHeap() throws IOException {
     try (WritableHandle handle =
-        WritableMemory.allocateDirect((CompareAndCopy.UNSAFE_COPY_THRESHOLD * 5) + 10)) {
+        WritableMemory.allocateDirect((CompareAndCopy.UNSAFE_COPY_THRESHOLD_BYTES * 5) + 10)) {
       WritableMemory mem = handle.get();
       testWriteTo(mem.region(0, 0));
       testOffHeap(mem, 7);
       testOffHeap(mem, 1023);
       testOffHeap(mem, 10_000);
-      testOffHeap(mem, CompareAndCopy.UNSAFE_COPY_THRESHOLD * 5);
-      testOffHeap(mem, (CompareAndCopy.UNSAFE_COPY_THRESHOLD * 5) + 10);
+      testOffHeap(mem, CompareAndCopy.UNSAFE_COPY_THRESHOLD_BYTES * 5);
+      testOffHeap(mem, (CompareAndCopy.UNSAFE_COPY_THRESHOLD_BYTES * 5) + 10);
     }
   }
 

--- a/src/test/java/com/yahoo/memory/WritableMemoryTest.java
+++ b/src/test/java/com/yahoo/memory/WritableMemoryTest.java
@@ -5,7 +5,7 @@
 
 package com.yahoo.memory;
 
-import static com.yahoo.memory.CompareAndCopy.UNSAFE_COPY_THRESHOLD;
+import static com.yahoo.memory.CompareAndCopy.UNSAFE_COPY_THRESHOLD_BYTES;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -111,7 +111,7 @@ public class WritableMemoryTest {
   public void checkLargeEquals() {
     // Size bigger than UNSAFE_COPY_MEMORY_THRESHOLD; size with "reminder" = 7, to test several
     // traits of the implementation
-    final int thresh = UNSAFE_COPY_THRESHOLD;
+    final int thresh = UNSAFE_COPY_THRESHOLD_BYTES;
     byte[] bytes1 = new byte[(thresh * 2) + 7];
     ThreadLocalRandom.current().nextBytes(bytes1);
     byte[] bytes2 = bytes1.clone();


### PR DESCRIPTION
Also:
 - Fixed a bug - BaseWritableBufferImpl.checkValidForWrite() used to check resource's read-only flag instead of local read-only flag
 - Some cleanup across the codebase, added final modifiers to methods and classes

I'll add tests in some time. But you could review the code already.