### PR TITLE
Prepare Release 3.0.2-RC2

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Note: *primitive* = *{byte, short, int, long, float, double}*
 * **Memory-Mapped Files**  
     * *WritableMemory.writableMap(File)* method.
 
-# Release [3.0.0, 4.0.0)
+# Releases 3.0.0 (inclusive) to 4.0.0 (exclusive)
 These are transitional releases that also supports Java 8 and 11. 
 However, the goal of this set of releases is to migrate the API to what it will be in release 4.0.0.
 The 4.0.0 release will require Java 17 and will utilize the Project Panama (FFM) capabilites introduced in Java 17.
@@ -79,7 +79,7 @@ It is our expectation that this set of releases will be the last that support Ja
 
 The comments in the following section for releases [2.0.0, 3.0.0) still apply.
 
-# Releases [2.0.0, 3.0.0)
+# Releases 2.0.0 (inclusive) to 3.0.0 (exclusive)
 Starting with release *datasketches-memory-2.0.0*, this Memory component supports Java 8 and 11. Providing access to the off-heap resources in Java 8 only requires reflection. However, **Java 9 introduced the Java Platform Module System (JPMS) where access to these internal classes requires starting up the JVM with special JPMS arguments.**  The actual JVM arguments required will depend on how the user intends to use the Memory API, the Java version used to run the user's application and whether the user's application is a JPMS application or not.
 
 Also see the [usage examples](docs/usage-examples.md) for more information.

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/ResourceImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/ResourceImpl.java
@@ -37,7 +37,7 @@ import org.apache.datasketches.memory.Resource;
  */
 @SuppressWarnings("restriction")
 public abstract class ResourceImpl implements Resource {
-  static final String JDK; //must be at least "1.8"
+  static final String JDK; 
   static final int JDK_MAJOR; //8, 11, 17, etc
 
   //Used to convert "type" to bytes:  bytes = longs << LONG_SHIFT
@@ -141,10 +141,19 @@ public abstract class ResourceImpl implements Resource {
     }
   }
 
+  /**
+   * Checks the runtime Java Version string. Note that Java 17 and 21 is allowed only because some clients do not use the
+   * WritableMemory.allocateDirect(..) and related functions, which will not work with Java versions >= 14.  
+   * The on-heap functions may work with 17 and 21, nonetheless, versions > Java 11 are not officially supported. 
+   * Caveat emptor.
+   * @param jdkVer the <i>System.getProperty("java.version")</i> string of the form "p0.p1.X"
+   * @param p0 The first number group 
+   * @param p1 The second number group
+   */
   static void checkJavaVersion(final String jdkVer, final int p0, final int p1 ) {
-    final boolean ok = ((p0 == 1) && (p1 == 8)) || (p0 == 8) || (p0 == 11) || (p0 == 17);
+    final boolean ok = ((p0 == 1) && (p1 == 8)) || (p0 == 8) || (p0 == 11) || (p0 == 17 || (p0 == 21));
     if (!ok) { throw new IllegalArgumentException(
-        "Unsupported JDK Major Version. It must be one of 1.8, 8, 11, 17: " + jdkVer);
+        "Unsupported JDK Major Version. It must be one of 1.8, 8, 11, 17, 21: " + jdkVer);
     }
   }
 
