### PR TITLE
Add git properties to output JARs by default

### DIFF
--- a/datasketches-memory/pom.xml
+++ b/datasketches-memory/pom.xml
@@ -312,6 +312,41 @@
           <groupId>pl.project13.maven</groupId>
           <artifactId>git-commit-id-plugin</artifactId>
           <version>${git-commit-id-plugin.version}</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>revision</goal>
+              </goals>
+              <phase>initialize</phase>
+            </execution>
+          </executions>
+          <configuration>
+            <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+            <dateFormatTimeZone>UTC</dateFormatTimeZone>
+            <verbose>false</verbose>
+            <skipPoms>false</skipPoms>
+            <format>json</format>
+            <generateGitPropertiesFile>true</generateGitPropertiesFile>
+            <generateGitPropertiesFilename>${project.build.directory}/git.properties</generateGitPropertiesFilename>
+            <failOnNoGitDirectory>true</failOnNoGitDirectory>
+            <failOnUnableToExtractRepoInfo>true</failOnUnableToExtractRepoInfo>
+            <commitIdGenerationMode>full</commitIdGenerationMode>
+            <includeOnlyProperties>
+              <includeProperty>git.branch</includeProperty>
+              <includeProperty>git.commit.id.full</includeProperty>
+              <includeProperty>git.commit.time</includeProperty>
+              <includeProperty>git.commit.user.email</includeProperty>
+              <includeProperty>git.tags</includeProperty>
+            </includeOnlyProperties>
+            <gitDescribe>
+              <skip>false</skip>
+              <always>true</always>
+              <abbrev>7</abbrev>
+              <dirty>-dirty</dirty>
+              <tags>true</tags>
+              <forceLongFormat>true</forceLongFormat>
+            </gitDescribe>
+          </configuration>
         </plugin>
 
         <plugin>
@@ -362,47 +397,6 @@
       <build>
         <pluginManagement>
           <plugins>
-            <plugin>
-              <groupId>pl.project13.maven</groupId>
-              <artifactId>git-commit-id-plugin</artifactId>
-              <version>${git-commit-id-plugin.version}</version>
-              <executions>
-                <execution>
-                  <goals>
-                    <goal>revision</goal>
-                  </goals>
-                  <phase>initialize</phase>
-                </execution>
-              </executions>
-              <configuration>
-                <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
-                <dateFormatTimeZone>UTC</dateFormatTimeZone>
-                <verbose>false</verbose>
-                <skipPoms>false</skipPoms>
-                <format>json</format>
-                <generateGitPropertiesFile>true</generateGitPropertiesFile>
-                <generateGitPropertiesFilename>${project.build.directory}/git.properties</generateGitPropertiesFilename>
-                <failOnNoGitDirectory>true</failOnNoGitDirectory>
-                <failOnUnableToExtractRepoInfo>true</failOnUnableToExtractRepoInfo>
-                <commitIdGenerationMode>full</commitIdGenerationMode>
-                <includeOnlyProperties>
-                  <includeProperty>git.branch</includeProperty>
-                  <includeProperty>git.commit.id.full</includeProperty>
-                  <includeProperty>git.commit.time</includeProperty>
-                  <includeProperty>git.commit.user.email</includeProperty>
-                  <includeProperty>git.tags</includeProperty>
-                </includeOnlyProperties>
-                <gitDescribe>
-                  <skip>false</skip>
-                  <always>true</always>
-                  <abbrev>7</abbrev>
-                  <dirty>-dirty</dirty>
-                  <tags>true</tags>
-                  <forceLongFormat>true</forceLongFormat>
-                </gitDescribe>
-              </configuration>
-            </plugin>
-
             <!-- We want to sign the artifacts, POM, and all attached artifacts -->
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Previously, git properties were only added to the JAR Manifest.MF file whilst the nexus-jars profile was active. Now, they are included by default regardless of whether the JARs are published to Nexus or not.
This also aligns with the behaviour of the shell build script, where the entries are always added to the JAR's manifest.