### PR TITLE
Reported in issue #178:

### DIFF
--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/Memory.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/Memory.java
@@ -195,7 +195,7 @@ public interface Memory extends BaseState {
     negativeCheck(offsetBytes, "offsetBytes");
     negativeCheck(lengthBytes, "lengthBytes");
     UnsafeUtil.checkBounds(offsetBytes, lengthBytes, array.length);
-    return BaseWritableMemoryImpl.wrapHeapArray(array, 0, lengthBytes, true, ByteOrder.nativeOrder(), null);
+    return BaseWritableMemoryImpl.wrapHeapArray(array, offsetBytes, lengthBytes, true, ByteOrder.nativeOrder(), null);
   }
 
   /**

--- a/datasketches-memory-java8/src/test/java/org/apache/datasketches/memory/internal/MemoryTest.java
+++ b/datasketches-memory-java8/src/test/java/org/apache/datasketches/memory/internal/MemoryTest.java
@@ -458,6 +458,18 @@ public class MemoryTest {
   }
 
   @Test
+  public void checkIssue178() {
+    int n = 8;
+    byte[] bArr = new byte[n];
+    for (int i = 0; i < n; i++) { bArr[i] = (byte)i; }
+    Memory mem = Memory.wrap(bArr, n / 2, n / 2, ByteOrder.nativeOrder());
+    for (int i = 0; i < n / 2; i++) {
+      println(mem.getByte(i));
+      assertEquals(mem.getByte(i), n / 2 + i);
+    }
+  }
+
+  @Test
   public void printlnTest() {
     println("PRINTING: "+this.getClass().getName());
   }


### PR DESCRIPTION
static Memory wrap(byte[] array, int offsetBytes, int lengthBytes, ByteOrder byteOrder) ...
...
return BaseWritableMemoryImpl.wrapHeapArray(array, 0, lengthBytes, true, ByteOrder.nativeOrder(), null);

The "0" in the return statement should have been "offsetBytes". I checked the similar classes WritableMemory, Buffer and WritableBuffer for a similar error and they were all OK.
This fix includes a test for this bug.

This will be merged into branch 2.2.X in preparation for a bug fix release 2.2.1.