@@ -441,7 +450,7 @@ public abstract class ResourceImpl implements Resource {
     sb.append("Read Only           : ").append(state.isReadOnly()).append(LS);
     sb.append("Type Byte Order     : ").append(state.getTypeByteOrder().toString()).append(LS);
     sb.append("Native Byte Order   : ").append(ByteOrder.nativeOrder().toString()).append(LS);
-    sb.append("JDK Runtime Version : ").append(UnsafeUtil.JDK).append(LS);
+    sb.append("JDK Runtime Version : ").append(JDK).append(LS);
     //Data detail
     if (withData) {
       sb.append("Data, bytes         :  0  1  2  3  4  5  6  7");

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/UnsafeUtil.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/UnsafeUtil.java
@@ -32,8 +32,6 @@ import sun.misc.Unsafe;
 @SuppressWarnings({"restriction","javadoc"})
 public final class UnsafeUtil {
   public static final Unsafe unsafe;
-  public static final String JDK; //must be at least "1.8"
-  public static final int JDK_MAJOR; //8, 9, 10, 11, 12, etc
 
   //not an indicator of whether compressed references are used.
   public static final int ADDRESS_SIZE;
@@ -115,50 +113,9 @@ public final class UnsafeUtil {
 
     ARRAY_OBJECT_INDEX_SCALE = unsafe.arrayIndexScale(Object[].class);
     OBJECT_SHIFT = ARRAY_OBJECT_INDEX_SCALE == 4 ? 2 : 3;
-
-    final String jdkVer = System.getProperty("java.version");
-    final int[] p = parseJavaVersion(jdkVer);
-    JDK = p[0] + "." + p[1];
-    JDK_MAJOR = (p[0] == 1) ? p[1] : p[0];
   }
 
   private UnsafeUtil() {}
-
-  /**
-   * Returns first two number groups of the java version string.
-   * @param jdkVer the java version string from System.getProperty("java.version").
-   * @return first two number groups of the java version string.
-   */
-  public static int[] parseJavaVersion(final String jdkVer) {
-    final int p0, p1;
-    try {
-      String[] parts = jdkVer.trim().split("[^0-9\\.]");//grab only number groups and "."
-      parts = parts[0].split("\\."); //split out the number groups
-      p0 = Integer.parseInt(parts[0]); //the first number group
-      p1 = (parts.length > 1) ? Integer.parseInt(parts[1]) : 0; //2nd number group, or 0
-    } catch (final NumberFormatException | ArrayIndexOutOfBoundsException  e) {
-      throw new IllegalArgumentException("Improper Java -version string: " + jdkVer + LS + e);
-    }
-    checkJavaVersion(jdkVer, p0, p1);
-    return new int[] {p0, p1};
-  }
-
-  /**
-   * Checks the runtime Java Version string. Note that Java 17 and 21 is allowed only because some clients do not use the
-   * WritableMemory.allocateDirect(..) and related functions, which will not work with Java versions >= 14.  
-   * The on-heap functions may work with 17 and 21, nonetheless, versions > Java 11 are not officially supported. 
-   * Caveat emptor.
-   * @param jdkVer the <i>System.getProperty("java.version")</i> string of the form "p0.p1.X"
-   * @param p0 The first number group 
-   * @param p1 The second number group
-   */
-  public static void checkJavaVersion(final String jdkVer, final int p0, final int p1) {
-    final boolean ok = ( ((p0 == 1) && (p1 == 8)) || (p0 == 8) || (p0 == 11) || (p0 == 17) || (p0 == 21));
-    if (!ok) {
-      throw new IllegalArgumentException(
-          "Unsupported Runtime JDK Major Version, must be one of 1.8, 8, 11, 17, 21: " + jdkVer);
-    }
-  }
 
   /**
    * Gets the <i>unsafe.objectFieldOffset(..)</i> for declared fields of a class.

--- a/datasketches-memory-java8/src/test/java/org/apache/datasketches/memory/internal/ResourceTest.java
+++ b/datasketches-memory-java8/src/test/java/org/apache/datasketches/memory/internal/ResourceTest.java
@@ -121,6 +121,64 @@ public class ResourceTest {
     }
   }
 
+  @Test
+  public void checkJdkString() {
+    String jdkVer;
+    int[] p = new int[2];
+    String[] good1_Strings = {"1.8.0_121", "8", "11", "17", "21"};
+    int len = good1_Strings.length;
+    for (int i = 0; i < len; i++) {
+      jdkVer = good1_Strings[i];
+      p = ResourceImpl.parseJavaVersion(jdkVer);
+      ResourceImpl.checkJavaVersion(jdkVer, p[0], p[1]);
+      int jdkMajor = (p[0] == 1) ? p[1] : p[0]; //model the actual JDK_MAJOR
+      if (p[0] == 1) { assertTrue(jdkMajor == p[1]); }
+      if (p[0] > 1 ) { assertTrue(jdkMajor == p[0]); }
+    }
+    try {
+      jdkVer = "14.0.4";
+      p = ResourceImpl.parseJavaVersion(jdkVer);
+      ResourceImpl.checkJavaVersion(jdkVer, p[0], p[1]);
+      fail();
+    } catch (IllegalArgumentException e) {
+      println("" + e);
+    }
+
+    try {
+      jdkVer = "1.7.0_80";
+      p = ResourceImpl.parseJavaVersion(jdkVer);
+      ResourceImpl.checkJavaVersion(jdkVer, p[0], p[1]);
+      fail();
+    } catch (IllegalArgumentException e) {
+      println("" + e);
+    }
+    try {
+      jdkVer = "1.6.0_65";
+      p = ResourceImpl.parseJavaVersion(jdkVer);
+      ResourceImpl.checkJavaVersion(jdkVer, p[0], p[1]); //throws
+      fail();
+    } catch (IllegalArgumentException e) {
+      println("" + e);
+    }
+    try {
+      jdkVer = "b"; //invalid string
+      p = ResourceImpl.parseJavaVersion(jdkVer);
+      ResourceImpl.checkJavaVersion(jdkVer, p[0], p[1]); //throws
+      fail();
+    } catch (IllegalArgumentException e) {
+      println("" + e);
+    }
+    try {
+      jdkVer = ""; //invalid string
+      p = ResourceImpl.parseJavaVersion(jdkVer);
+      ResourceImpl.checkJavaVersion(jdkVer, p[0], p[1]); //throws
+      fail();
+    } catch (IllegalArgumentException e) {
+      println("" + e);
+    }
+  }
+
+  
   /********************/
   @Test
   public void printlnTest() {

--- a/datasketches-memory-java8/src/test/java/org/apache/datasketches/memory/internal/UnsafeUtilTest.java
+++ b/datasketches-memory-java8/src/test/java/org/apache/datasketches/memory/internal/UnsafeUtilTest.java
@@ -20,7 +20,6 @@
 package org.apache.datasketches.memory.internal;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import java.util.ArrayList;
@@ -33,63 +32,6 @@ import org.testng.annotations.Test;
  */
 public class UnsafeUtilTest {
   long testField = 1; //Do not remove & cannot be static. Used in reflection check.
-
-  @Test
-  public void checkJdkString() {
-    String jdkVer;
-    int[] p = new int[2];
-    String[] good1_Strings = {"1.8.0_121", "8", "11", "17"};
-    int len = good1_Strings.length;
-    for (int i = 0; i < len; i++) {
-      jdkVer = good1_Strings[i];
-      p = UnsafeUtil.parseJavaVersion(jdkVer);
-      UnsafeUtil.checkJavaVersion(jdkVer, p[0], p[1]);
-      int jdkMajor = (p[0] == 1) ? p[1] : p[0]; //model the actual JDK_MAJOR
-      if (p[0] == 1) { assertTrue(jdkMajor == p[1]); }
-      if (p[0] > 1 ) { assertTrue(jdkMajor == p[0]); }
-    }
-    try {
-      jdkVer = "14.0.4"; //ver 14 string
-      p = UnsafeUtil.parseJavaVersion(jdkVer);
-      UnsafeUtil.checkJavaVersion(jdkVer, p[0], p[1]);
-      fail();
-    } catch (IllegalArgumentException e) {
-      println("" + e);
-    }
-
-    try {
-      jdkVer = "1.7.0_80"; //1.7 string
-      p = UnsafeUtil.parseJavaVersion(jdkVer);
-      UnsafeUtil.checkJavaVersion(jdkVer, p[0], p[1]);
-      fail();
-    } catch (IllegalArgumentException e) {
-      println("" + e);
-    }
-    try {
-      jdkVer = "1.6.0_65"; //valid string but < 1.7
-      p = UnsafeUtil.parseJavaVersion(jdkVer);
-      UnsafeUtil.checkJavaVersion(jdkVer, p[0], p[1]); //throws
-      fail();
-    } catch (IllegalArgumentException e) {
-      println("" + e);
-    }
-    try {
-      jdkVer = "b"; //invalid string
-      p = UnsafeUtil.parseJavaVersion(jdkVer);
-      UnsafeUtil.checkJavaVersion(jdkVer, p[0], p[1]); //throws
-      fail();
-    } catch (IllegalArgumentException e) {
-      println("" + e);
-    }
-    try {
-      jdkVer = ""; //invalid string
-      p = UnsafeUtil.parseJavaVersion(jdkVer);
-      UnsafeUtil.checkJavaVersion(jdkVer, p[0], p[1]); //throws
-      fail();
-    } catch (IllegalArgumentException e) {
-      println("" + e);
-    }
-  }
 
   @Test
   public void checkFieldOffset() {


### PR DESCRIPTION
Removed redundant java runtime version check.

Revised README to be more clear.

