### PR TITLE
Speed up CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
  - mvn clean compile test -Dgpg.skip=true
 
 after_success: 
- - mvn clean test jacoco:report coveralls:report
+ - mvn jacoco:report coveralls:report
 
 notifications:
   email: false


### PR DESCRIPTION
The CI jobs were unnecessarily executing `mvn test` a second time for code coverage.