### PR TITLE
Some improvements and bug fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <!-- End of Environment Settings -->
 
     <dependencies>
-        <!-- Test Scope -->
+        <!-- Compile, Test Scope -->
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
@@ -148,14 +148,12 @@
             <version>3.5.0</version>
             <scope>test</scope>
         </dependency>
-        <!-- run locally for now
         <dependency>
           <groupId>com.google.code.findbugs</groupId>
           <artifactId>findbugs</artifactId>
           <version>3.0.1</version>
-          <scope>test</scope>
+          <scope>compile</scope>
         </dependency>
-        -->
     </dependencies>
 
     <build>

--- a/src/main/java/com/yahoo/memory/BaseWritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/BaseWritableBufferImpl.java
@@ -85,7 +85,7 @@ abstract class BaseWritableBufferImpl extends WritableBuffer {
 
   @Override
   public WritableBuffer writableRegion() {
-    return writableRegionImpl(getPosition(), getEnd() - getPosition(),  localReadOnly);
+    return writableRegionImpl(getPosition(), getEnd() - getPosition(), localReadOnly);
   }
 
   @Override

--- a/src/main/java/com/yahoo/memory/BaseWritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/BaseWritableBufferImpl.java
@@ -73,7 +73,7 @@ abstract class BaseWritableBufferImpl extends WritableBuffer {
   @Override
   public WritableBuffer writableDuplicate() {
     if (localReadOnly) {
-      throw new ReadOnlyException("Couldn't make a writable duplicate of a read-only Buffer");
+      throw new ReadOnlyException("Writable duplicate of a read-only Buffer is not allowed.");
     }
     return writableDuplicateImpl(false);
   }
@@ -89,7 +89,7 @@ abstract class BaseWritableBufferImpl extends WritableBuffer {
   @Override
   public WritableBuffer writableRegion() {
     if (localReadOnly) {
-      throw new ReadOnlyException("Couldn't create a writable region of a read-only Buffer");
+      throw new ReadOnlyException("Writable region of a read-only Buffer is not allowed.");
     }
     return writableRegionImpl(getPosition(), getEnd() - getPosition(), false);
   }
@@ -97,7 +97,7 @@ abstract class BaseWritableBufferImpl extends WritableBuffer {
   @Override
   public WritableBuffer writableRegion(final long offsetBytes, final long capacityBytes) {
     if (localReadOnly) {
-      throw new ReadOnlyException("Couldn't create a writable region of a read-only Buffer");
+      throw new ReadOnlyException("Writable region of a read-only Buffer is not allowed.");
     }
     return writableRegionImpl(offsetBytes, capacityBytes, false);
   }

--- a/src/main/java/com/yahoo/memory/BaseWritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/BaseWritableBufferImpl.java
@@ -72,7 +72,10 @@ abstract class BaseWritableBufferImpl extends WritableBuffer {
 
   @Override
   public WritableBuffer writableDuplicate() {
-    return writableDuplicateImpl(localReadOnly);
+    if (localReadOnly) {
+      throw new ReadOnlyException("Couldn't make a writable duplicate of a read-only Buffer");
+    }
+    return writableDuplicateImpl(false);
   }
 
   abstract WritableBuffer writableDuplicateImpl(boolean localReadOnly);
@@ -85,15 +88,22 @@ abstract class BaseWritableBufferImpl extends WritableBuffer {
 
   @Override
   public WritableBuffer writableRegion() {
-    return writableRegionImpl(getPosition(), getEnd() - getPosition(), localReadOnly);
+    if (localReadOnly) {
+      throw new ReadOnlyException("Couldn't create a writable region of a read-only Buffer");
+    }
+    return writableRegionImpl(getPosition(), getEnd() - getPosition(), false);
   }
 
   @Override
   public WritableBuffer writableRegion(final long offsetBytes, final long capacityBytes) {
-    return writableRegionImpl(offsetBytes, capacityBytes, localReadOnly);
+    if (localReadOnly) {
+      throw new ReadOnlyException("Couldn't create a writable region of a read-only Buffer");
+    }
+    return writableRegionImpl(offsetBytes, capacityBytes, false);
   }
 
-  abstract WritableBuffer writableRegionImpl(long offsetBytes, long capacityBytes, boolean localReadOnly);
+  abstract WritableBuffer writableRegionImpl(long offsetBytes, long capacityBytes,
+      boolean localReadOnly);
 
   //MEMORY XXX
   @Override

--- a/src/main/java/com/yahoo/memory/BaseWritableBufferImpl.java
+++ b/src/main/java/com/yahoo/memory/BaseWritableBufferImpl.java
@@ -67,7 +67,7 @@ abstract class BaseWritableBufferImpl extends WritableBuffer {
   //DUPLICATES XXX
   @Override
   public Buffer duplicate() {
-    return writableDuplicateImpl(false);
+    return writableDuplicateImpl(true);
   }
 
   @Override

--- a/src/main/java/com/yahoo/memory/BaseWritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/BaseWritableMemoryImpl.java
@@ -81,7 +81,7 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
   @Override
   public WritableMemory writableRegion(final long offsetBytes, final long capacityBytes) {
     if (localReadOnly) {
-      throw new ReadOnlyException("Couldn't create a writable region of a read-only Memory");
+      throw new ReadOnlyException("Writable region of a read-only Memory is not allowed.");
     }
     return writableRegionImpl(offsetBytes, capacityBytes, false);
   }
@@ -98,7 +98,7 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
   @Override
   public WritableBuffer asWritableBuffer() {
     if (localReadOnly) {
-      throw new ReadOnlyException("Couldn't wrap a read-only Memory as a writable Buffer");
+      throw new ReadOnlyException("Wrapping a read-only Memory as a writable Buffer is not allowed.");
     }
     return asWritableBufferImpl(false);
   }

--- a/src/main/java/com/yahoo/memory/BaseWritableMemoryImpl.java
+++ b/src/main/java/com/yahoo/memory/BaseWritableMemoryImpl.java
@@ -80,10 +80,14 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
 
   @Override
   public WritableMemory writableRegion(final long offsetBytes, final long capacityBytes) {
-    return writableRegionImpl(offsetBytes, capacityBytes, localReadOnly);
+    if (localReadOnly) {
+      throw new ReadOnlyException("Couldn't create a writable region of a read-only Memory");
+    }
+    return writableRegionImpl(offsetBytes, capacityBytes, false);
   }
 
-  abstract WritableMemory writableRegionImpl(long offsetBytes, long capacity, boolean localReadOnly);
+  abstract WritableMemory writableRegionImpl(long offsetBytes, long capacity,
+      boolean localReadOnly);
 
   //BUFFER XXX
   @Override
@@ -93,7 +97,10 @@ abstract class BaseWritableMemoryImpl extends WritableMemory {
 
   @Override
   public WritableBuffer asWritableBuffer() {
-    return asWritableBufferImpl(localReadOnly);
+    if (localReadOnly) {
+      throw new ReadOnlyException("Couldn't wrap a read-only Memory as a writable Buffer");
+    }
+    return asWritableBufferImpl(false);
   }
 
   abstract WritableBuffer asWritableBufferImpl(boolean localReadOnly);

--- a/src/main/java/com/yahoo/memory/ReadOnlyException.java
+++ b/src/main/java/com/yahoo/memory/ReadOnlyException.java
@@ -10,7 +10,7 @@ package com.yahoo.memory;
  *
  * @author Praveenkumar Venkatesan
  */
-public class ReadOnlyException extends RuntimeException {
+public class ReadOnlyException extends IllegalStateException {
     private static final long serialVersionUID = 1L;
 
     public ReadOnlyException(final String message) {

--- a/src/main/java/com/yahoo/memory/ReadOnlyException.java
+++ b/src/main/java/com/yahoo/memory/ReadOnlyException.java
@@ -10,7 +10,7 @@ package com.yahoo.memory;
  *
  * @author Praveenkumar Venkatesan
  */
-public class ReadOnlyException extends IllegalStateException {
+public class ReadOnlyException extends UnsupportedOperationException {
     private static final long serialVersionUID = 1L;
 
     public ReadOnlyException(final String message) {

--- a/src/main/java/com/yahoo/memory/WritableBuffer.java
+++ b/src/main/java/com/yahoo/memory/WritableBuffer.java
@@ -35,8 +35,8 @@ public abstract class WritableBuffer extends Buffer {
 
   //First creates a WritableMemory so that it can be cached into the target buffer.
   static WritableBuffer wrapBB(final ByteBuffer byteBuf, final boolean localReadOnly) {
-    final WritableMemory wmem = WritableMemory.wrapBB(byteBuf, localReadOnly);
-    final WritableBuffer wbuf = wmem.asWritableBuffer();
+    final BaseWritableMemoryImpl wmem = WritableMemory.wrapBB(byteBuf, localReadOnly);
+    final WritableBuffer wbuf = wmem.asWritableBufferImpl(localReadOnly);
     wbuf.setStartPositionEnd(0, byteBuf.position(), byteBuf.limit());
     return wbuf;
   }

--- a/src/main/java/com/yahoo/memory/WritableMemory.java
+++ b/src/main/java/com/yahoo/memory/WritableMemory.java
@@ -40,7 +40,7 @@ public abstract class WritableMemory extends Memory {
     return wrapBB(byteBuf, false);
   }
 
-  static WritableMemory wrapBB(final ByteBuffer byteBuf, final boolean localReadOnly) {
+  static BaseWritableMemoryImpl wrapBB(final ByteBuffer byteBuf, final boolean localReadOnly) {
     if (byteBuf.capacity() == 0) { return ZERO_SIZE_MEMORY; }
     final ResourceState state = new ResourceState(byteBuf.isReadOnly());//sets resourceIsReadOnly
     state.putByteBuffer(byteBuf); //sets resourceOrder

--- a/src/test/java/com/yahoo/memory/Buffer2Test.java
+++ b/src/test/java/com/yahoo/memory/Buffer2Test.java
@@ -366,12 +366,12 @@ public class Buffer2Test {
 
   @Test
   public void testWritableDuplicate() {
-    WritableMemory wmem = WritableMemory.wrap(new byte[0]);
+    WritableMemory wmem = WritableMemory.wrap(new byte[1]);
     WritableBuffer wbuf = wmem.asWritableBuffer();
     WritableBuffer wbuf2 = wbuf.writableDuplicate();
-    assertEquals(wbuf2.capacity, 0);
+    assertEquals(wbuf2.capacity, 1);
     Buffer buf = wmem.asBuffer();
-    assertEquals(buf.capacity, 0);
+    assertEquals(buf.capacity, 1);
   }
 
   @Test

--- a/src/test/java/com/yahoo/memory/BufferReadWriteSafetyTest.java
+++ b/src/test/java/com/yahoo/memory/BufferReadWriteSafetyTest.java
@@ -148,4 +148,10 @@ public class BufferReadWriteSafetyTest {
     WritableBuffer buf = (WritableBuffer) WritableMemory.allocate(8).asWritableBuffer().region();
     buf.putInt(1);
   }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testWritableBufferDuplicate() {
+    WritableBuffer buf = (WritableBuffer) WritableMemory.allocate(8).asWritableBuffer().duplicate();
+    buf.putInt(1);
+  }
 }

--- a/src/test/java/com/yahoo/memory/BufferTest.java
+++ b/src/test/java/com/yahoo/memory/BufferTest.java
@@ -73,16 +73,8 @@ public class BufferTest {
     assertEquals(buffZeroLengthArrayWrap.getCapacity(), 0);
     // check 0 length array wraps
     List<Buffer> buffersToCheck = Lists.newArrayList();
-    buffersToCheck.add(WritableMemory.allocate(0).asWritableBuffer());
+    buffersToCheck.add(WritableMemory.allocate(0).asBuffer());
     buffersToCheck.add(WritableBuffer.wrap(ByteBuffer.allocate(0)));
-    buffersToCheck.add(WritableMemory.wrap(new boolean[0]).asWritableBuffer());
-    buffersToCheck.add(WritableMemory.wrap(new byte[0]).asWritableBuffer());
-    buffersToCheck.add(WritableMemory.wrap(new char[0]).asWritableBuffer());
-    buffersToCheck.add(WritableMemory.wrap(new short[0]).asWritableBuffer());
-    buffersToCheck.add(WritableMemory.wrap(new int[0]).asWritableBuffer());
-    buffersToCheck.add(WritableMemory.wrap(new long[0]).asWritableBuffer());
-    buffersToCheck.add(WritableMemory.wrap(new float[0]).asWritableBuffer());
-    buffersToCheck.add(WritableMemory.wrap(new double[0]).asWritableBuffer());
     buffersToCheck.add(Buffer.wrap(ByteBuffer.allocate(0)));
     buffersToCheck.add(Memory.wrap(new boolean[0]).asBuffer());
     buffersToCheck.add(Memory.wrap(new byte[0]).asBuffer());

--- a/src/test/java/com/yahoo/memory/NioBitsTest.java
+++ b/src/test/java/com/yahoo/memory/NioBitsTest.java
@@ -27,9 +27,9 @@ public class NioBitsTest {
   public void checkGetAtomicFields() {
     long cap = 1024L + Integer.MAX_VALUE;
     printStats();
-    NioBits.reserveMemory(cap);
+    NioBits.reserveMemory(cap, cap);
     printStats();
-    NioBits.unreserveMemory(cap);
+    NioBits.unreserveMemory(cap, cap);
     printStats();
   }
 

--- a/src/test/java/com/yahoo/memory/NonNativeWritableBufferImplTest.java
+++ b/src/test/java/com/yahoo/memory/NonNativeWritableBufferImplTest.java
@@ -232,12 +232,12 @@ public class NonNativeWritableBufferImplTest {
   public void checkDuplicateZeros() {
     byte[] bArr = new byte[0];
     WritableMemory wmem = WritableMemory.wrap(bArr, ByteOrder.BIG_ENDIAN);
-    WritableBuffer wbuf = wmem.asWritableBuffer();
-    WritableBuffer wdup = wbuf.writableDuplicate();
-    assertEquals(wdup.getResourceOrder(), ByteOrder.LITTLE_ENDIAN);
+    Buffer buf = wmem.asBuffer();
+    Buffer dup = buf.duplicate();
+    assertEquals(dup.getResourceOrder(), ByteOrder.LITTLE_ENDIAN);
 
-    WritableBuffer wreg = wbuf.writableRegion();
-    assertEquals(wreg.getResourceOrder(), ByteOrder.LITTLE_ENDIAN);
+    Buffer reg = buf.region();
+    assertEquals(reg.getResourceOrder(), ByteOrder.LITTLE_ENDIAN);
   }
 
 }

--- a/src/test/java/com/yahoo/memory/NonNativeWritableMemoryImplTest.java
+++ b/src/test/java/com/yahoo/memory/NonNativeWritableMemoryImplTest.java
@@ -195,8 +195,8 @@ public class NonNativeWritableMemoryImplTest {
   public void checkRegionZeros() {
     byte[] bArr = new byte[0];
     WritableMemory wmem = WritableMemory.wrap(bArr, ByteOrder.BIG_ENDIAN);
-    WritableMemory wreg = wmem.writableRegion(0, wmem.getCapacity());
-    assertEquals(wreg.getResourceOrder(), ByteOrder.LITTLE_ENDIAN);
+    Memory reg = wmem.region(0, wmem.getCapacity());
+    assertEquals(reg.getResourceOrder(), ByteOrder.LITTLE_ENDIAN);
   }
 
 }

--- a/src/test/java/com/yahoo/memory/ResourceStateTest.java
+++ b/src/test/java/com/yahoo/memory/ResourceStateTest.java
@@ -15,6 +15,8 @@ import java.nio.ByteOrder;
 
 import org.testng.annotations.Test;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public class ResourceStateTest {
 
   @Test
@@ -30,6 +32,7 @@ public class ResourceStateTest {
     assertTrue(state.isSwapBytes());
   }
 
+  @SuppressFBWarnings(value="NP_NULL_PARAM_DEREF_ALL_TARGETS_DANGEROUS", justification="Test")
   @Test
   public void checkExceptions() {
     ResourceState state = new ResourceState(false);
@@ -41,12 +44,12 @@ public class ResourceStateTest {
       //ok
     }
 
-    //    try {
-    //      state.putByteBuffer(null); //FindBugs does not like this
-    //      fail();
-    //    } catch (IllegalArgumentException e) {
-    //      //ok
-    //    }
+    try {
+      state.putByteBuffer(null);
+      fail();
+    } catch (IllegalArgumentException e) {
+      //ok
+    }
 
     try {
       state.putRegionOffset( -16L);

--- a/src/test/java/com/yahoo/memory/UnsafeUtilTest.java
+++ b/src/test/java/com/yahoo/memory/UnsafeUtilTest.java
@@ -27,7 +27,7 @@ public class UnsafeUtilTest {
       final long one = JDK7Compatible.getAndAddLong(byteArr, 16, 1L);
       assertEquals(one, 1L);
 
-      final long two = JDK7Compatible.getAndSetLong(byteArr,  16, 3L);
+      final long two = JDK7Compatible.getAndSetLong(byteArr, 16, 3L);
       assertEquals(two, 2L);
       assertEquals(byteArr[0], 3);
 

--- a/src/test/java/com/yahoo/memory/WritableBufferImplTest.java
+++ b/src/test/java/com/yahoo/memory/WritableBufferImplTest.java
@@ -12,6 +12,7 @@ import static org.testng.Assert.assertTrue;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class WritableBufferImplTest {
@@ -473,19 +474,75 @@ public class WritableBufferImplTest {
     assertEquals(reg.getCapacity(), 0);
   }
 
-  @SuppressWarnings("unused")
   @Test
   public void checkAsWritableMemoryRO() {
     ByteBuffer bb = ByteBuffer.allocate(64);
     WritableBuffer wbuf = WritableBuffer.wrap(bb);
+    @SuppressWarnings("unused")
     WritableMemory wmem = wbuf.asWritableMemory();
 
     try {
       Buffer buf = Buffer.wrap(bb);
       wbuf = (WritableBuffer) buf;
-      wmem = wbuf.asWritableMemory();
-    } catch (ReadOnlyException e) {
-      //OK
+      @SuppressWarnings("unused")
+      WritableMemory wmem2 = wbuf.asWritableMemory();
+      Assert.fail();
+    } catch (ReadOnlyException expected) {
+      // expected
+    }
+  }
+
+  @Test
+  public void checkWritableDuplicateRO() {
+    ByteBuffer bb = ByteBuffer.allocate(64);
+    WritableBuffer wbuf = WritableBuffer.wrap(bb);
+    @SuppressWarnings("unused")
+    WritableBuffer wdup = wbuf.writableDuplicate();
+
+    try {
+      Buffer buf = Buffer.wrap(bb);
+      wbuf = (WritableBuffer) buf;
+      @SuppressWarnings("unused")
+      WritableBuffer wdup2 = wbuf.writableDuplicate();
+      Assert.fail();
+    } catch (ReadOnlyException expected) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void checkWritableRegionRO() {
+    ByteBuffer bb = ByteBuffer.allocate(64);
+    WritableBuffer wbuf = WritableBuffer.wrap(bb);
+    @SuppressWarnings("unused")
+    WritableBuffer wreg = wbuf.writableRegion();
+
+    try {
+      Buffer buf = Buffer.wrap(bb);
+      wbuf = (WritableBuffer) buf;
+      @SuppressWarnings("unused")
+      WritableBuffer wreg2 = wbuf.writableRegion();
+      Assert.fail();
+    } catch (ReadOnlyException expected) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void checkWritableRegionWithParamsRO() {
+    ByteBuffer bb = ByteBuffer.allocate(64);
+    WritableBuffer wbuf = WritableBuffer.wrap(bb);
+    @SuppressWarnings("unused")
+    WritableBuffer wreg = wbuf.writableRegion(0, 1);
+
+    try {
+      Buffer buf = Buffer.wrap(bb);
+      wbuf = (WritableBuffer) buf;
+      @SuppressWarnings("unused")
+      WritableBuffer wreg2 = wbuf.writableRegion(0, 1);
+      Assert.fail();
+    } catch (ReadOnlyException expected) {
+      // ignore
     }
   }
 

--- a/src/test/java/com/yahoo/memory/WritableDirectCopyTest.java
+++ b/src/test/java/com/yahoo/memory/WritableDirectCopyTest.java
@@ -20,19 +20,19 @@ public class WritableDirectCopyTest {
   @Test
   public void checkCopyWithinNativeSmall() {
     int memCapacity = 64;
-    int half = memCapacity/2;
+    int half = memCapacity / 2;
     try (WritableHandle wrh = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem = wrh.get();
       mem.clear();
 
-      for (int i=0; i<half; i++) { //fill first half
+      for (int i = 0; i < half; i++) { //fill first half
         mem.putByte(i, (byte) i);
       }
 
       mem.copyTo(0, mem, half, half);
 
-      for (int i=0; i<half; i++) {
-        assertEquals(mem.getByte(i+half), (byte) i);
+      for (int i = 0; i < half; i++) {
+        assertEquals(mem.getByte(i + half), (byte) i);
       }
     }
   }
@@ -47,14 +47,14 @@ public class WritableDirectCopyTest {
       WritableMemory mem = wrh.get();
       mem.clear();
 
-      for (int i=0; i < halfLongs; i++) {
-        mem.putLong(i*8,  i);
+      for (int i = 0; i < halfLongs; i++) {
+        mem.putLong(i * 8, i);
       }
 
       mem.copyTo(0, mem, halfBytes, halfBytes);
 
-      for (int i=0; i < halfLongs; i++) {
-        assertEquals(mem.getLong((i + halfLongs)*8), i);
+      for (int i = 0; i < halfLongs; i++) {
+        assertEquals(mem.getLong((i + halfLongs) * 8), i);
       }
     }
   }
@@ -67,11 +67,11 @@ public class WritableDirectCopyTest {
       mem.clear();
       //println(mem.toHexString("Clear 64", 0, memCapacity));
 
-      for (int i=0; i < (memCapacity/2); i++) {
+      for (int i = 0; i < (memCapacity / 2); i++) {
         mem.putByte(i, (byte) i);
       }
       //println(mem.toHexString("Set 1st 32 to ints ", 0, memCapacity));
-      mem.copyTo(0, mem, memCapacity/4, memCapacity/2);  //overlap is OK
+      mem.copyTo(0, mem, memCapacity / 4, memCapacity / 2);  //overlap is OK
     }
   }
 
@@ -82,8 +82,7 @@ public class WritableDirectCopyTest {
       WritableMemory mem = wrh.get();
       mem.copyTo(32, mem, 32, 33);  //hit source bound check
       fail("Did Not Catch Assertion Error: source bound");
-    }
-    catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException e) {
       //pass
     }
   }
@@ -95,8 +94,7 @@ public class WritableDirectCopyTest {
       WritableMemory mem = wrh.get();
       mem.copyTo(0, mem, 32, 33);  //hit dst bound check
       fail("Did Not Catch Assertion Error: dst bound");
-    }
-    catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException e) {
       //pass
     }
   }
@@ -106,18 +104,17 @@ public class WritableDirectCopyTest {
     int memCapacity = 64;
 
     try (WritableHandle wrh1 = WritableMemory.allocateDirect(memCapacity);
-        WritableHandle wrh2 = WritableMemory.allocateDirect(memCapacity))
-    {
+         WritableHandle wrh2 = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem1 = wrh1.get();
       WritableMemory mem2 = wrh2.get();
 
-      for (int i=0; i < memCapacity; i++) {
+      for (int i = 0; i < memCapacity; i++) {
         mem1.putByte(i, (byte) i);
       }
       mem2.clear();
       mem1.copyTo(0, mem2, 0, memCapacity);
 
-      for (int i=0; i<memCapacity; i++) {
+      for (int i = 0; i < memCapacity; i++) {
         assertEquals(mem2.getByte(i), (byte) i);
       }
       wrh1.close();
@@ -127,24 +124,23 @@ public class WritableDirectCopyTest {
 
   @Test
   public void checkCopyCrossNativeLarge() {
-    int memCapacity = (2<<20) + 64;
+    int memCapacity = (2 << 20) + 64;
     int memCapLongs = memCapacity / 8;
 
     try (WritableHandle wrh1 = WritableMemory.allocateDirect(memCapacity);
-        WritableHandle wrh2 = WritableMemory.allocateDirect(memCapacity))
-    {
+         WritableHandle wrh2 = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem1 = wrh1.get();
       WritableMemory mem2 = wrh2.get();
 
-      for (int i=0; i < memCapLongs; i++) {
-        mem1.putLong(i*8, i);
+      for (int i = 0; i < memCapLongs; i++) {
+        mem1.putLong(i * 8, i);
       }
       mem2.clear();
 
       mem1.copyTo(0, mem2, 0, memCapacity);
 
-      for (int i=0; i<memCapLongs; i++) {
-        assertEquals(mem2.getLong(i*8), i);
+      for (int i = 0; i < memCapLongs; i++) {
+        assertEquals(mem2.getLong(i * 8), i);
       }
     }
   }
@@ -155,15 +151,15 @@ public class WritableDirectCopyTest {
     try (WritableHandle wrh1 = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem1 = wrh1.get();
 
-      for (int i= 0; i < mem1.getCapacity(); i++) {
+      for (int i = 0; i < mem1.getCapacity(); i++) {
         mem1.putByte(i, (byte) i);
       }
 
       WritableMemory mem2 = WritableMemory.allocate(memCapacity);
       mem1.copyTo(8, mem2, 16, 16);
 
-      for (int i=0; i<16; i++) {
-        assertEquals(mem1.getByte(8+i), mem2.getByte(16+i));
+      for (int i = 0; i < 16; i++) {
+        assertEquals(mem1.getByte(8 + i), mem2.getByte(16 + i));
       }
       //println(mem2.toHexString("Mem2", 0, (int)mem2.getCapacity()));
     }
@@ -176,7 +172,7 @@ public class WritableDirectCopyTest {
     try (WritableHandle wrh1 = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem1 = wrh1.get();
 
-      for (int i= 0; i < mem1.getCapacity(); i++) {
+      for (int i = 0; i < mem1.getCapacity(); i++) {
         mem1.putByte(i, (byte) i);
       }
       //println(mem1.toHexString("Mem1", 0, (int)mem1.getCapacity()));
@@ -188,9 +184,9 @@ public class WritableDirectCopyTest {
       //println(reg2.toHexString("Reg2", 0, (int)reg2.getCapacity()));
       reg1.copyTo(0, reg2, 0, 16);
 
-      for (int i=0; i<16; i++) {
+      for (int i = 0; i < 16; i++) {
         assertEquals(reg1.getByte(i), reg2.getByte(i));
-        assertEquals(mem1.getByte(8+i), mem1.getByte(24+i));
+        assertEquals(mem1.getByte(8 + i), mem1.getByte(24 + i));
       }
       //println(mem1.toHexString("Mem1", 0, (int)mem1.getCapacity()));
     }
@@ -202,7 +198,7 @@ public class WritableDirectCopyTest {
     try (WritableHandle wrh1 = WritableMemory.allocateDirect(memCapacity)) {
       WritableMemory mem1 = wrh1.get();
 
-      for (int i= 0; i < mem1.getCapacity(); i++) { //fill with numbers
+      for (int i = 0; i < mem1.getCapacity(); i++) { //fill with numbers
         mem1.putByte(i, (byte) i);
       }
       //println(mem1.toHexString("Mem1", 0, (int)mem1.getCapacity()));
@@ -227,7 +223,7 @@ public class WritableDirectCopyTest {
 
   @Test
   public void printlnTest() {
-    println("PRINTING: "+this.getClass().getName());
+    println("PRINTING: " + this.getClass().getName());
   }
 
   /**

--- a/src/test/java/com/yahoo/memory/WritableMemoryImplTest.java
+++ b/src/test/java/com/yahoo/memory/WritableMemoryImplTest.java
@@ -659,6 +659,20 @@ public class WritableMemoryImplTest {
     assertEquals(wbuf.getEnd(), 64);
   }
 
+  @Test(expectedExceptions = ReadOnlyException.class)
+  public void checkAsWritableRegionRO() {
+    ByteBuffer byteBuf = ByteBuffer.allocate(64);
+    WritableMemory wmem = (WritableMemory) Memory.wrap(byteBuf);
+    wmem.writableRegion(0, 1);
+  }
+
+  @Test(expectedExceptions = ReadOnlyException.class)
+  public void checkAsWritableBufferRO() {
+    ByteBuffer byteBuf = ByteBuffer.allocate(64);
+    WritableMemory wmem = (WritableMemory) Memory.wrap(byteBuf);
+    wmem.asWritableBuffer();
+  }
+
   @Test
   public void printlnTest() {
     println("PRINTING: "+this.getClass().getName());

--- a/src/test/java/com/yahoo/memory/WritableMemoryImplTest.java
+++ b/src/test/java/com/yahoo/memory/WritableMemoryImplTest.java
@@ -242,7 +242,7 @@ public class WritableMemoryImplTest {
       mem.clear();
 
       for (int i=0; i < halfLongs; i++) {
-        mem.putLong(i*8,  i);
+        mem.putLong(i*8, i);
       }
 
       mem.copyTo(0, mem, halfBytes, halfBytes);
@@ -568,7 +568,7 @@ public class WritableMemoryImplTest {
     assertEquals(comp, -1);
     comp = mem3.compareTo(0, 5, mem1, 0, 4);
     assertEquals(comp, 1);
-    comp = mem3.compareTo(0,  5, mem4, 0, 5);
+    comp = mem3.compareTo(0, 5, mem4, 0, 5);
     assertEquals(comp, 0);
     comp = mem3.compareTo(0, 4, mem4, 1, 4);
     assertEquals(comp, -1);

--- a/src/test/java/com/yahoo/memory/WritableMemoryTest.java
+++ b/src/test/java/com/yahoo/memory/WritableMemoryTest.java
@@ -84,7 +84,7 @@ public class WritableMemoryTest {
     assertTrue(wmem1.equalTo(0, wmem2, 0, len));
     wmem2.putByte(0, (byte) 10);
     assertFalse(wmem1.equalTo(0, wmem2, 0, len));
-    wmem2.putByte(0,  (byte) 0);
+    wmem2.putByte(0, (byte) 0);
     wmem2.putByte(len - 2, (byte) 0);
     assertFalse(wmem1.equalTo(0, wmem2, 0, len - 1));
   }
@@ -145,7 +145,7 @@ public class WritableMemoryTest {
     owner.putInt(0, 1); //But owner can write
     ((WritableMemory)client1).putInt(0, 2); //Client1 can write, but with explicit effort.
     Memory client2 = owner.region(0, owner.getCapacity()); //client2 cannot write (no API)
-    owner.putInt(0,  3); //But Owner should be able to write
+    owner.putInt(0, 3); //But Owner should be able to write
   }
 
   @Test

--- a/src/test/java/com/yahoo/memory/WritableMemoryTest.java
+++ b/src/test/java/com/yahoo/memory/WritableMemoryTest.java
@@ -50,11 +50,13 @@ public class WritableMemoryTest {
     wmem.getByteArray(0, srcAndDst, 64, 64);  //non-overlapping
   }
 
+  @SuppressWarnings({"EqualsWithItself", "SelfEquals"})
+  //SelfEquals for Plexus, EqualsWithItself for IntelliJ
   @Test
   public void checkEquals() {
     int len = 7;
     WritableMemory wmem1 = WritableMemory.allocate(len);
-    //assertTrue(wmem1.equals(wmem1)); //intentionally ignoring this check
+    assertTrue(wmem1.equals(wmem1));
 
     WritableMemory wmem2 = WritableMemory.allocate(len + 1);
     assertFalse(wmem1.equals(wmem2));


### PR DESCRIPTION
 - Fix a bug in `BaseWritableBufferImpl`
 - Make `writableRegion()`, `writableDuplicate()`, and `asWritableBuffer()` methods to throw ReadOnlyException eagerly
 - More accurate `NioBits.reserveMemory()` and `NioBits.unreserveMemory()`