### PR TITLE
Add BaseState.longHashCode(off, len) and XxHashTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,13 @@
           <version>${findbugs.version}</version>
           <scope>test</scope>
         </dependency>
+        <dependency>
+            <!-- Used for xxHash testing -->
+            <groupId>net.openhft</groupId>
+            <artifactId>zero-allocation-hashing</artifactId>
+            <version>0.8</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/yahoo/memory/BaseState.java
+++ b/src/main/java/com/yahoo/memory/BaseState.java
@@ -230,12 +230,13 @@ abstract class BaseState {
   }
 
   /**
-   * Returns the 64-bit hash code of the specified range of bytes in this object.
+   * Returns the 64-bit hash of the sequence of bytes in this object specified by 
+   * <i>offsetBytes</i> and <i>lengthBytes</i>.
    *
-   * @param offsetBytes the offset to the first byte of the byte sequence in this object to compute
-   *                    hash code of
-   * @param lengthBytes the length of the byte sequence to compute hash code of
-   * @return the 64-bit hash code of the specified range of bytes in this object.
+   * @param offsetBytes the given offset in bytes to the first byte of the byte sequence.
+   * @param lengthBytes the given length in bytes of the byte sequence.
+   * @return the 64-bit hash of the sequence of bytes in this object specified by 
+   * <i>offsetBytes</i> and <i>lengthBytes</i>.
    */
   public final long longHashCode(final long offsetBytes, final long lengthBytes) {
     return CompareAndCopy.longHashCode(this, offsetBytes, lengthBytes);

--- a/src/main/java/com/yahoo/memory/BaseState.java
+++ b/src/main/java/com/yahoo/memory/BaseState.java
@@ -212,20 +212,33 @@ abstract class BaseState {
   }
 
   /**
-   * Returns the hashCode of this class.
-   *
-   * <p>The hash code of this class depends upon all of its contents.
-   * Because of this, it is inadvisable to use these objects as keys in hash maps
-   * or similar data structures unless it is known that their contents will not change.</p>
+   * Returns the hash code of this object depends upon all of its contents. Because of this, it is
+   * inadvisable to use these objects as keys in hash maps or similar data structures unless it is
+   * known that their contents will not change.</p>
    *
    * <p>If it is desirable to use these objects in a hash map depending only on object identity,
    * than the {@link java.util.IdentityHashMap} can be used.</p>
    *
-   * @return the hashCode of this class.
+   * <p>Use {@link #longHashCode(long, long) longHashCode(0, getCapacity())} if a 64-bit hash code
+   * is required.</p>
+   *
+   * @return the hashCode of this object.
    */
   @Override
   public final int hashCode() {
     return CompareAndCopy.hashCode(this);
+  }
+
+  /**
+   * Returns the 64-bit hash code of the specified range of bytes in this object.
+   *
+   * @param offsetBytes the offset to the first byte of the byte sequence in this object to compute
+   *                    hash code of
+   * @param lengthBytes the length of the byte sequence to compute hash code of
+   * @return the 64-bit hash code of the specified range of bytes in this object.
+   */
+  public final long longHashCode(final long offsetBytes, final long lengthBytes) {
+    return CompareAndCopy.longHashCode(this, offsetBytes, lengthBytes);
   }
 
   /**

--- a/src/main/java/com/yahoo/memory/CompareAndCopy.java
+++ b/src/main/java/com/yahoo/memory/CompareAndCopy.java
@@ -108,13 +108,30 @@ final class CompareAndCopy {
     return true;
   }
 
+  static int hashCode(final BaseState state) {
+    state.checkValid();
+    final long lengthBytes = state.getCapacity();
+    long offsetBytes = state.getCumulativeOffset();
+    final Object unsafeObj = state.getUnsafeObject(); //could be null
+
+    long hash = xxHash64(unsafeObj, offsetBytes, lengthBytes);
+    return (int) hash;
+  }
+
+  static long longHashCode(final BaseState state, final long offsetBytes, final long lengthBytes) {
+    state.checkValid();
+    checkBounds(offsetBytes, lengthBytes, state.getCapacity());
+    long cumulativeOffset = state.getCumulativeOffset(offsetBytes);
+    final Object unsafeObj = state.getUnsafeObject(); //could be null
+    return xxHash64(unsafeObj, cumulativeOffset, lengthBytes);
+  }
+
   // Unsigned, 64-bit primes
   private static final long P1 = -7046029288634856825L;
   private static final long P2 = -4417276706812531889L;
   private static final long P3 =  1609587929392839161L;
   private static final long P4 = -8796714831421723037L;
   private static final long P5 =  2870177450012600261L;
-
 
   /**
    * The hashCode is computed using the XxHash algorithm, a fast, non-cryptographic, 64-bit hash
@@ -132,12 +149,7 @@ final class CompareAndCopy {
    * <a href="https://github.com/OpenHFT/Zero-Allocation-Hashing/blob/master/src/main/java/net/openhft/hashing/XxHash.java">
    * OpenHFT/Zero-Allocation-Hashing</a>, which has an Apache 2 license as does this site.
    */
-  static int hashCode(final BaseState state) {
-    state.checkValid();
-    final long lengthBytes = state.getCapacity();
-    long offsetBytes = state.getCumulativeOffset();
-    final Object arr = state.getUnsafeObject(); //could be null
-
+  private static long xxHash64(final Object unsafeObj, long offsetBytes, final long lengthBytes) {
     long hash;
     long remaining = lengthBytes;
 
@@ -145,22 +157,22 @@ final class CompareAndCopy {
       long v1 = P1 + P2;
       long v2 = P2;
       long v3 = 0;
-      long v4 = P1;
+      long v4 = -P1;
 
       do {
-        v1 += unsafe.getLong(arr, offsetBytes) * P2;
+        v1 += unsafe.getLong(unsafeObj, offsetBytes) * P2;
         v1 = Long.rotateLeft(v1, 31);
         v1 *= P1;
 
-        v2 += unsafe.getLong(arr, offsetBytes + 8L) * P2;
+        v2 += unsafe.getLong(unsafeObj, offsetBytes + 8L) * P2;
         v2 = Long.rotateLeft(v2, 31);
         v2 *= P1;
 
-        v3 += unsafe.getLong(arr, offsetBytes + 16L) * P2;
+        v3 += unsafe.getLong(unsafeObj, offsetBytes + 16L) * P2;
         v3 = Long.rotateLeft(v3, 31);
         v3 *= P1;
 
-        v4 += unsafe.getLong(arr, offsetBytes + 24L) * P2;
+        v4 += unsafe.getLong(unsafeObj, offsetBytes + 24L) * P2;
         v4 = Long.rotateLeft(v4, 31);
         v4 *= P1;
 
@@ -204,7 +216,7 @@ final class CompareAndCopy {
     hash += lengthBytes;
 
     while (remaining >= 8) {
-      long k1 = unsafe.getLong(arr, offsetBytes);
+      long k1 = unsafe.getLong(unsafeObj, offsetBytes);
       k1 *= P2;
       k1 = Long.rotateLeft(k1, 31);
       k1 *= P1;
@@ -215,14 +227,14 @@ final class CompareAndCopy {
     }
 
     if (remaining >= 4) { //treat as unsigned ints
-      hash ^= (unsafe.getInt(arr, offsetBytes) & 0XFFFF_FFFFL) * P1;
+      hash ^= (unsafe.getInt(unsafeObj, offsetBytes) & 0XFFFF_FFFFL) * P1;
       hash = (Long.rotateLeft(hash, 23) * P2) + P3;
       offsetBytes += 4;
       remaining -= 4;
     }
 
     while (remaining != 0) { //treat as unsigned bytes
-      hash ^= (unsafe.getByte(arr, offsetBytes) & 0XFFL) * P5;
+      hash ^= (unsafe.getByte(unsafeObj, offsetBytes) & 0XFFL) * P5;
       hash = Long.rotateLeft(hash, 11) * P1;
       --remaining;
       ++offsetBytes;
@@ -234,7 +246,7 @@ final class CompareAndCopy {
     hash ^= hash >>> 29;
     hash *= P3;
     hash ^= hash >>> 32;
-    return (int) hash;
+    return hash;
   }
 
   static void copy(final BaseState srcState, final long srcOffsetBytes,

--- a/src/main/java/com/yahoo/memory/CompareAndCopy.java
+++ b/src/main/java/com/yahoo/memory/CompareAndCopy.java
@@ -111,17 +111,17 @@ final class CompareAndCopy {
   static int hashCode(final BaseState state) {
     state.checkValid();
     final long lengthBytes = state.getCapacity();
-    long offsetBytes = state.getCumulativeOffset();
+    final long offsetBytes = state.getCumulativeOffset();
     final Object unsafeObj = state.getUnsafeObject(); //could be null
 
-    long hash = xxHash64(unsafeObj, offsetBytes, lengthBytes);
+    final long hash = xxHash64(unsafeObj, offsetBytes, lengthBytes);
     return (int) hash;
   }
 
   static long longHashCode(final BaseState state, final long offsetBytes, final long lengthBytes) {
     state.checkValid();
     checkBounds(offsetBytes, lengthBytes, state.getCapacity());
-    long cumulativeOffset = state.getCumulativeOffset(offsetBytes);
+    final long cumulativeOffset = state.getCumulativeOffset(offsetBytes);
     final Object unsafeObj = state.getUnsafeObject(); //could be null
     return xxHash64(unsafeObj, cumulativeOffset, lengthBytes);
   }

--- a/src/test/java/com/yahoo/memory/MemoryTest.java
+++ b/src/test/java/com/yahoo/memory/MemoryTest.java
@@ -412,7 +412,7 @@ public class MemoryTest {
   public void checkHashCode() {
     WritableMemory wmem = WritableMemory.allocate(32 + 7);
     int hc = wmem.hashCode();
-    assertEquals(hc, -960627348);
+    assertEquals(hc, -1895166923);
   }
 
   @Test

--- a/src/test/java/com/yahoo/memory/XxHashTest.java
+++ b/src/test/java/com/yahoo/memory/XxHashTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018, Yahoo! Inc. Licensed under the terms of the
+ * Apache License 2.0. See LICENSE file at the project root for terms.
+ */
+
+package com.yahoo.memory;
+
+import net.openhft.hashing.LongHashFunction;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * This test compares the output of {@link BaseState#longHashCode(long, long)} with the output of
+ * {@link net.openhft.hashing.LongHashFunction}, that itself is tested against the reference
+ * implementation in C. The point of verifying that longHashCode() is exactly xxHash is not because
+ * longHashCode() is specified to be xxHash (it's not), but in order to be sure that longHashCode()
+ * has good avalanche and mixing properties (xxHash is tested using SMHasher,
+ * https://github.com/aappleby/smhasher)
+ */
+public class XxHashTest {
+
+  @Test
+  public void testXxHash() {
+    Random random = ThreadLocalRandom.current();
+    for (int len = 0; len < 100; len++) {
+      byte[] bytes = new byte[len];
+      for (int i = 0; i < 10; i++) {
+        long zahXxHash = LongHashFunction.xx().hashBytes(bytes);
+        long memoryXxHash = Memory.wrap(bytes).longHashCode(0, len);
+        Assert.assertEquals(memoryXxHash, zahXxHash);
+        random.nextBytes(bytes);
+      }
+    }
+  }
+}

--- a/src/test/java/com/yahoo/memory/XxHashTest.java
+++ b/src/test/java/com/yahoo/memory/XxHashTest.java
@@ -5,12 +5,13 @@
 
 package com.yahoo.memory;
 
-import net.openhft.hashing.LongHashFunction;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.util.Random;
-import java.util.concurrent.ThreadLocalRandom;
+import net.openhft.hashing.LongHashFunction;
 
 /**
  * This test compares the output of {@link BaseState#longHashCode(long, long)} with the output of


### PR DESCRIPTION
Adds `longHashCode(off, len)` to `Memory` and `Buffer`, that fixes #82.

Adds XxHashTest that ensures that the output of `hashCode()` and `longHashCode()` _is_ xxHash (although it's not specified), in order to be confident in their good avalanche and mixing properties.