### PR TITLE
Fix rat configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -322,7 +322,7 @@ under the License.
               <exclude>**/.*/**/*</exclude>
               <exclude>**/.clover/**/*</exclude>
               <exclude>**/test/resources/**/*.txt</exclude>
-              <exclude>**/docs/img/**/*</exclude>
+              <exclude>**/img/**/*.png</exclude>
               <exclude>**/git.properties</exclude>
               <exclude>LICENSE</exclude>
               <exclude>NOTICE</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -322,7 +322,8 @@ under the License.
               <exclude>**/.*/**/*</exclude>
               <exclude>**/.clover/**/*</exclude>
               <exclude>**/test/resources/**/*.txt</exclude>
-              <exclude>**/docs/*.md</exclude>
+              <exclude>**/docs/img/**/*</exclude>
+              <exclude>**/git.properties</exclude>
               <exclude>LICENSE</exclude>
               <exclude>NOTICE</exclude>
             </excludes>


### PR DESCRIPTION
Markdown documentation should not be excluded from licensing requirements.  Instead, images and autogenerated files should be, and are added to the exclusion list.