### PR TITLE
Don't call getCapacity() in BaseState when asserting for read and write

### DIFF
--- a/src/main/java/org/apache/datasketches/memory/BaseState.java
+++ b/src/main/java/org/apache/datasketches/memory/BaseState.java
@@ -371,12 +371,12 @@ abstract class BaseState {
 
   final void assertValidAndBoundsForRead(final long offsetBytes, final long lengthBytes) {
     assertValid();
-    assertBounds(offsetBytes, lengthBytes, getCapacity());
+    assertBounds(offsetBytes, lengthBytes, capacityBytes_);
   }
 
   final void assertValidAndBoundsForWrite(final long offsetBytes, final long lengthBytes) {
     assertValid();
-    assertBounds(offsetBytes, lengthBytes, getCapacity());
+    assertBounds(offsetBytes, lengthBytes, capacityBytes_);
     assert !isReadOnly() : "Memory is read-only.";
   }
 

--- a/src/main/java/org/apache/datasketches/memory/BaseState.java
+++ b/src/main/java/org/apache/datasketches/memory/BaseState.java
@@ -371,11 +371,17 @@ abstract class BaseState {
 
   final void assertValidAndBoundsForRead(final long offsetBytes, final long lengthBytes) {
     assertValid();
+    // capacityBytes_ is intentionally read directly instead of calling getCapacity()
+    // because the later can make JVM to not inline the assert code path (and entirely remove it)
+    // even though it does nothing in production code path.
     assertBounds(offsetBytes, lengthBytes, capacityBytes_);
   }
 
   final void assertValidAndBoundsForWrite(final long offsetBytes, final long lengthBytes) {
     assertValid();
+    // capacityBytes_ is intentionally read directly instead of calling getCapacity()
+    // because the later can make JVM to not inline the assert code path (and entirely remove it)
+    // even though it does nothing in production code path.
     assertBounds(offsetBytes, lengthBytes, capacityBytes_);
     assert !isReadOnly() : "Memory is read-only.";
   }


### PR DESCRIPTION
In `assertValidAndBoundsForRead()` and `assertValidAndBoundsForWrite()` of `BaseState`, they call `getCapacity()` to pass it to `assertBounds()` which performs a boundary check. Interestingly, this doesn't seem good in terms of performance in some cases.

I'm doing some experiments with Apache Druid for some faster groupBy idea. In my branch result, [I sort the offsets in `Memory` by their values, so that I can read them in a sorted order](https://github.com/jihoonson/druid/blob/dict-merge/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/HashVectorGrouper.java#L304-L326) (someone could say this may hurt the CPU cache locality, which is true but is out of the scope of this PR). In my benchmark using [GroupByBenchmark](https://github.com/jihoonson/druid/blob/dict-merge/benchmarks/src/test/java/org/apache/druid/benchmark/query/GroupByBenchmark.java) of Druid, `getCapacity()` in `assertValidAndBoundsForRead()` contributed lots of time during sort as shown in the first flame graph below. This seems because calling `getCapacity()` makes JVM not inline assert methods even though they do nothing in production code path.

![Screenshot from 2020-11-25 14-20-38](https://user-images.githubusercontent.com/2322288/100287447-836c2780-2f29-11eb-9ddf-bbec02fe7bfd.png)

Another flame graph below was taken after applying the change in this PR. 

![Screenshot from 2020-11-25 14-21-01](https://user-images.githubusercontent.com/2322288/100287450-86671800-2f29-11eb-8d43-e4566d4379f3.png)

The above flame graphs were taken with Java 8, but I observed the same improvement with Java 11 as well after applying this change.

Regarding asserting the validity, the snippet of `getCapacity()` is:

```java
  public final long getCapacity() {
    assertValid();
    return capacityBytes_;
  }
```

So, this change seems OK to me because, in `assertValidAndBoundsForRead()`, `assertValid()` is called right before `capacityBytes_` is directly read which seems practically the same as what it did before.