### PR TITLE
Fix check java version() in 3.0.x

### DIFF
--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/UnsafeUtil.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/UnsafeUtil.java
@@ -143,13 +143,28 @@ public final class UnsafeUtil {
     return new int[] {p0, p1};
   }
 
+  /**
+   * Checks the runtime Java Version string. Note that Java 17 is allowed only because some clients do not use the
+   * WritableMemory.allocateDirect(..) and related functions, which will not work with 17.  
+   * The on-heap functions work just fine with 17. Nonetheless, Java 17 is not officially supported. 
+   * @param jdkVer the <i>System.getProperty("java.version")</i> string of the form "p0.p1.X"
+   * @param p0 The first number group 
+   * @param p1 The second number group
+   */
   public static void checkJavaVersion(final String jdkVer, final int p0, final int p1) {
-    if ( (p0 < 1) || ((p0 == 1) && (p1 < 8)) || (p0 > 13)  ) {
+    final boolean ok = ( ((p0 == 1) && (p1 == 8)) || (p0 == 8) || (p0 == 11) || (p0 == 17) );
+    if (!ok) {
       throw new IllegalArgumentException(
-          "Unsupported JDK Major Version, must be one of 1.8, 8, 11, 17: " + jdkVer);
+          "Unsupported Runtime JDK Major Version, must be one of 1.8, 8, 11, 17: " + jdkVer);
     }
   }
 
+  /**
+   * Gets the <i>unsafe.objectFieldOffset(..)</i> for declared fields of a class.
+   * @param c the class
+   * @param fieldName the declared field name
+   * @return the field offset in bytes.
+   */
   public static long getFieldOffset(final Class<?> c, final String fieldName) {
     try {
       return unsafe.objectFieldOffset(c.getDeclaredField(fieldName));

--- a/datasketches-memory-java8/src/test/java/org/apache/datasketches/memory/internal/UnsafeUtilTest.java
+++ b/datasketches-memory-java8/src/test/java/org/apache/datasketches/memory/internal/UnsafeUtilTest.java
@@ -38,7 +38,7 @@ public class UnsafeUtilTest {
   public void checkJdkString() {
     String jdkVer;
     int[] p = new int[2];
-    String[] good1_Strings = {"1.8.0_121", "8", "9", "10", "11", "12", "13"};
+    String[] good1_Strings = {"1.8.0_121", "8", "11", "17"};
     int len = good1_Strings.length;
     for (int i = 0; i < len; i++) {
       jdkVer = good1_Strings[i];


### PR DESCRIPTION
This applies the same fix to 3.0.X as was applied to master. Cherry-picking worked!