### PR TITLE
Update pom to fix eclipse warnings

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -98,6 +98,13 @@ jobs:
         run: >
           java -version
 
+      - name: Compile
+        run: >
+          mvn clean compile
+          -Dmaven.javadoc.skip=true
+          -Dgpg.skip=true
+          --toolchains .github/workflows/.toolchains.xml
+
       - name: Install Dependencies
         run: >
           mvn clean install

--- a/datasketches-memory-resources/pom.xml
+++ b/datasketches-memory-resources/pom.xml
@@ -92,7 +92,6 @@
       </dependencies>
 
       <build>
-        <pluginManagement>
           <plugins>
 
             <plugin>
@@ -120,7 +119,6 @@
             </plugin>
 
           </plugins>
-        </pluginManagement>
       </build>
     </profile>
 

--- a/datasketches-memory/pom.xml
+++ b/datasketches-memory/pom.xml
@@ -28,6 +28,8 @@
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
     <version>23</version>
+    <!-- Bypass resolution within source directory and resolve parent from remote repository instead -->
+    <relativePath />
   </parent>
 
   <!-- datasketches-memory assembly module
@@ -370,6 +372,31 @@
             <artifactId>maven-gpg-plugin</artifactId>
           </plugin>
         </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>only-eclipse</id>
+      <activation>
+        <property>
+          <name>m2e.version</name>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-remote-resources-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>process-resource-bundles</id>
+                  <phase>none</phase>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
       </build>
     </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -421,7 +421,7 @@ under the License.
             </jdkToolchain>
           </configuration>
         </plugin>
-
+        
       </plugins>
     </pluginManagement>
     <plugins>
@@ -469,9 +469,6 @@ under the License.
   </build>
 
   <profiles>
-
-
-
     <!-- Disable source release assembly for 'apache-release' profile.
              This is performed from a script outside Maven
     -->
@@ -492,6 +489,33 @@ under the License.
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>only-eclipse</id>
+      <activation>
+        <property>
+          <name>m2e.version</name>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-remote-resources-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>process-resource-bundles</id>
+                  <phase>none</phase>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+
+  
   </profiles>
 
   <!-- This Maven project is divided into an aggregator project (the root), that manages a group of submodules that


### PR DESCRIPTION
This PR address the following warnings:

- the relative path warning discussed recently in the dev mailing group.
- the maven resource plugin that is ignored by m2e, through the introduction of an eclipse only profile.