### PR TITLE
Cache arrayBaseOffset.

### DIFF
--- a/src/main/java/org/apache/datasketches/memory/BaseState.java
+++ b/src/main/java/org/apache/datasketches/memory/BaseState.java
@@ -94,7 +94,7 @@ abstract class BaseState {
     capacityBytes_ = capacityBytes;
     cumBaseOffset_ = regionOffset + ((unsafeObj == null)
         ? nativeBaseOffset
-        : unsafe.arrayBaseOffset(unsafeObj.getClass()));
+        : UnsafeUtil.getArrayBaseOffset(unsafeObj.getClass()));
   }
 
   //Byte Order Related
@@ -233,7 +233,7 @@ abstract class BaseState {
     final Object unsafeObj = getUnsafeObject();
     return (unsafeObj == null)
         ? cumBaseOffset_ - getNativeBaseOffset()
-        : cumBaseOffset_ - unsafe.arrayBaseOffset(unsafeObj.getClass());
+        : cumBaseOffset_ - UnsafeUtil.getArrayBaseOffset(unsafeObj.getClass());
   }
 
   /**
@@ -518,7 +518,7 @@ abstract class BaseState {
       uObjHeader = 0;
     } else {
       uObjStr =  uObj.getClass().getSimpleName() + ", " + (uObj.hashCode() & 0XFFFFFFFFL);
-      uObjHeader = unsafe.arrayBaseOffset(uObj.getClass());
+      uObjHeader = UnsafeUtil.getArrayBaseOffset(uObj.getClass());
     }
     final ByteBuffer bb = state.getByteBuffer();
     final String bbStr = (bb == null) ? "null"

--- a/src/main/java/org/apache/datasketches/memory/UnsafeUtil.java
+++ b/src/main/java/org/apache/datasketches/memory/UnsafeUtil.java
@@ -157,15 +157,14 @@ public final class UnsafeUtil {
     }
   }
 
+  /**
+   * Like {@link Unsafe#arrayBaseOffset(Class)}, but caches return values for common array types. Useful because
+   * calling {@link Unsafe#arrayBaseOffset(Class)} directly incurs more overhead.
+   */
   static long getArrayBaseOffset(final Class<?> c) {
+    // Ordering here is roughly in order of what we expect to be most popular.
     if (c == byte[].class) {
       return ARRAY_BYTE_BASE_OFFSET;
-    } else if (c == boolean[].class) {
-      return ARRAY_BOOLEAN_BASE_OFFSET;
-    } else if (c == short[].class) {
-      return ARRAY_SHORT_BASE_OFFSET;
-    } else if (c == char[].class) {
-      return ARRAY_CHAR_BASE_OFFSET;
     } else if (c == int[].class) {
       return ARRAY_INT_BASE_OFFSET;
     } else if (c == long[].class) {
@@ -174,6 +173,12 @@ public final class UnsafeUtil {
       return ARRAY_FLOAT_BASE_OFFSET;
     } else if (c == double[].class) {
       return ARRAY_DOUBLE_BASE_OFFSET;
+    } else if (c == boolean[].class) {
+      return ARRAY_BOOLEAN_BASE_OFFSET;
+    } else if (c == short[].class) {
+      return ARRAY_SHORT_BASE_OFFSET;
+    } else if (c == char[].class) {
+      return ARRAY_CHAR_BASE_OFFSET;
     } else if (c == Object[].class) {
       return ARRAY_OBJECT_BASE_OFFSET;
     } else {

--- a/src/main/java/org/apache/datasketches/memory/UnsafeUtil.java
+++ b/src/main/java/org/apache/datasketches/memory/UnsafeUtil.java
@@ -157,6 +157,30 @@ public final class UnsafeUtil {
     }
   }
 
+  static long getArrayBaseOffset(final Class<?> c) {
+    if (c == byte[].class) {
+      return ARRAY_BYTE_BASE_OFFSET;
+    } else if (c == boolean[].class) {
+      return ARRAY_BOOLEAN_BASE_OFFSET;
+    } else if (c == short[].class) {
+      return ARRAY_SHORT_BASE_OFFSET;
+    } else if (c == char[].class) {
+      return ARRAY_CHAR_BASE_OFFSET;
+    } else if (c == int[].class) {
+      return ARRAY_INT_BASE_OFFSET;
+    } else if (c == long[].class) {
+      return ARRAY_LONG_BASE_OFFSET;
+    } else if (c == float[].class) {
+      return ARRAY_FLOAT_BASE_OFFSET;
+    } else if (c == double[].class) {
+      return ARRAY_DOUBLE_BASE_OFFSET;
+    } else if (c == Object[].class) {
+      return ARRAY_OBJECT_BASE_OFFSET;
+    } else {
+      return unsafe.arrayBaseOffset(c);
+    }
+  }
+
   /**
    * Assert the requested offset and length against the allocated size.
    * The invariants equation is: {@code 0 <= reqOff <= reqLen <= reqOff + reqLen <= allocSize}.

--- a/src/test/java/org/apache/datasketches/memory/UnsafeUtilTest.java
+++ b/src/test/java/org/apache/datasketches/memory/UnsafeUtilTest.java
@@ -23,6 +23,9 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.testng.annotations.Test;
 
 
@@ -120,6 +123,30 @@ public class UnsafeUtilTest {
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void checkInts() {
     Ints.checkedCast(1L << 32);
+  }
+
+  @Test
+  public void checkArrayBaseOffset()
+  {
+    final List<Class<?>> classes = new ArrayList<>();
+    classes.add(byte[].class);
+    classes.add(int[].class);
+    classes.add(long[].class);
+    classes.add(float[].class);
+    classes.add(double[].class);
+    classes.add(boolean[].class);
+    classes.add(short[].class);
+    classes.add(char[].class);
+    classes.add(Object[].class);
+    classes.add(byte[][].class); // An array type that is not cached
+
+    for (Class<?> clazz : classes) {
+      assertEquals(
+          UnsafeUtil.getArrayBaseOffset(clazz),
+          UnsafeUtil.unsafe.arrayBaseOffset(clazz),
+          clazz.getTypeName()
+      );
+    }
   }
 
   @Test


### PR DESCRIPTION
I've been doing some investigations into DataSketches HLL performance in Druid (see also: https://github.com/apache/incubator-druid/pull/8194). One thing I found is that when the Druid query broker — a process responsible for merging partial results originating from each Druid data server — is merging results, it spends nearly 50% (!) of its CPU time calling `Unsafe.arrayBaseOffset` as part of `Memory.wrap` of serialized `byte[]` sketches.

This patch caches those offsets, which speeds up the Broker code path by nearly 2x.

<img width="1665" alt="image" src="https://user-images.githubusercontent.com/1214075/62093271-8835a400-b22d-11e9-8e97-764585f65030.png">