### PR TITLE
Update POM with latest versions

### DIFF
--- a/datasketches-memory/pom.xml
+++ b/datasketches-memory/pom.xml
@@ -1,22 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one
-  ~ or more contributor license agreements.  See the NOTICE file
-  ~ distributed with this work for additional information
-  ~ regarding copyright ownership.  The ASF licenses this file
-  ~ to you under the Apache License, Version 2.0 (the
-  ~ "License"); you may not use this file except in compliance
-  ~ with the License.  You may obtain a copy of the License at
-  ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing,
-  ~ software distributed under the License is distributed on an
-  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  ~ KIND, either express or implied.  See the License for the
-  ~ specific language governing permissions and limitations
-  ~ under the License.
-  -->
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
@@ -59,11 +60,11 @@
       <archive>https://mail-archives.apache.org/mod_mbox/datasketches-dev</archive>
     </mailingList>
     <mailingList>
-      <name>sketches-user</name>
-      <archive>https://groups.google.com/forum/#!forum/sketches-user</archive>
-      <subscribe>mailto:sketches-user%2Bsubscribe@googlegroups.com</subscribe>
-      <unsubscribe>mailto:sketches-user%2Bunsubscribe@googlegroups.com</unsubscribe>
-      <post>mailto:sketches-user@googlegroups.com</post>
+      <name>DataSketches Users</name>
+      <subscribe>user-subscribe@datasketches.apache.org</subscribe>
+      <unsubscribe>user-unsubscribe@datasketches.apache.org</unsubscribe>
+      <post>user@datasketches.apache.org</post>
+      <archive>https://mail-archives.apache.org/mod_mbox/datasketches-user</archive>
     </mailingList>
   </mailingLists>
 
@@ -116,7 +117,7 @@
     <!--  Maven Plugins -->
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version> <!-- overrides parent -->
     <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version> <!-- overrides parent -->
-    <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version> <!-- overrides parent -->
+    <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version> <!-- overrides parent -->
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version> <!-- overrides parent -->
     <maven-remote-resources-plugin.version>1.7.0</maven-remote-resources-plugin.version> <!-- overrides parent -->
     <!-- org.jacoco Maven Plugins -->


### PR DESCRIPTION
Some minor changes to the POM

Updates maven-gpg-plugin from 1.6 to 3.0.1 (first upgrade in this plugin in about 6 years.)
Removed the leading tildas in the license header (they are not necessary to satisfy the Rat plugin).