### PR TITLE
Fix jacoco plugin report

### DIFF
--- a/datasketches-memory-java11/pom.xml
+++ b/datasketches-memory-java11/pom.xml
@@ -53,21 +53,6 @@
                         </compilerArgs>
                     </configuration>
                 </plugin>
-                <plugin>
-                    <!-- Generates aggregate code coverage report from website.  This applies across all Maven submodules. -->
-                    <groupId>org.jacoco</groupId>
-                    <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>${jacoco-maven-plugin.version}</version>
-                    <executions>
-                        <execution>
-                            <id>default-report</id>
-                            <phase>verify</phase>
-                            <goals>
-                                <goal>report-aggregate</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/datasketches-memory-java8/pom.xml
+++ b/datasketches-memory-java8/pom.xml
@@ -61,4 +61,24 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>report</id>
+              <phase>test</phase>
+              <goals>
+                <goal>report</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -413,7 +413,7 @@ under the License.
             <!--suppress UnresolvedMavenProperty -->
             <repoToken>${coveralls-repo-token}</repoToken>
             <!--suppress UnresolvedMavenProperty -->
-            <jacocoReports>${maven.multiModuleProjectDirectory}/datasketches-memory-java11/target/site/jacoco-aggregate/jacoco.xml</jacocoReports>
+            <jacocoReports>${maven.multiModuleProjectDirectory}/datasketches-memory-java8/target/site/jacoco/jacoco.xml</jacocoReports>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
The test coverage report is now generated during
the test phase when a user runs 'mvn test'.