### PR TITLE
Ds java issue358

### DIFF
--- a/datasketches-memory-java8-tests/src/test/java/org/apache/datasketches/memory/test/AllocateDirectMemoryTest.java
+++ b/datasketches-memory-java8-tests/src/test/java/org/apache/datasketches/memory/test/AllocateDirectMemoryTest.java
@@ -87,7 +87,7 @@ public class AllocateDirectMemoryTest {
 
   @Test
   public void checkNullMemoryRequestServer() throws Exception {
-    try (WritableHandle wh = WritableMemory.allocateDirect(128, null)) {
+    try (WritableHandle wh = WritableMemory.allocateDirect(128, Util.nativeByteOrder, null)) {
       WritableMemory wmem = wh.getWritable();
       assertNotNull(wmem.getMemoryRequestServer());
     }
@@ -95,9 +95,8 @@ public class AllocateDirectMemoryTest {
 
 
   @Test
-  public void checkNonNativeDirect() throws Exception { //not allowed in public API
-    try (WritableHandle h = ReflectUtil.wrapDirect(8,  Util.nonNativeByteOrder, null)) { 
-        //BaseWritableMemory.wrapDirect(8, Util.nonNativeByteOrder, null)) {
+  public void checkNonNativeDirect() throws Exception {
+    try (WritableHandle h = WritableMemory.allocateDirect(128, Util.nonNativeByteOrder, null)) {
       WritableMemory wmem = h.getWritable();
       wmem.putChar(0, (char) 1);
       assertEquals(wmem.getByte(1), (byte) 1);

--- a/datasketches-memory-java8-tests/src/test/java/org/apache/datasketches/memory/test/ExampleMemoryRequestServerTest.java
+++ b/datasketches-memory-java8-tests/src/test/java/org/apache/datasketches/memory/test/ExampleMemoryRequestServerTest.java
@@ -21,6 +21,7 @@ package org.apache.datasketches.memory.test;
 
 import static org.testng.Assert.assertFalse;
 
+import java.nio.ByteOrder;
 import java.util.IdentityHashMap;
 
 import org.apache.datasketches.memory.MemoryRequestServer;
@@ -61,7 +62,7 @@ public class ExampleMemoryRequestServerTest {
   public void checkExampleMemoryRequestServer2() throws Exception {
     int bytes = 8;
     ExampleMemoryRequestServer svr = new ExampleMemoryRequestServer();
-    try (WritableHandle handle = WritableMemory.allocateDirect(bytes, svr)) {
+    try (WritableHandle handle = WritableMemory.allocateDirect(bytes, ByteOrder.nativeOrder(), svr)) {
       WritableMemory wMem = handle.getWritable();
       MemoryClient client = new MemoryClient(wMem);
       client.process();
@@ -73,7 +74,7 @@ public class ExampleMemoryRequestServerTest {
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void checkZeroCapacity() {
     ExampleMemoryRequestServer svr = new ExampleMemoryRequestServer();
-    WritableMemory.allocateDirect(0, svr);
+    WritableMemory.allocateDirect(0, ByteOrder.nativeOrder(), svr);
   }
 
   /**
@@ -126,7 +127,7 @@ public class ExampleMemoryRequestServerTest {
     @SuppressWarnings("resource")
     @Override
     public WritableMemory request(long capacityBytes) {
-     WritableHandle handle = WritableMemory.allocateDirect(capacityBytes, this);
+     WritableHandle handle = WritableMemory.allocateDirect(capacityBytes, ByteOrder.nativeOrder(), this);
      WritableMemory wmem = handle.getWritable();
      map.put(wmem, handle); //We track the newly allocated memory and its handle.
      return wmem;

--- a/datasketches-memory-java8-tests/src/test/java/org/apache/datasketches/memory/test/LeafImplTest.java
+++ b/datasketches-memory-java8-tests/src/test/java/org/apache/datasketches/memory/test/LeafImplTest.java
@@ -227,7 +227,7 @@ public class LeafImplTest {
 
     assertTrue(mem.getByteBuffer() != null);
     assertTrue(mem.getTypeByteOrder() == Util.nativeByteOrder);
-    assertTrue(mem.getMemoryRequestServer() == null);
+    assertNotNull(mem.getMemoryRequestServer());
     Object obj = ReflectUtil.getUnsafeObject(mem);
     //Object obj = mem.getUnsafeObject();
     if (direct) {
@@ -269,7 +269,7 @@ public class LeafImplTest {
 
     assertTrue(nnMem.getByteBuffer() != null);
     assertTrue(nnMem.getTypeByteOrder() == Util.nonNativeByteOrder);
-    assertTrue(nnMem.getMemoryRequestServer() == null);
+    assertNotNull(nnMem.getMemoryRequestServer());
     obj = ReflectUtil.getUnsafeObject(nnMem);
     //obj = nnMem.getUnsafeObject();
     if (direct) {

--- a/datasketches-memory-java8-tests/src/test/java/org/apache/datasketches/memory/test/LeafImplTest.java
+++ b/datasketches-memory-java8-tests/src/test/java/org/apache/datasketches/memory/test/LeafImplTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.datasketches.memory.test;
 
+import static org.apache.datasketches.memory.internal.Util.nativeByteOrder;
+import static org.apache.datasketches.memory.internal.Util.nonNativeByteOrder;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -30,12 +32,11 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
-import org.apache.datasketches.memory.WritableHandle;
-import org.apache.datasketches.memory.internal.Util;
+import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.WritableBuffer;
-
-import org.apache.datasketches.memory.WritableMemory;
+import org.apache.datasketches.memory.WritableHandle;
 import org.apache.datasketches.memory.WritableMapHandle;
+import org.apache.datasketches.memory.WritableMemory;
 import org.testng.annotations.Test;
 
 /**
@@ -43,78 +44,80 @@ import org.testng.annotations.Test;
  */
 @SuppressWarnings("javadoc")
 public class LeafImplTest {
-  static final ByteOrder LE = ByteOrder.LITTLE_ENDIAN;
-  static final ByteOrder BE = ByteOrder.BIG_ENDIAN;
+  private static final ByteOrder NO = nativeByteOrder;
+  private static final ByteOrder NNO = nonNativeByteOrder;
+  private static final MemoryRequestServer dummyMemReqSvr = new DummyMemoryRequestServer();
+  
+  private static ByteOrder otherOrder(ByteOrder order) { return (order == NO) ? NNO : NO; } 
+  
+  static class DummyMemoryRequestServer implements MemoryRequestServer {
+    @Override
+    public WritableMemory request(long capacityBytes) { return null; }
+    @Override
+    public void requestClose(WritableMemory memToClose, WritableMemory newMemory) { }
+  }
   
   @Test
   public void checkDirectLeafs() throws Exception {
     long off = 0;
     long cap = 128;
-    try (WritableHandle wdh = WritableMemory.allocateDirect(cap)) {
-      WritableMemory memLE = wdh.getWritable();
-      memLE.putShort(0, (short) 1);
-      checkDirect(memLE, off, cap);
+    // Off Heap, Native order, No ByteBuffer, has MemReqSvr
+    try (WritableHandle wdh = WritableMemory.allocateDirect(cap, NO, dummyMemReqSvr)) {
+      WritableMemory memNO = wdh.getWritable();
+      memNO.putShort(0, (short) 1);
+      assertNull(ReflectUtil.getUnsafeObject(memNO));
+      assertTrue(memNO.isDirect());
+      checkCombinations(memNO, off, cap, memNO.isDirect(), NO, false, true);
+    }
+    // Off Heap, Non Native order, No ByteBuffer, has MemReqSvr
+    try (WritableHandle wdh = WritableMemory.allocateDirect(cap, NNO, dummyMemReqSvr)) {
+      WritableMemory memNNO = wdh.getWritable();
+      memNNO.putShort(0, (short) 1);
+      assertNull(ReflectUtil.getUnsafeObject(memNNO));
+      assertTrue(memNNO.isDirect());
+      checkCombinations(memNNO, off, cap, memNNO.isDirect(), NNO, false, true);
     }
   }
   
-  private static void checkDirect(WritableMemory mem, long off, long cap) {
-    assertEquals(mem.writableRegion(off, cap, LE).getShort(0), 1);
-    assertEquals(mem.writableRegion(off, cap, BE).getShort(0), 256);
-    assertEquals(mem.asWritableBuffer(LE).getShort(0), 1);
-    assertEquals(mem.asWritableBuffer(BE).getShort(0), 256);
-
-    assertTrue(mem.getByteBuffer() == null);
-    assertTrue(mem.getTypeByteOrder() == Util.nativeByteOrder);
-    assertTrue(mem.getMemoryRequestServer() != null);
-    assertTrue(mem.isDirect());
-    assertTrue(ReflectUtil.getUnsafeObject(mem) == null);
-    //assertTrue(mem.getUnsafeObject() == null);
-    assertTrue(mem.isValid() == true);
-
-    WritableBuffer buf = mem.asWritableBuffer();
-
-    assertEquals(buf.writableRegion(off, cap, LE).getShort(0), 1);
-    assertEquals(buf.writableRegion(off, cap, BE).getShort(0), 256);
-    assertEquals(buf.writableDuplicate(LE).getShort(0), 1);
-    assertEquals(buf.writableDuplicate(BE).getShort(0), 256);
-
-    assertTrue(buf.getByteBuffer() == null);
-    assertTrue(buf.getTypeByteOrder() == Util.nativeByteOrder);
-    assertTrue(buf.getMemoryRequestServer() != null);
-    assertTrue(buf.isDirect());
-    assertTrue(ReflectUtil.getUnsafeObject(buf) == null);
-    //assertTrue(buf.getUnsafeObject() == null);
-    assertTrue(buf.isValid() == true);
-
-    WritableMemory nnMem = mem.writableRegion(off, cap, Util.nonNativeByteOrder);
-
-    assertEquals(nnMem.writableRegion(off, cap, LE).getShort(0), 1);
-    assertEquals(nnMem.writableRegion(off, cap, BE).getShort(0), 256);
-    assertEquals(nnMem.asWritableBuffer(LE).getShort(0), 1);
-    assertEquals(nnMem.asWritableBuffer(BE).getShort(0), 256);
-
-    assertTrue(nnMem.getByteBuffer() == null);
-    assertTrue(nnMem.getTypeByteOrder() == Util.nonNativeByteOrder);
-    assertTrue(nnMem.getMemoryRequestServer() != null);
-    assertTrue(nnMem.isDirect());
-    assertTrue(ReflectUtil.getUnsafeObject(nnMem) == null);
-    //assertTrue(nnMem.getUnsafeObject() == null);
-    assertTrue(nnMem.isValid() == true);
-
-    WritableBuffer nnBuf = mem.asWritableBuffer(Util.nonNativeByteOrder);
-
-    assertEquals(nnBuf.writableRegion(off, cap, LE).getShort(0), 1);
-    assertEquals(nnBuf.writableRegion(off, cap, BE).getShort(0), 256);
-    assertEquals(nnBuf.writableDuplicate(LE).getShort(0), 1);
-    assertEquals(nnBuf.writableDuplicate(BE).getShort(0), 256);
-
-    assertTrue(nnBuf.getByteBuffer() == null);
-    assertTrue(nnBuf.getTypeByteOrder() == Util.nonNativeByteOrder);
-    assertTrue(nnBuf.getMemoryRequestServer() != null);
-    assertTrue(nnBuf.isDirect());
-    assertTrue(ReflectUtil.getUnsafeObject(nnBuf) == null);
-    //assertTrue(nnBuf.getUnsafeObject() == null);
-    assertTrue(nnBuf.isValid() == true);
+  @Test
+  public void checkByteBufferLeafs() {
+    long off = 0;
+    long cap = 128;
+    //BB on heap, native order, has ByteBuffer, has MemReqSvr
+    ByteBuffer bb = ByteBuffer.allocate((int)cap);
+    bb.order(NO);
+    bb.putShort(0, (short) 1);
+    WritableMemory mem = WritableMemory.writableWrap(bb, NO, dummyMemReqSvr);
+    assertEquals(bb.isDirect(), mem.isDirect());
+    assertNotNull(ReflectUtil.getUnsafeObject(mem));
+    checkCombinations(mem, off, cap, mem.isDirect(), mem.getTypeByteOrder(), true, true); 
+    
+    //BB off heap, native order, has ByteBuffer, has MemReqSvr
+    ByteBuffer dbb = ByteBuffer.allocateDirect((int)cap);
+    dbb.order(NO);
+    dbb.putShort(0, (short) 1);
+    mem = WritableMemory.writableWrap(dbb, NO, dummyMemReqSvr);
+    assertEquals(dbb.isDirect(), mem.isDirect());
+    assertNull(ReflectUtil.getUnsafeObject(mem));
+    checkCombinations(mem, off, cap,  mem.isDirect(), mem.getTypeByteOrder(), true, true);
+    
+    //BB on heap, non native order, has ByteBuffer, has MemReqSvr
+    bb = ByteBuffer.allocate((int)cap);
+    bb.order(NNO);
+    bb.putShort(0, (short) 1);
+    mem = WritableMemory.writableWrap(bb, NNO, dummyMemReqSvr);
+    assertEquals(bb.isDirect(), mem.isDirect());
+    assertNotNull(ReflectUtil.getUnsafeObject(mem));
+    checkCombinations(mem, off, cap, mem.isDirect(), mem.getTypeByteOrder(), true, true);
+    
+    //BB off heap, non native order, has ByteBuffer, has MemReqSvr
+    dbb = ByteBuffer.allocateDirect((int)cap);
+    dbb.order(NNO);
+    dbb.putShort(0, (short) 1);
+    mem = WritableMemory.writableWrap(dbb, NNO, dummyMemReqSvr);
+    assertEquals(dbb.isDirect(), mem.isDirect());
+    assertNull(ReflectUtil.getUnsafeObject(mem));
+    checkCombinations(mem, off, cap,  mem.isDirect(), mem.getTypeByteOrder(), true, true);
   }
 
   @Test
@@ -133,103 +136,60 @@ public class LeafImplTest {
     assertTrue(file.setWritable(true, false)); //writable=true, ownerOnly=false
     assertTrue(file.isFile());
     file.deleteOnExit();  //comment out if you want to examine the file.
-
-    try (WritableMapHandle wmh = WritableMemory.writableMap(file, off, cap, Util.nativeByteOrder)) {
-      WritableMemory mem = wmh.getWritable();
-      mem.putShort(0, (short) 1);
-      assertEquals(mem.getByte(0), (byte) 1);
-      checkMap(mem, off, cap);
+    // Off Heap, Native order, No ByteBuffer, No MemReqSvr
+    try (WritableMapHandle wmh = WritableMemory.writableMap(file, off, cap, NO)) {
+      WritableMemory memNO = wmh.getWritable();
+      memNO.putShort(0, (short) 1);
+      assertNull(ReflectUtil.getUnsafeObject(memNO));
+      assertTrue(memNO.isDirect());
+      checkCombinations(memNO, off, cap, memNO.isDirect(), NO, false, false);
+    }
+    // Off heap, Non Native order, No ByteBuffer, no MemReqSvr
+    try (WritableMapHandle wmh = WritableMemory.writableMap(file, off, cap, NNO)) {
+      WritableMemory memNNO = wmh.getWritable();
+      memNNO.putShort(0, (short) 1);
+      assertNull(ReflectUtil.getUnsafeObject(memNNO));
+      assertTrue(memNNO.isDirect());
+      checkCombinations(memNNO, off, cap, memNNO.isDirect(), NNO, false, false);
     }
   }
-
-  private static void checkMap(WritableMemory mem, long off, long cap) {
-    assertEquals(mem.writableRegion(off, cap, LE).getShort(0), 1);
-    assertEquals(mem.writableRegion(off, cap, BE).getShort(0), 256);
-    assertEquals(mem.asWritableBuffer(LE).getShort(0), 1);
-    assertEquals(mem.asWritableBuffer(BE).getShort(0), 256);
-
-    assertTrue(mem.getByteBuffer() == null);
-    assertTrue(mem.getTypeByteOrder() == Util.nativeByteOrder);
-    assertTrue(mem.getMemoryRequestServer() == null);
-    assertTrue(mem.isDirect());
-    assertTrue(ReflectUtil.getUnsafeObject(mem) == null);
-    //assertTrue(mem.getUnsafeObject() == null);
-    assertTrue(mem.isValid() == true);
-
-    WritableBuffer buf = mem.asWritableBuffer();
-
-    assertEquals(buf.writableRegion(off, cap, LE).getShort(0), 1);
-    assertEquals(buf.writableRegion(off, cap, BE).getShort(0), 256);
-    assertEquals(buf.writableDuplicate(LE).getShort(0), 1);
-    assertEquals(buf.writableDuplicate(BE).getShort(0), 256);
-
-    assertTrue(buf.getByteBuffer() == null);
-    assertTrue(buf.getTypeByteOrder() == Util.nativeByteOrder);
-    assertTrue(buf.getMemoryRequestServer() == null);
-    assertTrue(buf.isDirect());
-    assertTrue(ReflectUtil.getUnsafeObject(buf) == null);
-    //assertTrue(buf.getUnsafeObject() == null);
-    assertTrue(buf.isValid() == true);
-
-    WritableMemory nnMem = mem.writableRegion(off, cap, Util.nonNativeByteOrder);
-
-    assertEquals(nnMem.writableRegion(off, cap, LE).getShort(0), 1);
-    assertEquals(nnMem.writableRegion(off, cap, BE).getShort(0), 256);
-    assertEquals(nnMem.asWritableBuffer(LE).getShort(0), 1);
-    assertEquals(nnMem.asWritableBuffer(BE).getShort(0), 256);
-
-    assertTrue(nnMem.getByteBuffer() == null);
-    assertTrue(nnMem.getTypeByteOrder() == Util.nonNativeByteOrder);
-    assertTrue(nnMem.getMemoryRequestServer() == null);
-    assertTrue(nnMem.isDirect());
-    assertTrue(ReflectUtil.getUnsafeObject(nnMem) == null);
-    //assertTrue(nnMem.getUnsafeObject() == null);
-    assertTrue(nnMem.isValid() == true);
-
-    WritableBuffer nnBuf = mem.asWritableBuffer(Util.nonNativeByteOrder);
-
-    assertEquals(nnBuf.writableRegion(off, cap, LE).getShort(0), 1);
-    assertEquals(nnBuf.writableRegion(off, cap, BE).getShort(0), 256);
-    assertEquals(nnBuf.writableDuplicate(LE).getShort(0), 1);
-    assertEquals(nnBuf.writableDuplicate(BE).getShort(0), 256);
-
-    assertTrue(nnBuf.getByteBuffer() == null);
-    assertTrue(nnBuf.getTypeByteOrder() == Util.nonNativeByteOrder);
-    assertTrue(nnBuf.getMemoryRequestServer() == null);
-    assertTrue(nnBuf.isDirect());
-    assertTrue(ReflectUtil.getUnsafeObject(nnBuf) == null);
-    //assertTrue(nnBuf.getUnsafeObject() == null);
-    assertTrue(nnBuf.isValid() == true);
-  }
-
+  
   @Test
-  public void checkByteBufferLeafs() {
+  public void checkHeapLeafs() {
     long off = 0;
     long cap = 128;
-    ByteBuffer bb = ByteBuffer.allocate((int)cap);
-    bb.order(ByteOrder.nativeOrder());
-    bb.putShort(0, (short) 1);
-    WritableMemory mem = WritableMemory.writableWrap(bb);
-    checkByteBuffer(mem, off, cap, false);
-
-    ByteBuffer dbb = ByteBuffer.allocateDirect((int)cap);
-    dbb.order(ByteOrder.nativeOrder());
-    dbb.putShort(0, (short) 1);
-    mem = WritableMemory.writableWrap(dbb);
-    checkByteBuffer(mem, off, cap, true);
+    // On Heap, Native order, No ByteBuffer, No MemReqSvr
+    WritableMemory memNO = WritableMemory.allocate((int)cap); //assumes NO
+    memNO.putShort(0, (short) 1);
+    assertNotNull(ReflectUtil.getUnsafeObject(memNO));
+    assertFalse(memNO.isDirect());
+    checkCombinations(memNO, off, cap, memNO.isDirect(), NO, false, false);
+    // On Heap, Non-native order, No ByteBuffer, No MemReqSvr
+    WritableMemory memNNO = WritableMemory.allocate((int)cap, NNO);
+    memNNO.putShort(0, (short) 1);
+    assertNotNull(ReflectUtil.getUnsafeObject(memNNO));
+    assertFalse(memNNO.isDirect());
+    checkCombinations(memNNO, off, cap, memNNO.isDirect(), NNO, false, false);
   }
 
-  private static void checkByteBuffer(WritableMemory mem, long off, long cap, boolean direct) {
-    assertEquals(mem.writableRegion(off, cap, LE).getShort(0), 1);
-    assertEquals(mem.writableRegion(off, cap, BE).getShort(0), 256);
-    assertEquals(mem.asWritableBuffer(LE).getShort(0), 1);
-    assertEquals(mem.asWritableBuffer(BE).getShort(0), 256);
+  private static void checkCombinations(WritableMemory mem, long off, long cap, 
+      boolean direct, ByteOrder bo, boolean hasByteBuffer, boolean hasMemReqSvr) {
+    ByteOrder oo = otherOrder(bo);
+    
+    assertEquals(mem.writableRegion(off, cap, bo).getShort(0), 1);
+    assertEquals(mem.writableRegion(off, cap, oo).getShort(0), 256);
+    
+    assertEquals(mem.asWritableBuffer(bo).getShort(0), 1);
+    assertEquals(mem.asWritableBuffer(oo).getShort(0), 256);
 
-    assertTrue(mem.getByteBuffer() != null);
-    assertTrue(mem.getTypeByteOrder() == Util.nativeByteOrder);
-    assertNotNull(mem.getMemoryRequestServer());
+    ByteBuffer bb = mem.getByteBuffer();
+    assertTrue( hasByteBuffer ? bb != null : bb == null);
+
+    assertTrue(mem.getTypeByteOrder() == bo);
+    
+    if (hasMemReqSvr) { assertTrue(mem.getMemoryRequestServer() instanceof DummyMemoryRequestServer); }
+    
     Object obj = ReflectUtil.getUnsafeObject(mem);
-    //Object obj = mem.getUnsafeObject();
     if (direct) {
       assertTrue(mem.isDirect());
       assertNull(obj);
@@ -237,20 +197,24 @@ public class LeafImplTest {
       assertFalse(mem.isDirect());
       assertNotNull(obj);
     }
+    
     assertTrue(mem.isValid() == true);
 
     WritableBuffer buf = mem.asWritableBuffer();
 
-    assertEquals(buf.writableRegion(off, cap, LE).getShort(0), 1);
-    assertEquals(buf.writableRegion(off, cap, BE).getShort(0), 256);
-    assertEquals(buf.writableDuplicate(LE).getShort(0), 1);
-    assertEquals(buf.writableDuplicate(BE).getShort(0), 256);
+    assertEquals(buf.writableRegion(off, cap, bo).getShort(0), 1);
+    assertEquals(buf.writableRegion(off, cap, oo).getShort(0), 256);
+    assertEquals(buf.writableDuplicate(bo).getShort(0), 1);
+    assertEquals(buf.writableDuplicate(oo).getShort(0), 256);
 
-    assertTrue(buf.getByteBuffer() != null);
-    assertTrue(buf.getTypeByteOrder() == Util.nativeByteOrder);
-    assertTrue(buf.getMemoryRequestServer() == null);
+    bb = buf.getByteBuffer();
+    assertTrue(hasByteBuffer ? bb != null : bb == null);
+    
+    assertTrue(buf.getTypeByteOrder() == bo);
+    
+    if (hasMemReqSvr) { assertTrue(buf.getMemoryRequestServer() instanceof DummyMemoryRequestServer); }
+
     obj = ReflectUtil.getUnsafeObject(buf);
-    //obj = buf.getUnsafeObject();
     if (direct) {
       assertTrue(buf.isDirect());
       assertNull(obj);
@@ -258,20 +222,24 @@ public class LeafImplTest {
       assertFalse(buf.isDirect());
       assertNotNull(obj);
     }
+    
     assertTrue(buf.isValid() == true);
 
-    WritableMemory nnMem = mem.writableRegion(off, cap, Util.nonNativeByteOrder);
+    WritableMemory nnMem = mem.writableRegion(off, cap, oo);
 
-    assertEquals(nnMem.writableRegion(off, cap, LE).getShort(0), 1);
-    assertEquals(nnMem.writableRegion(off, cap, BE).getShort(0), 256);
-    assertEquals(nnMem.asWritableBuffer(LE).getShort(0), 1);
-    assertEquals(nnMem.asWritableBuffer(BE).getShort(0), 256);
+    assertEquals(nnMem.writableRegion(off, cap, bo).getShort(0), 1);
+    assertEquals(nnMem.writableRegion(off, cap, oo).getShort(0), 256);
+    assertEquals(nnMem.asWritableBuffer(bo).getShort(0), 1);
+    assertEquals(nnMem.asWritableBuffer(oo).getShort(0), 256);
 
-    assertTrue(nnMem.getByteBuffer() != null);
-    assertTrue(nnMem.getTypeByteOrder() == Util.nonNativeByteOrder);
-    assertNotNull(nnMem.getMemoryRequestServer());
+    bb = nnMem.getByteBuffer();
+    assertTrue( hasByteBuffer ? bb != null : bb == null);
+    
+    assertTrue(nnMem.getTypeByteOrder() == oo);
+    
+    if (hasMemReqSvr) { assertTrue(nnMem.getMemoryRequestServer() instanceof DummyMemoryRequestServer); }
+    
     obj = ReflectUtil.getUnsafeObject(nnMem);
-    //obj = nnMem.getUnsafeObject();
     if (direct) {
       assertTrue(nnMem.isDirect());
       assertNull(obj);
@@ -279,20 +247,24 @@ public class LeafImplTest {
       assertFalse(nnMem.isDirect());
       assertNotNull(obj);
     }
+    
     assertTrue(nnMem.isValid() == true);
 
-    WritableBuffer nnBuf = mem.asWritableBuffer(Util.nonNativeByteOrder);
+    WritableBuffer nnBuf = mem.asWritableBuffer(oo);
 
-    assertEquals(nnBuf.writableRegion(off, cap, LE).getShort(0), 1);
-    assertEquals(nnBuf.writableRegion(off, cap, BE).getShort(0), 256);
-    assertEquals(nnBuf.writableDuplicate(LE).getShort(0), 1);
-    assertEquals(nnBuf.writableDuplicate(BE).getShort(0), 256);
+    assertEquals(nnBuf.writableRegion(off, cap, bo).getShort(0), 1);
+    assertEquals(nnBuf.writableRegion(off, cap, oo).getShort(0), 256);
+    assertEquals(nnBuf.writableDuplicate(bo).getShort(0), 1);
+    assertEquals(nnBuf.writableDuplicate(oo).getShort(0), 256);
 
-    assertTrue(nnBuf.getByteBuffer() != null);
-    assertTrue(nnBuf.getTypeByteOrder() == Util.nonNativeByteOrder);
-    assertTrue(nnBuf.getMemoryRequestServer() == null);
+    bb = nnBuf.getByteBuffer();
+    assertTrue( hasByteBuffer ? bb != null : bb == null);
+    
+    assertTrue(nnBuf.getTypeByteOrder() == oo);
+    
+    if (hasMemReqSvr) { assertTrue(nnBuf.getMemoryRequestServer() instanceof DummyMemoryRequestServer); }
+
     obj = ReflectUtil.getUnsafeObject(nnBuf);
-    //obj = nnBuf.getUnsafeObject();
     if (direct) {
       assertTrue(nnBuf.isDirect());
       assertNull(obj);
@@ -300,76 +272,8 @@ public class LeafImplTest {
       assertFalse(nnBuf.isDirect());
       assertNotNull(obj);
     }
+    
     assertTrue(nnBuf.isValid() == true);
   }
-
-  @Test
-  public void checkHeapLeafs() {
-    long off = 0;
-    long cap = 128;
-    WritableMemory mem = WritableMemory.allocate((int)cap);
-    mem.putShort(0, (short) 1);
-    checkHeap(mem, off, cap);
-  }
-
-  private static void checkHeap(WritableMemory mem, long off, long cap) {
-    assertEquals(mem.writableRegion(off, cap, LE).getShort(0), 1);
-    assertEquals(mem.writableRegion(off, cap, BE).getShort(0), 256);
-    assertEquals(mem.asWritableBuffer(LE).getShort(0), 1);
-    assertEquals(mem.asWritableBuffer(BE).getShort(0), 256);
-
-    assertTrue(mem.getByteBuffer() == null);
-    assertTrue(mem.getTypeByteOrder() == Util.nativeByteOrder);
-    assertTrue(mem.getMemoryRequestServer() == null);
-    assertFalse(mem.isDirect());
-    assertTrue(ReflectUtil.getUnsafeObject(mem) != null);
-    //assertTrue(mem.getUnsafeObject() != null);
-    assertTrue(mem.isValid() == true);
-
-    WritableBuffer buf = mem.asWritableBuffer();
-
-    assertEquals(buf.writableRegion(off, cap, LE).getShort(0), 1);
-    assertEquals(buf.writableRegion(off, cap, BE).getShort(0), 256);
-    assertEquals(buf.writableDuplicate(LE).getShort(0), 1);
-    assertEquals(buf.writableDuplicate(BE).getShort(0), 256);
-
-    assertTrue(buf.getByteBuffer() == null);
-    assertTrue(buf.getTypeByteOrder() == Util.nativeByteOrder);
-    assertTrue(buf.getMemoryRequestServer() == null);
-    assertFalse(buf.isDirect());
-    assertTrue(ReflectUtil.getUnsafeObject(buf) != null);
-    //assertTrue(buf.getUnsafeObject() != null);
-    assertTrue(buf.isValid() == true);
-
-    WritableMemory nnMem = mem.writableRegion(off, cap, Util.nonNativeByteOrder);
-
-    assertEquals(nnMem.writableRegion(off, cap, LE).getShort(0), 1);
-    assertEquals(nnMem.writableRegion(off, cap, BE).getShort(0), 256);
-    assertEquals(nnMem.asWritableBuffer(LE).getShort(0), 1);
-    assertEquals(nnMem.asWritableBuffer(BE).getShort(0), 256);
-
-    assertTrue(nnMem.getByteBuffer() == null);
-    assertTrue(nnMem.getTypeByteOrder() == Util.nonNativeByteOrder);
-    assertTrue(nnMem.getMemoryRequestServer() == null);
-    assertFalse(nnMem.isDirect());
-    assertTrue(ReflectUtil.getUnsafeObject(nnMem) != null);
-    //assertTrue(nnMem.getUnsafeObject() != null);
-    assertTrue(nnMem.isValid() == true);
-
-    WritableBuffer nnBuf = mem.asWritableBuffer(Util.nonNativeByteOrder);
-
-    assertEquals(nnBuf.writableRegion(off, cap, LE).getShort(0), 1);
-    assertEquals(nnBuf.writableRegion(off, cap, BE).getShort(0), 256);
-    assertEquals(nnBuf.writableDuplicate(LE).getShort(0), 1);
-    assertEquals(nnBuf.writableDuplicate(BE).getShort(0), 256);
-
-    assertTrue(nnBuf.getByteBuffer() == null);
-    assertTrue(nnBuf.getTypeByteOrder() == Util.nonNativeByteOrder);
-    assertTrue(nnBuf.getMemoryRequestServer() == null);
-    assertFalse(nnBuf.isDirect());
-    assertTrue(ReflectUtil.getUnsafeObject(nnBuf) != null);
-    //assertTrue(nnBuf.getUnsafeObject() != null);
-    assertTrue(nnBuf.isValid() == true);
-  }
-
+  
 }

--- a/datasketches-memory-java8-tests/src/test/java/org/apache/datasketches/memory/test/MemoryTest.java
+++ b/datasketches-memory-java8-tests/src/test/java/org/apache/datasketches/memory/test/MemoryTest.java
@@ -458,7 +458,7 @@ public class MemoryTest {
   @Test
   public void wrapBigEndianAsLittle() {
     ByteBuffer bb = ByteBuffer.allocate(64);
-    bb.putChar(0, (char)1); //as BE
+    bb.putChar(0, (char)1); //as NNO
     Memory mem = Memory.wrap(bb, ByteOrder.LITTLE_ENDIAN);
     assertEquals(mem.getChar(0), 256);
   }

--- a/datasketches-memory-java8-tests/src/test/java/org/apache/datasketches/memory/test/ReflectUtil.java
+++ b/datasketches-memory-java8-tests/src/test/java/org/apache/datasketches/memory/test/ReflectUtil.java
@@ -27,7 +27,6 @@ import java.lang.reflect.Method;
 import java.nio.ByteOrder;
 
 import org.apache.datasketches.memory.MemoryRequestServer;
-import org.apache.datasketches.memory.WritableHandle;
 
 public final class ReflectUtil {
 
@@ -392,15 +391,6 @@ public final class ReflectUtil {
   static void unreserveMemory(final long allocationSize, final long capacity) {
     try {
       UNRESERVE_MEMORY.invoke(null, allocationSize, capacity);
-    } catch (final IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  static WritableHandle wrapDirect(final long capacityBytes,
-      final ByteOrder byteOrder, final MemoryRequestServer memReqSvr) {
-    try {
-      return (WritableHandle) WRAP_DIRECT.invoke(null, capacityBytes, byteOrder, memReqSvr);
     } catch (final IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
       throw new RuntimeException(e);
     }

--- a/datasketches-memory-java8-tests/src/test/java/org/apache/datasketches/memory/test/WritableMemoryTest.java
+++ b/datasketches-memory-java8-tests/src/test/java/org/apache/datasketches/memory/test/WritableMemoryTest.java
@@ -47,7 +47,7 @@ public class WritableMemoryTest {
   public void wrapBigEndianAsLittle() {
     ByteBuffer bb = ByteBuffer.allocate(64);
     bb.putChar(0, (char)1); //as BE
-    WritableMemory wmem = WritableMemory.writableWrap(bb, ByteOrder.LITTLE_ENDIAN);
+    WritableMemory wmem = WritableMemory.writableWrap(bb, ByteOrder.LITTLE_ENDIAN, null);
     assertEquals(wmem.getChar(0), 256);
   }
 

--- a/datasketches-memory-java8-tests/src/test/java/org/apache/datasketches/memory/test/WritableMemoryTest.java
+++ b/datasketches-memory-java8-tests/src/test/java/org/apache/datasketches/memory/test/WritableMemoryTest.java
@@ -46,7 +46,7 @@ public class WritableMemoryTest {
   @Test
   public void wrapBigEndianAsLittle() {
     ByteBuffer bb = ByteBuffer.allocate(64);
-    bb.putChar(0, (char)1); //as BE
+    bb.putChar(0, (char)1); //as NNO
     WritableMemory wmem = WritableMemory.writableWrap(bb, ByteOrder.LITTLE_ENDIAN, null);
     assertEquals(wmem.getChar(0), 256);
   }

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/BaseState.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/BaseState.java
@@ -32,6 +32,7 @@ import org.apache.datasketches.memory.internal.BaseStateImpl;
  * @author Lee Rhodes
  */
 public interface BaseState {
+  static final MemoryRequestServer defaultMemReqSvr = new DefaultMemoryRequestServer();
 
   //Byte Order Related
   

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/WritableBuffer.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/WritableBuffer.java
@@ -37,7 +37,7 @@ public interface WritableBuffer extends Buffer {
    * @return a new WritableBuffer for write operations on the given ByteBuffer.
    */
   static WritableBuffer writableWrap(ByteBuffer byteBuf) {
-    return WritableBufferImpl.writableWrap(byteBuf, byteBuf.order());
+    return WritableBufferImpl.writableWrap(byteBuf);
   }
 
   /**
@@ -48,10 +48,13 @@ public interface WritableBuffer extends Buffer {
    * @param byteBuf the given ByteBuffer, must not be null
    * @param byteOrder the byte order to be used, which may be independent of the byte order
    * state of the given ByteBuffer
+   * @param memReqSvr A user-specified MemoryRequestServer.
+   * This is a callback mechanism for a user client to request a larger Memory.
    * @return a new WritableBuffer for write operations on the given ByteBuffer.
    */
-  static WritableBuffer writableWrap(ByteBuffer byteBuf, ByteOrder byteOrder) {
-    return WritableBufferImpl.writableWrap(byteBuf, byteOrder);
+  static WritableBuffer writableWrap(ByteBuffer byteBuf, ByteOrder byteOrder, MemoryRequestServer memReqSvr) {
+    MemoryRequestServer mReqSvr = (memReqSvr == null) ? defaultMemReqSvr : memReqSvr;
+    return WritableBufferImpl.writableWrap(byteBuf, byteOrder, mReqSvr);
   }  
   
   //DUPLICATES
@@ -363,10 +366,11 @@ public interface WritableBuffer extends Buffer {
 
   //OTHER WRITABLE API METHODS
   /**
-   * For Direct Memory only. Other types of backing resources will return null.
-   * Gets the MemoryRequestServer object used by dynamic off-heap (Direct) memory objects
-   * to request additional memory.
-   * Set using {@link WritableMemory#allocateDirect(long, MemoryRequestServer)}.
+   * For ByteBuffer and Direct Memory backed resources only. Heap and Map backed resources will return null.
+   * Gets the MemoryRequestServer object used by dynamic Memory-backed objects
+   * to request additional memory.  To customize the actions of the MemoryRequestServer, 
+   * extend the MemoryRequestServer interfact and 
+   * set using {@link WritableMemory#allocateDirect(long, MemoryRequestServer)}.
    * If not explicity set, this returns the {@link DefaultMemoryRequestServer}.
    * @return the MemoryRequestServer object (if direct memory) or null.
    */

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/WritableBuffer.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/WritableBuffer.java
@@ -55,8 +55,8 @@ public interface WritableBuffer extends Buffer {
   static WritableBuffer writableWrap(ByteBuffer byteBuf, ByteOrder byteOrder, MemoryRequestServer memReqSvr) {
     MemoryRequestServer mReqSvr = (memReqSvr == null) ? defaultMemReqSvr : memReqSvr;
     return WritableBufferImpl.writableWrap(byteBuf, byteOrder, mReqSvr);
-  }  
-  
+  }
+
   //DUPLICATES
   /**
    * Returns a duplicate writable view of this Buffer with the same but independent values of
@@ -368,9 +368,9 @@ public interface WritableBuffer extends Buffer {
   /**
    * For ByteBuffer and Direct Memory backed resources only. Heap and Map backed resources will return null.
    * Gets the MemoryRequestServer object used by dynamic Memory-backed objects
-   * to request additional memory.  To customize the actions of the MemoryRequestServer, 
-   * extend the MemoryRequestServer interfact and 
-   * set using {@link WritableMemory#allocateDirect(long, MemoryRequestServer)}.
+   * to request additional memory.  To customize the actions of the MemoryRequestServer,
+   * extend the MemoryRequestServer interfact and
+   * set using {@link WritableMemory#allocateDirect(long, ByteOrder, MemoryRequestServer)}.
    * If not explicity set, this returns the {@link DefaultMemoryRequestServer}.
    * @return the MemoryRequestServer object (if direct memory) or null.
    */

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/WritableMemory.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/WritableMemory.java
@@ -40,15 +40,15 @@ public interface WritableMemory extends Memory {
   static WritableMemory writableWrap(ByteBuffer byteBuf) {
     return WritableMemoryImpl.writableWrap(byteBuf);
   }
-  
+
   /**
    * Accesses the given ByteBuffer for write operations. The returned WritableMemory object has
    * the given byte order, ignoring the byte order of the given ByteBuffer. If the capacity of
    * the given ByteBuffer is zero the byte order of the returned WritableMemory object
    * (as well as backing storage) is unspecified.
    * @param byteBuf the given ByteBuffer, must not be null
-   * @param byteOrder the byte order to be used, which may be independent of the byte order
-   * state of the given ByteBuffer
+   * @param byteOrder the byte order to be used when reading and writing to the ByteBuffer.
+   * This is independent of the byte order state of the given ByteBuffer.
    * @param memReqSvr A user-specified MemoryRequestServer. If null, the DefaultMemoryRequestServer is used.
    * This is a callback mechanism for a user client to request a larger Memory.
    * @return a new WritableMemory for write operations on the given ByteBuffer.
@@ -57,7 +57,7 @@ public interface WritableMemory extends Memory {
     MemoryRequestServer mReqSvr = (memReqSvr == null) ? defaultMemReqSvr : memReqSvr;
     return WritableMemoryImpl.writableWrap(byteBuf, byteOrder, mReqSvr);
   }
-  
+
   //MAP
   /**
    * Maps the entire given file into native-ordered WritableMemory for write operations
@@ -73,7 +73,7 @@ public interface WritableMemory extends Memory {
   static WritableMapHandle writableMap(File file) {
     return WritableMemoryImpl.writableMap(file);
   }
-  
+
   /**
    * Maps the specified portion of the given file into Memory for write operations
    * (including those &gt; 2GB).
@@ -90,7 +90,7 @@ public interface WritableMemory extends Memory {
   static WritableMapHandle writableMap(File file, long fileOffsetBytes, long capacityBytes, ByteOrder byteOrder) {
     return WritableMemoryImpl.writableMap(file, fileOffsetBytes, capacityBytes, byteOrder);
   }
-  
+
   //ALLOCATE DIRECT
   /**
    * Allocates and provides access to capacityBytes directly in native (off-heap) memory
@@ -113,7 +113,7 @@ public interface WritableMemory extends Memory {
   static WritableHandle allocateDirect(long capacityBytes) {
     return WritableMemoryImpl.allocateDirect(capacityBytes);
   }
-  
+
   /**
    * Allocates and provides access to capacityBytes directly in native (off-heap) memory
    * leveraging the WritableMemory API. The allocated memory will be 8-byte aligned, but may not
@@ -125,16 +125,17 @@ public interface WritableMemory extends Memory {
    * and to call <i>close()</i> when done.</p>
    *
    * @param capacityBytes the size of the desired memory in bytes.
+   * @param byteOrder the given byte order
    * @param memReqSvr A user-specified MemoryRequestServer.
    * This is a callback mechanism for a user client of direct memory to request more memory.
    * @return WritableHandle for this off-heap resource.
    * Please read Javadocs for {@link Handle}.
    */
-  static WritableHandle allocateDirect(long capacityBytes, MemoryRequestServer memReqSvr) {
+  static WritableHandle allocateDirect(long capacityBytes, ByteOrder byteOrder, MemoryRequestServer memReqSvr) {
     MemoryRequestServer mReqSvr = (memReqSvr == null) ? defaultMemReqSvr : memReqSvr;
-    return WritableMemoryImpl.allocateDirect(capacityBytes, mReqSvr);
+    return WritableMemoryImpl.allocateDirect(capacityBytes, byteOrder, mReqSvr);
   }
-  
+
   //REGIONS
   /**
    * A writable region is a writable view of this object.
@@ -207,7 +208,7 @@ public interface WritableMemory extends Memory {
    */
   WritableBuffer asWritableBuffer(ByteOrder byteOrder);
 
-  
+
   //ALLOCATE HEAP VIA AUTOMATIC BYTE ARRAY
   /**
    * Creates on-heap WritableMemory with the given capacity and the native byte order. If the given
@@ -597,17 +598,17 @@ public interface WritableMemory extends Memory {
    */
   void setBits(long offsetBytes, byte bitMask);
 
-  
+
   //OTHER WRITABLE API METHODS
   /**
    * For ByteBuffer and Direct Memory backed resources only. Heap and Map backed resources will return null.
    * Gets the MemoryRequestServer object used by dynamic Memory-backed objects
-   * to request additional memory.  To customize the actions of the MemoryRequestServer, 
-   * extend the MemoryRequestServer interfact and 
-   * set using {@link WritableMemory#allocateDirect(long, MemoryRequestServer)}.
+   * to request additional memory.  To customize the actions of the MemoryRequestServer,
+   * extend the MemoryRequestServer interfact and
+   * set using {@link WritableMemory#allocateDirect(long, ByteOrder, MemoryRequestServer)}.
    * If not explicity set, this returns the {@link DefaultMemoryRequestServer}.
    * @return the MemoryRequestServer object (if direct memory) or null.
    */
   MemoryRequestServer getMemoryRequestServer();
-  
+
 }

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BBNonNativeWritableBufferImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BBNonNativeWritableBufferImpl.java
@@ -45,11 +45,13 @@ final class BBNonNativeWritableBufferImpl extends NonNativeWritableBufferImpl {
       final long capacityBytes,
       final int typeId,
       final ByteBuffer byteBuf,
+      final MemoryRequestServer memReqSvr,
       final BaseWritableMemoryImpl originMemory) {
     super(unsafeObj, nativeBaseOffset, regionOffset, capacityBytes, originMemory);
     this.unsafeObj = unsafeObj;
     this.nativeBaseOffset = nativeBaseOffset;
     this.byteBuf = byteBuf;
+    this.memReqSvr = (memReqSvr == null) ? defaultMemReqSvr : memReqSvr;
     this.typeId = (byte) (id | (typeId & 0x7));
   }
 
@@ -60,10 +62,10 @@ final class BBNonNativeWritableBufferImpl extends NonNativeWritableBufferImpl {
     return Util.isNativeByteOrder(byteOrder)
         ? new BBWritableBufferImpl(
           unsafeObj, nativeBaseOffset, getRegionOffset(offsetBytes), capacityBytes,
-          type, byteBuf, originMemory)
+          type, byteBuf, memReqSvr, originMemory)
         : new BBNonNativeWritableBufferImpl(
           unsafeObj, nativeBaseOffset, getRegionOffset(offsetBytes), capacityBytes,
-          type, byteBuf, originMemory);
+          type, byteBuf, memReqSvr, originMemory);
   }
 
   @Override
@@ -72,10 +74,10 @@ final class BBNonNativeWritableBufferImpl extends NonNativeWritableBufferImpl {
     return Util.isNativeByteOrder(byteOrder)
         ? new BBWritableBufferImpl(
             unsafeObj, nativeBaseOffset, getRegionOffset(), getCapacity(),
-            type, byteBuf, originMemory)
+            type, byteBuf, memReqSvr, originMemory)
         : new BBNonNativeWritableBufferImpl(
             unsafeObj, nativeBaseOffset, getRegionOffset(), getCapacity(),
-            type, byteBuf, originMemory);
+            type, byteBuf, memReqSvr, originMemory);
   }
 
   @Override
@@ -89,7 +91,7 @@ final class BBNonNativeWritableBufferImpl extends NonNativeWritableBufferImpl {
     assertValid();
     return memReqSvr; //cannot be null
   }
-  
+
   @Override
   long getNativeBaseOffset() {
     return nativeBaseOffset;

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BBNonNativeWritableBufferImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BBNonNativeWritableBufferImpl.java
@@ -22,6 +22,8 @@ package org.apache.datasketches.memory.internal;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import org.apache.datasketches.memory.MemoryRequestServer;
+
 /**
  * Implementation of {@link WritableBufferImpl} for ByteBuffer, non-native byte order.
  *
@@ -33,6 +35,7 @@ final class BBNonNativeWritableBufferImpl extends NonNativeWritableBufferImpl {
   private final Object unsafeObj;
   private final long nativeBaseOffset; //used to compute cumBaseOffset
   private final ByteBuffer byteBuf; //holds a reference to a ByteBuffer until we are done with it.
+  private MemoryRequestServer memReqSvr = null; //cannot be final;
   private final byte typeId;
 
   BBNonNativeWritableBufferImpl(
@@ -81,6 +84,12 @@ final class BBNonNativeWritableBufferImpl extends NonNativeWritableBufferImpl {
     return byteBuf;
   }
 
+  @Override
+  public MemoryRequestServer getMemoryRequestServer() {
+    assertValid();
+    return memReqSvr; //cannot be null
+  }
+  
   @Override
   long getNativeBaseOffset() {
     return nativeBaseOffset;

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BBNonNativeWritableMemoryImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BBNonNativeWritableMemoryImpl.java
@@ -73,10 +73,10 @@ final class BBNonNativeWritableMemoryImpl extends NonNativeWritableMemoryImpl {
     return Util.isNativeByteOrder(byteOrder)
         ? new BBWritableBufferImpl(
             unsafeObj, nativeBaseOffset, getRegionOffset(), getCapacity(),
-            type, byteBuf, this)
+            type, byteBuf, memReqSvr, this)
         : new BBNonNativeWritableBufferImpl(
             unsafeObj, nativeBaseOffset, getRegionOffset(), getCapacity(),
-            type, byteBuf, this);
+            type, byteBuf, memReqSvr, this);
   }
 
   @Override
@@ -90,7 +90,7 @@ final class BBNonNativeWritableMemoryImpl extends NonNativeWritableMemoryImpl {
     assertValid();
     return memReqSvr; //cannot be null
   }
-  
+
   @Override
   long getNativeBaseOffset() {
     return nativeBaseOffset;

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BBNonNativeWritableMemoryImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BBNonNativeWritableMemoryImpl.java
@@ -22,6 +22,8 @@ package org.apache.datasketches.memory.internal;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import org.apache.datasketches.memory.MemoryRequestServer;
+
 /**
  * Implementation of {@link WritableMemoryImpl} for ByteBuffer, non-native byte order.
  *
@@ -33,6 +35,7 @@ final class BBNonNativeWritableMemoryImpl extends NonNativeWritableMemoryImpl {
   private final Object unsafeObj;
   private final long nativeBaseOffset; //used to compute cumBaseOffset
   private final ByteBuffer byteBuf; //holds a reference to a ByteBuffer until we are done with it.
+  private MemoryRequestServer memReqSvr = null; //cannot be final;
   private final byte typeId;
 
   BBNonNativeWritableMemoryImpl(
@@ -41,11 +44,13 @@ final class BBNonNativeWritableMemoryImpl extends NonNativeWritableMemoryImpl {
       final long regionOffset,
       final long capacityBytes,
       final int typeId,
-      final ByteBuffer byteBuf) {
+      final ByteBuffer byteBuf,
+      final MemoryRequestServer memReqSvr) {
     super(unsafeObj, nativeBaseOffset, regionOffset, capacityBytes);
     this.unsafeObj = unsafeObj;
     this.nativeBaseOffset = nativeBaseOffset;
     this.byteBuf = byteBuf;
+    this.memReqSvr = (memReqSvr == null) ? defaultMemReqSvr : memReqSvr;
     this.typeId = (byte) (id | (typeId & 0x7));
   }
 
@@ -56,10 +61,10 @@ final class BBNonNativeWritableMemoryImpl extends NonNativeWritableMemoryImpl {
     return Util.isNativeByteOrder(byteOrder)
         ? new BBWritableMemoryImpl(
             unsafeObj, nativeBaseOffset, getRegionOffset(offsetBytes), capacityBytes,
-            type, getByteBuffer())
+            type, getByteBuffer(), memReqSvr)
         : new BBNonNativeWritableMemoryImpl(
             unsafeObj, nativeBaseOffset, getRegionOffset(offsetBytes), capacityBytes,
-            type, getByteBuffer());
+            type, getByteBuffer(), memReqSvr);
   }
 
   @Override
@@ -80,6 +85,12 @@ final class BBNonNativeWritableMemoryImpl extends NonNativeWritableMemoryImpl {
     return byteBuf;
   }
 
+  @Override
+  public MemoryRequestServer getMemoryRequestServer() {
+    assertValid();
+    return memReqSvr; //cannot be null
+  }
+  
   @Override
   long getNativeBaseOffset() {
     return nativeBaseOffset;

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BBWritableBufferImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BBWritableBufferImpl.java
@@ -45,11 +45,13 @@ final class BBWritableBufferImpl extends NativeWritableBufferImpl {
       final long capacityBytes,
       final int typeId,
       final ByteBuffer byteBuf,
+      final MemoryRequestServer memReqSvr,
       final BaseWritableMemoryImpl originMemory) {
     super(unsafeObj, nativeBaseOffset, regionOffset, capacityBytes, originMemory);
     this.unsafeObj = unsafeObj;
     this.nativeBaseOffset = nativeBaseOffset;
     this.byteBuf = byteBuf;
+    this.memReqSvr = (memReqSvr == null) ? defaultMemReqSvr : memReqSvr;
     this.typeId = (byte) (id | (typeId & 0x7));
   }
 
@@ -60,10 +62,10 @@ final class BBWritableBufferImpl extends NativeWritableBufferImpl {
     return Util.isNativeByteOrder(byteOrder)
         ? new BBWritableBufferImpl(
             unsafeObj, nativeBaseOffset, getRegionOffset(offsetBytes), capacityBytes,
-            type, byteBuf, originMemory)
+            type, byteBuf, memReqSvr, originMemory)
         : new BBNonNativeWritableBufferImpl(
             unsafeObj, nativeBaseOffset, getRegionOffset(offsetBytes), capacityBytes,
-            type, byteBuf, originMemory);
+            type, byteBuf, memReqSvr, originMemory);
   }
 
   @Override
@@ -72,10 +74,10 @@ final class BBWritableBufferImpl extends NativeWritableBufferImpl {
     return Util.isNativeByteOrder(byteOrder)
         ? new BBWritableBufferImpl(
             unsafeObj, nativeBaseOffset, getRegionOffset(), getCapacity(),
-            type, byteBuf, originMemory)
+            type, byteBuf, memReqSvr, originMemory)
         : new BBNonNativeWritableBufferImpl(
             unsafeObj, nativeBaseOffset, getRegionOffset(), getCapacity(),
-            type, byteBuf, originMemory);
+            type, byteBuf, memReqSvr, originMemory);
   }
 
   @Override
@@ -89,7 +91,7 @@ final class BBWritableBufferImpl extends NativeWritableBufferImpl {
     assertValid();
     return memReqSvr; //cannot be null
   }
-  
+
   @Override
   long getNativeBaseOffset() {
     return nativeBaseOffset;

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BBWritableBufferImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BBWritableBufferImpl.java
@@ -22,6 +22,8 @@ package org.apache.datasketches.memory.internal;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import org.apache.datasketches.memory.MemoryRequestServer;
+
 /**
  * Implementation of {@link WritableBufferImpl} for ByteBuffer, native byte order.
  *
@@ -33,6 +35,7 @@ final class BBWritableBufferImpl extends NativeWritableBufferImpl {
   private final Object unsafeObj;
   private final long nativeBaseOffset; //used to compute cumBaseOffset
   private final ByteBuffer byteBuf; //holds a reference to a ByteBuffer until we are done with it.
+  private MemoryRequestServer memReqSvr = null; //cannot be final;
   private final byte typeId;
 
   BBWritableBufferImpl(
@@ -81,6 +84,12 @@ final class BBWritableBufferImpl extends NativeWritableBufferImpl {
     return byteBuf;
   }
 
+  @Override
+  public MemoryRequestServer getMemoryRequestServer() {
+    assertValid();
+    return memReqSvr; //cannot be null
+  }
+  
   @Override
   long getNativeBaseOffset() {
     return nativeBaseOffset;

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BBWritableMemoryImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BBWritableMemoryImpl.java
@@ -73,10 +73,10 @@ final class BBWritableMemoryImpl extends NativeWritableMemoryImpl {
     return Util.isNativeByteOrder(byteOrder)
         ? new BBWritableBufferImpl(
             unsafeObj, nativeBaseOffset, getRegionOffset(), getCapacity(),
-            type, byteBuf, this)
+            type, byteBuf, memReqSvr, this)
         : new BBNonNativeWritableBufferImpl(
             unsafeObj, nativeBaseOffset, getRegionOffset(), getCapacity(),
-            type, byteBuf, this);
+            type, byteBuf, memReqSvr, this);
   }
 
   @Override
@@ -90,7 +90,7 @@ final class BBWritableMemoryImpl extends NativeWritableMemoryImpl {
     assertValid();
     return memReqSvr; //cannot be null
   }
-  
+
   @Override
   long getNativeBaseOffset() {
     return nativeBaseOffset;

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BBWritableMemoryImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BBWritableMemoryImpl.java
@@ -22,6 +22,8 @@ package org.apache.datasketches.memory.internal;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import org.apache.datasketches.memory.MemoryRequestServer;
+
 /**
  * Implementation of {@link WritableMemoryImpl} for ByteBuffer, native byte order.
  *
@@ -33,6 +35,7 @@ final class BBWritableMemoryImpl extends NativeWritableMemoryImpl {
   private final Object unsafeObj;
   private final long nativeBaseOffset; //used to compute cumBaseOffset
   private final ByteBuffer byteBuf; //holds a reference to a ByteBuffer until we are done with it.
+  private MemoryRequestServer memReqSvr = null; //cannot be final;
   private final byte typeId;
 
   BBWritableMemoryImpl(
@@ -41,11 +44,13 @@ final class BBWritableMemoryImpl extends NativeWritableMemoryImpl {
       final long regionOffset,
       final long capacityBytes,
       final int typeId,
-      final ByteBuffer byteBuf) {
+      final ByteBuffer byteBuf,
+      final MemoryRequestServer memReqSvr) {
     super(unsafeObj, nativeBaseOffset, regionOffset, capacityBytes);
     this.unsafeObj = unsafeObj;
     this.nativeBaseOffset = nativeBaseOffset;
     this.byteBuf = byteBuf;
+    this.memReqSvr = (memReqSvr == null) ? defaultMemReqSvr : memReqSvr;
     this.typeId = (byte) (id | (typeId & 0x7));
   }
 
@@ -56,10 +61,10 @@ final class BBWritableMemoryImpl extends NativeWritableMemoryImpl {
     return Util.isNativeByteOrder(byteOrder)
         ? new BBWritableMemoryImpl(
             unsafeObj, nativeBaseOffset, getRegionOffset(offsetBytes), capacityBytes,
-            type, getByteBuffer())
+            type, getByteBuffer(), memReqSvr)
         : new BBNonNativeWritableMemoryImpl(
             unsafeObj, nativeBaseOffset, getRegionOffset(offsetBytes), capacityBytes,
-            type, getByteBuffer());
+            type, getByteBuffer(), memReqSvr);
   }
 
   @Override
@@ -80,6 +85,12 @@ final class BBWritableMemoryImpl extends NativeWritableMemoryImpl {
     return byteBuf;
   }
 
+  @Override
+  public MemoryRequestServer getMemoryRequestServer() {
+    assertValid();
+    return memReqSvr; //cannot be null
+  }
+  
   @Override
   long getNativeBaseOffset() {
     return nativeBaseOffset;

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BaseStateImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BaseStateImpl.java
@@ -46,7 +46,7 @@ public abstract class BaseStateImpl implements BaseState {
   static final AtomicLong currentDirectMemoryMapAllocations_ = new AtomicLong();
   static final AtomicLong currentDirectMemoryMapAllocated_ = new AtomicLong();
 
-  
+
 
   //class type IDs. Do not change the bit orders
   // 0000 0XXX
@@ -212,7 +212,7 @@ public abstract class BaseStateImpl implements BaseState {
   public final long xxHash64(final long in, final long seed) {
     return XxHash64.hash(in, seed);
   }
-  
+
   @Override
   public final boolean hasByteBuffer() {
     assertValid();
@@ -331,44 +331,41 @@ public abstract class BaseStateImpl implements BaseState {
     return (getTypeId() >>> 3 & 3) == 3;
   }
 
-  //MONITORING
-
-  /**
-   * Gets the current number of active direct memory allocations.
-   * @return the current number of active direct memory allocations.
-   */
-  public static final long getCurrentDirectMemoryAllocations() {
-    return BaseStateImpl.currentDirectMemoryAllocations_.get();
-  }
-
-  /**
-   * Gets the current size of active direct memory allocated.
-   * @return the current size of active direct memory allocated.
-   */
-  public static final long getCurrentDirectMemoryAllocated() {
-    return BaseStateImpl.currentDirectMemoryAllocated_.get();
-  }
-
-  /**
-   * Gets the current number of active direct memory map allocations.
-   * @return the current number of active direct memory map allocations.
-   */
-  public static final long getCurrentDirectMemoryMapAllocations() {
-    return BaseStateImpl.currentDirectMemoryMapAllocations_.get();
-  }
-
-  /**
-   * Gets the current size of active direct memory map allocated.
-   * @return the current size of active direct memory map allocated.
-   */
-  public static final long getCurrentDirectMemoryMapAllocated() {
-    return BaseStateImpl.currentDirectMemoryMapAllocated_.get();
-  }
-
-  //REACHABILITY FENCE
-  static void reachabilityFence(@SuppressWarnings("unused") final Object obj) { }
-
   //TO STRING
+  //For debugging
+  public static final String typeDecode(final BaseStateImpl mem) {
+    int typeId = mem.getTypeId();
+    StringBuilder sb = new StringBuilder();
+    int group1 = typeId & 0x7;
+    switch (group1) {
+      case 0 : sb.append(""); break;
+      case 1 : sb.append("ReadOnly, "); break;
+      case 2 : sb.append("Region, "); break;
+      case 3 : sb.append("ReadOnly Region, "); break;
+      case 4 : sb.append("Duplicate, "); break;
+      case 5 : sb.append("ReadOnly Duplicate, "); break;
+      case 6 : sb.append("Region Duplicate, "); break;
+      case 7 : sb.append("ReadOnly Region Duplicate, "); break;
+    }
+    int group2 = (typeId >>> 3) & 0x3;
+    switch (group2) {
+      case 0 : sb.append("Heap, "); break;
+      case 1 : sb.append("Direct, "); break;
+      case 2 : sb.append("Map, "); break;
+      case 3 : sb.append("ByteBuffer, "); break;
+    }
+    int group3 = (typeId >>> 5) & 0x1;
+    switch (group3) {
+      case 0 : sb.append("Native, "); break;
+      case 1 : sb.append("NonNative, "); break;
+    }
+    int group4 = (typeId >>> 6) & 0x1;
+    switch (group4) {
+      case 0 : sb.append("Memory"); break;
+      case 1 : sb.append("Buffer"); break;
+    }
+    return sb.toString();
+  }
 
   @Override
   public final String toHexString(final String header, final long offsetBytes,
@@ -444,5 +441,42 @@ public abstract class BaseStateImpl implements BaseState {
 
     return sb.toString();
   }
+
+  //MONITORING
+
+  /**
+   * Gets the current number of active direct memory allocations.
+   * @return the current number of active direct memory allocations.
+   */
+  public static final long getCurrentDirectMemoryAllocations() {
+    return BaseStateImpl.currentDirectMemoryAllocations_.get();
+  }
+
+  /**
+   * Gets the current size of active direct memory allocated.
+   * @return the current size of active direct memory allocated.
+   */
+  public static final long getCurrentDirectMemoryAllocated() {
+    return BaseStateImpl.currentDirectMemoryAllocated_.get();
+  }
+
+  /**
+   * Gets the current number of active direct memory map allocations.
+   * @return the current number of active direct memory map allocations.
+   */
+  public static final long getCurrentDirectMemoryMapAllocations() {
+    return BaseStateImpl.currentDirectMemoryMapAllocations_.get();
+  }
+
+  /**
+   * Gets the current size of active direct memory map allocated.
+   * @return the current size of active direct memory map allocated.
+   */
+  public static final long getCurrentDirectMemoryMapAllocated() {
+    return BaseStateImpl.currentDirectMemoryMapAllocated_.get();
+  }
+
+  //REACHABILITY FENCE
+  static void reachabilityFence(@SuppressWarnings("unused") final Object obj) { }
 
 }

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BaseStateImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BaseStateImpl.java
@@ -29,7 +29,6 @@ import java.nio.ByteOrder;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.datasketches.memory.BaseState;
-import org.apache.datasketches.memory.DefaultMemoryRequestServer;
 import org.apache.datasketches.memory.MemoryRequestServer;
 
 /**
@@ -47,7 +46,7 @@ public abstract class BaseStateImpl implements BaseState {
   static final AtomicLong currentDirectMemoryMapAllocations_ = new AtomicLong();
   static final AtomicLong currentDirectMemoryMapAllocated_ = new AtomicLong();
 
-  static final MemoryRequestServer defaultMemReqSvr = new DefaultMemoryRequestServer();
+  
 
   //class type IDs. Do not change the bit orders
   // 0000 0XXX

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BaseWritableMemoryImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BaseWritableMemoryImpl.java
@@ -89,7 +89,8 @@ abstract class BaseWritableMemoryImpl extends WritableMemoryImpl {
   }
 
   static BaseWritableMemoryImpl wrapByteBuffer(
-      final ByteBuffer byteBuf, final boolean localReadOnly, final ByteOrder byteOrder) {
+      final ByteBuffer byteBuf, final boolean localReadOnly, final ByteOrder byteOrder, 
+      final MemoryRequestServer memReqSvr) {
     final AccessByteBuffer abb = new AccessByteBuffer(byteBuf);
     if (abb.resourceReadOnly && !localReadOnly) {
       throw new ReadOnlyException("ByteBuffer is Read Only");
@@ -97,9 +98,9 @@ abstract class BaseWritableMemoryImpl extends WritableMemoryImpl {
     final int typeId = (abb.resourceReadOnly || localReadOnly) ? READONLY : 0;
     return Util.isNativeByteOrder(byteOrder)
         ? new BBWritableMemoryImpl(abb.unsafeObj, abb.nativeBaseOffset,
-            abb.regionOffset, abb.capacityBytes, typeId, byteBuf)
+            abb.regionOffset, abb.capacityBytes, typeId, byteBuf, memReqSvr)
         : new BBNonNativeWritableMemoryImpl(abb.unsafeObj, abb.nativeBaseOffset,
-            abb.regionOffset, abb.capacityBytes,  typeId, byteBuf);
+            abb.regionOffset, abb.capacityBytes,  typeId, byteBuf, memReqSvr);
   }
 
   @SuppressWarnings("resource")

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BufferImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BufferImpl.java
@@ -48,14 +48,14 @@ public abstract class BufferImpl extends BaseBufferImpl implements Buffer {
 
   public static BufferImpl wrap(final ByteBuffer byteBuf, final ByteOrder byteOrder) {
     final BaseWritableMemoryImpl wmem =
-        BaseWritableMemoryImpl.wrapByteBuffer(byteBuf, true, byteOrder);
+        BaseWritableMemoryImpl.wrapByteBuffer(byteBuf, true, byteOrder, defaultMemReqSvr);
     final WritableBufferImpl wbuf = wmem.asWritableBuffer(true, byteOrder);
     wbuf.setStartPositionEnd(0, byteBuf.position(), byteBuf.limit());
     return wbuf;
   }
 
   //MAP
-  //Use MemoryImpl for mapping files and the asBuffer()
+  //Use MemoryImpl for mapping files and then call asBuffer()
 
   //DUPLICATES
   @Override

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/DirectNonNativeWritableBufferImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/DirectNonNativeWritableBufferImpl.java
@@ -98,11 +98,4 @@ final class DirectNonNativeWritableBufferImpl extends NonNativeWritableBufferImp
     return valid.get();
   }
 
-  @Override
-  void checkValid() {
-    if (!this.isValid()) {
-      throw new IllegalStateException("MemoryImpl not valid.");
-    }
-  }
-  
 }

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/DirectNonNativeWritableMemoryImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/DirectNonNativeWritableMemoryImpl.java
@@ -96,11 +96,4 @@ final class DirectNonNativeWritableMemoryImpl extends NonNativeWritableMemoryImp
     return valid.get();
   }
 
-  @Override
-  void checkValid() {
-    if (!this.isValid()) {
-      throw new IllegalStateException("MemoryImpl not valid.");
-    }
-  }
-  
 }

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/DirectWritableBufferImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/DirectWritableBufferImpl.java
@@ -98,10 +98,4 @@ final class DirectWritableBufferImpl extends NativeWritableBufferImpl {
     return valid.get();
   }
 
-  @Override
-  void checkValid() {
-    if (!this.isValid()) {
-      throw new IllegalStateException("MemoryImpl not valid.");
-    }
-  }
 }

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/HeapNonNativeWritableBufferImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/HeapNonNativeWritableBufferImpl.java
@@ -21,6 +21,8 @@ package org.apache.datasketches.memory.internal;
 
 import java.nio.ByteOrder;
 
+import org.apache.datasketches.memory.MemoryRequestServer;
+
 /**
  * Implementation of {@link WritableBufferImpl} for heap-based, non-native byte order.
  *
@@ -68,6 +70,11 @@ final class HeapNonNativeWritableBufferImpl extends NonNativeWritableBufferImpl 
             type, originMemory);
   }
 
+  @Override
+  public MemoryRequestServer getMemoryRequestServer() {
+    return null;
+  }
+  
   @Override
   int getTypeId() {
     return typeId & 0xff;

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/HeapNonNativeWritableMemoryImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/HeapNonNativeWritableMemoryImpl.java
@@ -21,6 +21,8 @@ package org.apache.datasketches.memory.internal;
 
 import java.nio.ByteOrder;
 
+import org.apache.datasketches.memory.MemoryRequestServer;
+
 /**
  * Implementation of {@link WritableMemoryImpl} for heap-based, non-native byte order.
  *
@@ -68,6 +70,11 @@ final class HeapNonNativeWritableMemoryImpl extends NonNativeWritableMemoryImpl 
   }
 
   @Override
+  public MemoryRequestServer getMemoryRequestServer() {
+    return null;
+  }
+  
+  @Override
   int getTypeId() {
     return typeId & 0xff;
   }
@@ -76,5 +83,5 @@ final class HeapNonNativeWritableMemoryImpl extends NonNativeWritableMemoryImpl 
   Object getUnsafeObject() {
     return unsafeObj;
   }
-
+  
 }

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/HeapWritableBufferImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/HeapWritableBufferImpl.java
@@ -21,6 +21,8 @@ package org.apache.datasketches.memory.internal;
 
 import java.nio.ByteOrder;
 
+import org.apache.datasketches.memory.MemoryRequestServer;
+
 /**
  * Implementation of {@link WritableBufferImpl} for heap-based, native byte order.
  *
@@ -68,6 +70,11 @@ final class HeapWritableBufferImpl extends NativeWritableBufferImpl {
             type, originMemory);
   }
 
+  @Override
+  public MemoryRequestServer getMemoryRequestServer() {
+    return null;
+  }
+  
   @Override
   int getTypeId() {
     return typeId & 0xff;

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/HeapWritableMemoryImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/HeapWritableMemoryImpl.java
@@ -21,6 +21,8 @@ package org.apache.datasketches.memory.internal;
 
 import java.nio.ByteOrder;
 
+import org.apache.datasketches.memory.MemoryRequestServer;
+
 /**
  * Implementation of {@link WritableMemoryImpl} for heap-based, native byte order.
  *
@@ -67,6 +69,11 @@ final class HeapWritableMemoryImpl extends NativeWritableMemoryImpl {
             type, this);
   }
 
+  @Override
+  public MemoryRequestServer getMemoryRequestServer() {
+    return null;
+  }
+  
   @Override
   int getTypeId() {
     return typeId & 0xff;

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/MapNonNativeWritableBufferImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/MapNonNativeWritableBufferImpl.java
@@ -21,6 +21,8 @@ package org.apache.datasketches.memory.internal;
 
 import java.nio.ByteOrder;
 
+import org.apache.datasketches.memory.MemoryRequestServer;
+
 /**
  * Implementation of {@link WritableBufferImpl} for map memory, non-native byte order.
  *
@@ -72,6 +74,11 @@ final class MapNonNativeWritableBufferImpl extends NonNativeWritableBufferImpl {
   }
 
   @Override
+  public MemoryRequestServer getMemoryRequestServer() {
+    return null;
+  }
+  
+  @Override
   long getNativeBaseOffset() {
     return nativeBaseOffset;
   }
@@ -86,11 +93,4 @@ final class MapNonNativeWritableBufferImpl extends NonNativeWritableBufferImpl {
     return valid.get();
   }
 
-  @Override
-  void checkValid() {
-    if (!this.isValid()) {
-      throw new IllegalStateException("MemoryImpl not valid.");
-    }
-  }
-  
 }

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/MapNonNativeWritableMemoryImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/MapNonNativeWritableMemoryImpl.java
@@ -21,6 +21,8 @@ package org.apache.datasketches.memory.internal;
 
 import java.nio.ByteOrder;
 
+import org.apache.datasketches.memory.MemoryRequestServer;
+
 /**
  * Implementation of {@link WritableMemoryImpl} for map memory, non-native byte order.
  *
@@ -71,6 +73,11 @@ final class MapNonNativeWritableMemoryImpl extends NonNativeWritableMemoryImpl {
   }
 
   @Override
+  public MemoryRequestServer getMemoryRequestServer() {
+    return null;
+  }
+  
+  @Override
   long getNativeBaseOffset() {
     return nativeBaseOffset;
   }
@@ -83,13 +90,6 @@ final class MapNonNativeWritableMemoryImpl extends NonNativeWritableMemoryImpl {
   @Override
   public boolean isValid() {
     return valid.get();
-  }
-
-  @Override
-  void checkValid() {
-    if (!this.isValid()) {
-      throw new IllegalStateException("MemoryImpl not valid.");
-    }
   }
   
 }

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/MapWritableBufferImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/MapWritableBufferImpl.java
@@ -21,6 +21,8 @@ package org.apache.datasketches.memory.internal;
 
 import java.nio.ByteOrder;
 
+import org.apache.datasketches.memory.MemoryRequestServer;
+
 /**
  * Implementation of {@link WritableBufferImpl} for map memory, native byte order.
  *
@@ -72,6 +74,11 @@ final class MapWritableBufferImpl extends NativeWritableBufferImpl {
   }
 
   @Override
+  public MemoryRequestServer getMemoryRequestServer() {
+    return null;
+  }
+  
+  @Override
   long getNativeBaseOffset() {
     return nativeBaseOffset;
   }
@@ -86,11 +93,4 @@ final class MapWritableBufferImpl extends NativeWritableBufferImpl {
     return valid.get();
   }
 
-  @Override
-  void checkValid() {
-    if (!this.isValid()) {
-      throw new IllegalStateException("MemoryImpl not valid.");
-    }
-  }
-  
 }

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/MapWritableMemoryImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/MapWritableMemoryImpl.java
@@ -21,6 +21,8 @@ package org.apache.datasketches.memory.internal;
 
 import java.nio.ByteOrder;
 
+import org.apache.datasketches.memory.MemoryRequestServer;
+
 /**
  * Implementation of {@link WritableMemoryImpl} for map memory, native byte order.
  *
@@ -71,6 +73,11 @@ final class MapWritableMemoryImpl extends NativeWritableMemoryImpl {
   }
 
   @Override
+  public MemoryRequestServer getMemoryRequestServer() {
+    return null;
+  }
+  
+  @Override
   long getNativeBaseOffset() {
     return nativeBaseOffset;
   }
@@ -83,13 +90,6 @@ final class MapWritableMemoryImpl extends NativeWritableMemoryImpl {
   @Override
   public boolean isValid() {
     return valid.get();
-  }
-
-  @Override
-  void checkValid() {
-    if (!this.isValid()) {
-      throw new IllegalStateException("MemoryImpl not valid.");
-    }
   }
   
 }

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/MemoryImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/MemoryImpl.java
@@ -53,11 +53,11 @@ public abstract class MemoryImpl extends BaseStateImpl implements Memory {
 
   //BYTE BUFFER
   public static MemoryImpl wrap(final ByteBuffer byteBuf) {
-    return BaseWritableMemoryImpl.wrapByteBuffer(byteBuf, true, byteBuf.order());
+    return BaseWritableMemoryImpl.wrapByteBuffer(byteBuf, true, byteBuf.order(), defaultMemReqSvr);
   }
 
   public static MemoryImpl wrap(final ByteBuffer byteBuf, final ByteOrder byteOrder) {
-    return BaseWritableMemoryImpl.wrapByteBuffer(byteBuf, true, byteOrder);
+    return BaseWritableMemoryImpl.wrapByteBuffer(byteBuf, true, byteOrder, defaultMemReqSvr);
   }
 
   //MAP

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/WritableBufferImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/WritableBufferImpl.java
@@ -42,12 +42,13 @@ public abstract class WritableBufferImpl extends BufferImpl implements WritableB
 
   //BYTE BUFFER
   public static WritableBufferImpl writableWrap(final ByteBuffer byteBuf) {
-    return writableWrap(byteBuf, byteBuf.order());
+    return writableWrap(byteBuf, byteBuf.order(), defaultMemReqSvr);
   }
 
-  public static WritableBufferImpl writableWrap(final ByteBuffer byteBuf, final ByteOrder byteOrder) {
+  public static WritableBufferImpl writableWrap(final ByteBuffer byteBuf, final ByteOrder byteOrder,
+      final MemoryRequestServer memReqSvr) {
     final BaseWritableMemoryImpl wmem =
-        BaseWritableMemoryImpl.wrapByteBuffer(byteBuf, false, byteOrder);
+        BaseWritableMemoryImpl.wrapByteBuffer(byteBuf, false, byteOrder, memReqSvr);
     final WritableBufferImpl wbuf = wmem.asWritableBuffer(false, byteOrder);
     wbuf.setStartPositionEnd(0, byteBuf.position(), byteBuf.limit());
     return wbuf;
@@ -165,11 +166,5 @@ public abstract class WritableBufferImpl extends BufferImpl implements WritableB
 
   @Override
   public abstract void fill(byte value);
-
-  //OTHER WRITABLE API METHODS
-  @Override
-  public MemoryRequestServer getMemoryRequestServer() {
-    return null;
-  }
 
 }

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/WritableMemoryImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/WritableMemoryImpl.java
@@ -74,12 +74,12 @@ public abstract class WritableMemoryImpl extends MemoryImpl implements WritableM
 
   //ALLOCATE DIRECT
   public static WritableHandle allocateDirect(final long capacityBytes) {
-    return allocateDirect(capacityBytes, null);
+    return allocateDirect(capacityBytes, ByteOrder.nativeOrder(), defaultMemReqSvr);
   }
 
-  public static WritableHandle allocateDirect(final long capacityBytes,
+  public static WritableHandle allocateDirect(final long capacityBytes, final ByteOrder byteOrder,
       final MemoryRequestServer memReqSvr) {
-    return BaseWritableMemoryImpl.wrapDirect(capacityBytes, Util.nativeByteOrder, memReqSvr);
+    return BaseWritableMemoryImpl.wrapDirect(capacityBytes, byteOrder, memReqSvr);
   }
 
   //REGIONS

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/WritableMemoryImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/WritableMemoryImpl.java
@@ -50,11 +50,12 @@ public abstract class WritableMemoryImpl extends MemoryImpl implements WritableM
 
   //BYTE BUFFER
   public static WritableMemoryImpl writableWrap(final ByteBuffer byteBuf) {
-    return BaseWritableMemoryImpl.wrapByteBuffer(byteBuf, false, byteBuf.order());
+    return BaseWritableMemoryImpl.wrapByteBuffer(byteBuf, false, byteBuf.order(), defaultMemReqSvr);
   }
 
-  public static WritableMemoryImpl writableWrap(final ByteBuffer byteBuf, final ByteOrder byteOrder) {
-    return BaseWritableMemoryImpl.wrapByteBuffer(byteBuf, false, byteOrder);
+  public static WritableMemoryImpl writableWrap(final ByteBuffer byteBuf, final ByteOrder byteOrder,
+      final MemoryRequestServer memReqSvr) {
+    return BaseWritableMemoryImpl.wrapByteBuffer(byteBuf, false, byteOrder, memReqSvr);
   }
 
   //MAP
@@ -250,11 +251,4 @@ public abstract class WritableMemoryImpl extends MemoryImpl implements WritableM
   @Override
   public abstract void setBits(long offsetBytes, byte bitMask);
 
-  
-  //OTHER WRITABLE API METHODS
-  @Override
-  public MemoryRequestServer getMemoryRequestServer() {
-    return null;
-  }
-  
 }


### PR DESCRIPTION
This PR fixes the datasketches-java issue #358, which was actually an issue in Memory, and the Druid issue #11544. 

This is a rather complex set of changes that involved about 30 classes.  Along the way I found some other other discrepancies and missing capabilities in the API and fixed those as well.  The tests have been extensively rewritten to cover (I hope) all cases.  I do want to add one more test that closely reproduces the bug discovered by the Druid folks. 

I don't expect anyone to understand all the subtleties in these changes, at least not by only scanning. Nonetheless, I would appreciate another pair of eyes, just to see if anything looks weird. 

There will be a few more PRs coming, but with different focus.