### PR TITLE
Checkstyle and SpotBugs fixes

### DIFF
--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/WritableMemory.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/WritableMemory.java
@@ -250,7 +250,7 @@ public interface WritableMemory extends Memory {
    * @return a new WritableMemory for write operations on a new byte array.
    */
   static WritableMemory allocate(int capacityBytes, ByteOrder byteOrder, MemoryRequestServer memReqSvr) {
-    byte[] arr = new byte[capacityBytes];
+    final byte[] arr = new byte[capacityBytes];
     negativeCheck(capacityBytes, "capacityBytes");
     return writableWrap(arr, 0, capacityBytes, byteOrder, memReqSvr);
   }

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BaseStateImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BaseStateImpl.java
@@ -301,7 +301,7 @@ public abstract class BaseStateImpl implements BaseState {
     return (getTypeId() & READONLY) > 0;
   }
 
-  final static byte setReadOnlyType(byte type, boolean readOnly) {
+  final static byte setReadOnlyType(final byte type, final boolean readOnly) {
     return (byte)((type & ~1) | (readOnly ? READONLY : 0));
   }
 
@@ -346,10 +346,9 @@ public abstract class BaseStateImpl implements BaseState {
    * @return a human readable string.
    */
   public static final String typeDecode(final int typeId) {
-    StringBuilder sb = new StringBuilder();
-    int group1 = typeId & 0x7;
+    final StringBuilder sb = new StringBuilder();
+    final int group1 = typeId & 0x7;
     switch (group1) {
-      case 0 : sb.append(""); break;
       case 1 : sb.append("ReadOnly, "); break;
       case 2 : sb.append("Region, "); break;
       case 3 : sb.append("ReadOnly Region, "); break;
@@ -357,23 +356,27 @@ public abstract class BaseStateImpl implements BaseState {
       case 5 : sb.append("ReadOnly Duplicate, "); break;
       case 6 : sb.append("Region Duplicate, "); break;
       case 7 : sb.append("ReadOnly Region Duplicate, "); break;
+      default: break;
     }
-    int group2 = (typeId >>> 3) & 0x3;
+    final int group2 = (typeId >>> 3) & 0x3;
     switch (group2) {
       case 0 : sb.append("Heap, "); break;
       case 1 : sb.append("Direct, "); break;
       case 2 : sb.append("Map, "); break;
       case 3 : sb.append("ByteBuffer, "); break;
+      default: break;
     }
-    int group3 = (typeId >>> 5) & 0x1;
+    final int group3 = (typeId >>> 5) & 0x1;
     switch (group3) {
       case 0 : sb.append("Native, "); break;
       case 1 : sb.append("NonNative, "); break;
+      default: break;
     }
-    int group4 = (typeId >>> 6) & 0x1;
+    final int group4 = (typeId >>> 6) & 0x1;
     switch (group4) {
       case 0 : sb.append("Memory"); break;
       case 1 : sb.append("Buffer"); break;
+      default: break;
     }
     return sb.toString();
   }

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BaseWritableBufferImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/BaseWritableBufferImpl.java
@@ -80,7 +80,7 @@ public abstract class BaseWritableBufferImpl extends BaseBufferImpl implements W
       final MemoryRequestServer memReqSvr) {
     final AccessByteBuffer abb = new AccessByteBuffer(byteBuf);
     final int typeId = (abb.resourceReadOnly || localReadOnly) ? READONLY : 0;
-    BaseWritableBufferImpl bwbi = Util.isNativeByteOrder(byteOrder)
+    final BaseWritableBufferImpl bwbi = Util.isNativeByteOrder(byteOrder)
         ? new BBWritableBufferImpl(abb.unsafeObj, abb.nativeBaseOffset,
             abb.regionOffset, abb.capacityBytes, typeId, byteBuf, memReqSvr)
         : new BBNonNativeWritableBufferImpl(abb.unsafeObj, abb.nativeBaseOffset,

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/Util.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/Util.java
@@ -42,7 +42,7 @@ public final class Util {
   public static final ByteOrder NON_NATIVE_BYTE_ORDER = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN
       ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN;
 
-  public static ByteOrder otherByteOrder(ByteOrder order) {
+  public static ByteOrder otherByteOrder(final ByteOrder order) {
     return (order == ByteOrder.nativeOrder()) ? NON_NATIVE_BYTE_ORDER : ByteOrder.nativeOrder();
   }
 


### PR DESCRIPTION
The following violations were corrected:

- marking fields and parameters as final
- missing default cases in switch statement

Note that there are 'violations' in the MurmerHashV3 class concerning
switch fall-throughs.  This is left as-is.