### PR TITLE
Add instructions for local MR-jar testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ To run javadoc on this multi-module project, use:
 
     $ mvn clean process-classes javadoc:javadoc -DskipTests=true
 
+To run the CI tests against the multi-release JAR for specific JVM versions [9-13], use:
+
+    $ mvn clean package -Denvironment=ci -Dmatrix.jdk.version=9
+
 To run the eclipse plugin on this multi-module project, use:
 
     $ mvn clean process-classes eclipse:eclipse -DskipTests=true


### PR DESCRIPTION
Verified that the C/I tests actually do make use of the `sun.nio.ch`
package for memory-mapped files. Removing the runtime JPMS flag for
this package from Surefire results in a warning, since the tests
use the classpath and not the module path.  Using the module path
in the tests would require a local `module-info.java` in the tests,
which would present problems for Java8.

Using Datasketches Memory for memory-mapped in a JPMS-enabled user
application requires explicit opens access to the `sun.nio.ch` package
otherwise the user application will exit with a hard failure instead
of a warning.