### PR TITLE
Migrate to Java 21 FFM API

### DIFF
--- a/.github/workflows/auto-jdk-matrix.yml
+++ b/.github/workflows/auto-jdk-matrix.yml
@@ -18,7 +18,7 @@ jobs:
           fail-fast: false
 
         env:
-          JDK_VERSION: 17
+          JDK_VERSION: 21
 
         steps:
         - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
@@ -36,7 +36,7 @@ jobs:
               distribution: 'temurin'
               java-package: jdk
               architecture: x64
-              java-version: 17        
+              java-version: 21
         
         - name: Cache local Maven repository
           uses: actions/cache@v4

--- a/.github/workflows/auto-os-matrix.yml
+++ b/.github/workflows/auto-os-matrix.yml
@@ -17,7 +17,7 @@ jobs:
           fail-fast: false
 
           matrix:
-            jdk: [ 17 ]
+            jdk: [ 21 ]
             os: [ windows-latest, ubuntu-latest, macos-latest ]
             include:
               - os: windows-latest

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Echo Java Version

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ datasketches-memory*/.gitignore
 *.ipr
 *.iws
 
+# Netbeans project files
+nb-configuration.xml
+
 # Additional tools
 .clover/
 

--- a/pom.xml
+++ b/pom.xml
@@ -89,10 +89,10 @@ under the License.
 
     <!-- System-wide properties -->
     <maven.version>3.6.3</maven.version>
-    <java.version>17</java.version>
+    <java.version>21</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <argLine>-Xmx4g -Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8 --add-modules=jdk.incubator.foreign</argLine>
+    <argLine>-Xmx4g -Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8 --enable-preview</argLine>
     <charset.encoding>UTF-8</charset.encoding>
     <project.build.sourceEncoding>${charset.encoding}</project.build.sourceEncoding>
     <project.build.resourceEncoding>${charset.encoding}</project.build.resourceEncoding>
@@ -160,8 +160,9 @@ under the License.
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven-compiler-plugin.version}</version>
           <configuration>
+            <release>21</release>
             <compilerArgs>
-              <arg>--add-modules=jdk.incubator.foreign</arg>
+              <arg>--enable-preview</arg>
             </compilerArgs>
           </configuration>
         </plugin>
@@ -187,7 +188,7 @@ under the License.
               <configuration>
                 <rules>
                   <requireJavaVersion>
-                    <version>[17,18)</version>
+                    <version>21</version>
                   </requireJavaVersion>
                   <requireMavenVersion>
                     <version>[${maven.version},4.0.0)</version>
@@ -235,7 +236,7 @@ under the License.
             <excludePackageNames>org.apache.datasketches.memory/internal</excludePackageNames>
             <show>public</show>
             <additionalOptions>
-              <additionalOption>--add-modules=jdk.incubator.foreign</additionalOption>
+              <additionalOption>--enable-preview</additionalOption>
             </additionalOptions>
           </configuration>
           <executions>
@@ -281,7 +282,7 @@ under the License.
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire-failsafe-plugins.version}</version>
           <configuration>
-            <argLine>--add-modules=jdk.incubator.foreign</argLine>
+            <argLine>--enable-preview</argLine>
             <trimStackTrace>false</trimStackTrace>
             <useManifestOnlyJar>false</useManifestOnlyJar>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
@@ -307,6 +308,7 @@ under the License.
             <useDefaultExcludes>true</useDefaultExcludes>
             <excludes>
               <!-- rat uses .gitignore for excludes by default -->
+<!--              <exclude>**/nb-configuration.xml</exclude>-->
               <exclude>**/*.yaml</exclude>
               <exclude>**/*.yml</exclude>
               <exclude>**/.*</exclude>

--- a/src/main/java/org/apache/datasketches/memory/Buffer.java
+++ b/src/main/java/org/apache/datasketches/memory/Buffer.java
@@ -19,6 +19,7 @@
 
 package org.apache.datasketches.memory;
 
+import java.lang.foreign.Arena;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 

--- a/src/main/java/org/apache/datasketches/memory/DefaultMemoryRequestServer.java
+++ b/src/main/java/org/apache/datasketches/memory/DefaultMemoryRequestServer.java
@@ -19,9 +19,8 @@
 
 package org.apache.datasketches.memory;
 
+import java.lang.foreign.Arena;
 import java.nio.ByteOrder;
-
-import jdk.incubator.foreign.ResourceScope;
 
 /**
  * This example MemoryRequestServer is simple but demonstrates one of many ways to
@@ -59,7 +58,7 @@ public final class DefaultMemoryRequestServer implements MemoryRequestServer {
   public WritableMemory request(
       final WritableMemory currentWmem,
       final long newCapacityBytes,
-      final ResourceScope scope) {
+      final Arena arena) {
     final ByteOrder order = currentWmem.getTypeByteOrder();
     final long currentBytes = currentWmem.getCapacity();
     final WritableMemory newWmem;
@@ -69,7 +68,7 @@ public final class DefaultMemoryRequestServer implements MemoryRequestServer {
     }
 
     if (offHeap) {
-      newWmem = WritableMemory.allocateDirect(newCapacityBytes, 8, scope, order, this);
+      newWmem = WritableMemory.allocateDirect(arena, newCapacityBytes, 8, order, this);
     }
     else { //On-heap
       if (newCapacityBytes > Integer.MAX_VALUE) {
@@ -90,7 +89,7 @@ public final class DefaultMemoryRequestServer implements MemoryRequestServer {
       final WritableMemory memToClose,
       final WritableMemory newMemory) {
     //make this operation idempotent.
-    if (memToClose.isCloseable()) { memToClose.scope().close(); }
+    if (memToClose.isCloseable()) { memToClose.close(); }
   }
 
 }

--- a/src/main/java/org/apache/datasketches/memory/MemoryRequestServer.java
+++ b/src/main/java/org/apache/datasketches/memory/MemoryRequestServer.java
@@ -19,13 +19,13 @@
 
 package org.apache.datasketches.memory;
 
-import jdk.incubator.foreign.ResourceScope;
+import java.lang.foreign.Arena;
 
 /**
  * The MemoryRequestServer is a callback interface to provide a means to request more memory
  * for heap and off-heap WritableMemory resources that are not file-memory-mapped backed resources.
  *
- * <p>Note: this only works with Java 17.
+ * <p>Note: this only works with Java 21.
  *
  * @author Lee Rhodes
  */
@@ -42,7 +42,8 @@ public interface MemoryRequestServer {
   default WritableMemory request(
       WritableMemory currentWritableMemory,
       long newCapacityBytes) {
-    return request(currentWritableMemory, newCapacityBytes, ResourceScope.newConfinedScope());
+
+    return request(currentWritableMemory, newCapacityBytes, Arena.ofConfined());
   }
 
   /**
@@ -50,8 +51,7 @@ public interface MemoryRequestServer {
    * determine the byte order of the returned WritableMemory and other properties.
    * @param currentWritableMemory the current writableMemory of the client. It must be non-null.
    * @param newCapacityBytes The capacity being requested. It must be &gt; the capacity of the currentWritableMemory.
-   * @param scope the ResourceScope to be used for the newly allocated memory.
-   * It must be non-null.
+   * @param arena the Arena to be used for the newly allocated memory. It must be non-null.
    * Typically use <i>ResourceScope.newConfinedScope()</i>.
    * Warning: specifying a <i>newSharedScope()</i> is not supported.
    * @return new WritableMemory with the requested capacity.
@@ -59,7 +59,7 @@ public interface MemoryRequestServer {
   WritableMemory request(
       WritableMemory currentWritableMemory,
       long newCapacityBytes,
-      ResourceScope scope);
+      Arena arena);
 
   /**
    * Request to close the resource, if applicable.

--- a/src/main/java/org/apache/datasketches/memory/MemoryRequestServer.java
+++ b/src/main/java/org/apache/datasketches/memory/MemoryRequestServer.java
@@ -33,7 +33,7 @@ public interface MemoryRequestServer {
 
   /**
    * Request new WritableMemory with the given newCapacityBytes. The current WritableMemory can be used to
-   * determine the byte order of the returned WritableMemory and other properties. A new confined ResourceScope is
+   * determine the byte order of the returned WritableMemory and other properties. A new confined Arena is
    * assigned.
    * @param currentWritableMemory the current writableMemory of the client. It must be non-null.
    * @param newCapacityBytes The capacity being requested. It must be &gt; the capacity of the currentWritableMemory.
@@ -52,8 +52,8 @@ public interface MemoryRequestServer {
    * @param currentWritableMemory the current writableMemory of the client. It must be non-null.
    * @param newCapacityBytes The capacity being requested. It must be &gt; the capacity of the currentWritableMemory.
    * @param arena the Arena to be used for the newly allocated memory. It must be non-null.
-   * Typically use <i>ResourceScope.newConfinedScope()</i>.
-   * Warning: specifying a <i>newSharedScope()</i> is not supported.
+   * Typically use <i>Arena.ofConfined()</i>.
+   * Warning: specifying a <i>Arena.ofShared()</i> is not supported.
    * @return new WritableMemory with the requested capacity.
    */
   WritableMemory request(

--- a/src/main/java/org/apache/datasketches/memory/MurmurHash3.java
+++ b/src/main/java/org/apache/datasketches/memory/MurmurHash3.java
@@ -19,9 +19,9 @@
 
 package org.apache.datasketches.memory;
 
-import org.apache.datasketches.memory.internal.MurmurHash3v3;
+import java.lang.foreign.MemorySegment;
+import org.apache.datasketches.memory.internal.MurmurHash3v4;
 
-import jdk.incubator.foreign.MemorySegment;
 
 /**
  * <p>The MurmurHash3 is a fast, non-cryptographic, 128-bit hash function that has
@@ -39,12 +39,14 @@ import jdk.incubator.foreign.MemorySegment;
  * <p>This implementation produces exactly the same hash result as the
  * MurmurHash3 function in datasketches-java given compatible inputs.</p>
  *
- * <p>This version 3 of the implementation leverages the jdk.incubator.foreign package of JDK-17 in place of
+ * <p>This version 4 of the implementation leverages the java.lang.foreign package of JDK-21 in place of
  * the Unsafe class.
  *
  * @author Lee Rhodes
  */
 public final class MurmurHash3 {
+
+  private MurmurHash3() { }
 
   //Provided for backward compatibility
 
@@ -59,7 +61,7 @@ public final class MurmurHash3 {
   public static long[] hash(
       final long[] in,
       final long seed) {
-    return MurmurHash3v3.hash(in, seed);
+    return MurmurHash3v4.hash(in, seed);
   }
 
   /**
@@ -73,7 +75,7 @@ public final class MurmurHash3 {
   public static long[] hash(
       final int[] in,
       final long seed) {
-    return MurmurHash3v3.hash(in, seed);
+    return MurmurHash3v4.hash(in, seed);
   }
 
   /**
@@ -87,7 +89,7 @@ public final class MurmurHash3 {
   public static long[] hash(
       final char[] in,
       final long seed) {
-    return MurmurHash3v3.hash(in, seed);
+    return MurmurHash3v4.hash(in, seed);
   }
 
   /**
@@ -101,7 +103,7 @@ public final class MurmurHash3 {
   public static long[] hash(
       final byte[] in,
       final long seed) {
-    return MurmurHash3v3.hash(in, seed);
+    return MurmurHash3v4.hash(in, seed);
   }
 
   //Single primitive inputs
@@ -118,7 +120,7 @@ public final class MurmurHash3 {
       final long in,
       final long seed,
       final long[] hashOut) {
-    return MurmurHash3v3.hash(in, seed, hashOut);
+    return MurmurHash3v4.hash(in, seed, hashOut);
   }
 
   /**
@@ -133,7 +135,7 @@ public final class MurmurHash3 {
       final double in,
       final long seed,
       final long[] hashOut) {
-    return MurmurHash3v3.hash(in, seed, hashOut);
+    return MurmurHash3v4.hash(in, seed, hashOut);
   }
 
   /**
@@ -148,7 +150,7 @@ public final class MurmurHash3 {
       final String in,
       final long seed,
       final long[] hashOut) {
-    return MurmurHash3v3.hash(in, seed, hashOut);
+    return MurmurHash3v4.hash(in, seed, hashOut);
   }
 
   //The main API calls
@@ -169,7 +171,7 @@ public final class MurmurHash3 {
       final long lengthBytes,
       final long seed,
       final long[] hashOut) {
-    return MurmurHash3v3.hash(mem, offsetBytes, lengthBytes, seed, hashOut);
+    return MurmurHash3v4.hash(mem, offsetBytes, lengthBytes, seed, hashOut);
   }
 
   /**
@@ -188,7 +190,7 @@ public final class MurmurHash3 {
       final long lengthBytes,
       final long seed,
       final long[] hashOut) {
-    return MurmurHash3v3.hash(seg, offsetBytes, lengthBytes, seed, hashOut);
+    return MurmurHash3v4.hash(seg, offsetBytes, lengthBytes, seed, hashOut);
   }
 
 }

--- a/src/main/java/org/apache/datasketches/memory/Resource.java
+++ b/src/main/java/org/apache/datasketches/memory/Resource.java
@@ -19,11 +19,10 @@
 
 package org.apache.datasketches.memory;
 
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.MemorySegment.Scope;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-
-import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.ResourceScope;
 
 /**
  * The base class for Memory and Buffer plus some common static variables and check methods.
@@ -47,7 +46,7 @@ public interface Resource extends AutoCloseable {
    * <p>The user can customize the actions of the MemoryRequestServer by
    * implementing the MemoryRequestServer interface and set it using the
    * {@link #setMemoryRequestServer(MemoryRequestServer)} method or optionally with the
-   * {@link WritableMemory#allocateDirect(long, long, ByteOrder, MemoryRequestServer)} method.</p>
+   * {@link WritableMemory#allocateDirect(arena, long, long, ByteOrder, MemoryRequestServer)} method.</p>
    *
    * <p>If the MemoryRequestServer is not set by the user and additional memory is needed by the sketch,
    * null will be returned and the sketch will abort.
@@ -91,24 +90,27 @@ public interface Resource extends AutoCloseable {
   ByteBuffer asByteBufferView(ByteOrder order);
 
   /**
-   * <i>From Java 17 ResourceScope::close():</i>
+   * <i>From Java 21 java.lang.foreign.Arena::close():</i>
+   * Closes this arena. If this method completes normally, the arena scope is no longer {@linkplain Scope#isAlive() alive},
+   * and all the memory segments associated with it can no longer be accessed. Furthermore, any off-heap region of memory backing the
+   * segments obtained from this arena are also released.
    *
-   * <p>Closes this resource scope. As a side-effect, if this operation completes without exceptions, this scope will be marked
-   * as <em>not alive</em>, and subsequent operations on resources associated with this scope will fail with {@link IllegalStateException}.
-   * Additionally, upon successful closure, all direct (native) resources associated with this resource scope will be released.</p>
+   * This operation is not idempotent; that is, closing an already closed arena <em>always</em> results in an
+   * exception being thrown. This reflects a deliberate design choice: failure to close an arena might reveal a bug
+   * in the underlying application logic.
    *
-   * <p>API Note This operation is not idempotent; that is, closing an already closed resource scope <em>always</em> results in an
-   * exception being thrown. This reflects a deliberate design choice: resource scope state transitions should be
-   * manifest in the client code; a failure in any of these transitions reveals a bug in the underlying application
-   * logic. </p>
+   * If this method completes normally, then {@code java.lang.foreign.Arena.scope().isAlive() == false}.
+   * Implementations are allowed to throw {@link UnsupportedOperationException} if an explicit close operation is
+   * not supported.
    *
-   * @throws IllegalStateException if one of the following condition is met:
-   * <ul>
-   *     <li>this resource scope is not <em>alive</em>
-   *     <li>this resource scope is confined, and this method is called from a thread other than the thread owning this resource scope</li>
-   *     <li>this resource scope is shared and a resource associated with this scope is accessed while this method is called</li>
-   * </ul>
-   * @throws UnsupportedOperationException if this resource scope is <em>implicit</em>}.
+   * @see java.lang.foreign.MemorySegment.Scope#isAlive()
+   *
+   * @throws IllegalStateException if the arena has already been closed.
+   * @throws IllegalStateException if a segment associated with this arena is being accessed concurrently, e.g.
+   * by a {@linkplain java.lang.foreign.Linker#downcallHandle(FunctionDescriptor, Linker.Option...) downcall method handle}.
+   * @throws WrongThreadException if this arena is confined, and this method is called from a thread
+   * other than the arena's owner thread.
+   * @throws UnsupportedOperationException if this arena cannot be closed explicitly.
    */
   @Override
   void close();
@@ -158,12 +160,6 @@ public interface Resource extends AutoCloseable {
    * @return the capacity of this object in bytes
    */
   long getCapacity();
-
-  /**
-   * Return the owner thread of the underlying ResourceScope, or null.
-   * @return the owner thread of the underlying ResourceScope, or null.
-   */
-  Thread getOwnerThread();
 
   /**
    * Gets the relative base offset of <i>this</i> with respect to <i>that</i>, defined as: <i>this</i> - <i>that</i>.
@@ -297,7 +293,7 @@ public interface Resource extends AutoCloseable {
    * Returns the resource scope associated with this memory segment.
    * @return the resource scope associated with this memory segment.
    */
-  ResourceScope scope();
+  Scope scope();
 
   /**
    * Returns a new ByteBuffer with a copy of the data from this Memory object.

--- a/src/main/java/org/apache/datasketches/memory/WritableMemory.java
+++ b/src/main/java/org/apache/datasketches/memory/WritableMemory.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.MemorySegment.Scope;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -74,7 +73,7 @@ public interface WritableMemory extends Memory {
   /**
    * Maps the entire given file into native-ordered WritableMemory for write operations
    * Calling this method is equivalent to calling
-   * {@link #writableMap(File, long, long, ByteOrder) writableMap(file, 0, file.length(), scope, ByteOrder.nativeOrder())}.
+   * {@link #writableMap(File, long, long, ByteOrder) writableMap(file, 0, file.length(), ByteOrder.nativeOrder())}.
    * @param file the given file to map. It must be non-null and writable.
    * @return a file-mapped WritableMemory
    * @throws IllegalArgumentException if file is not readable or not writable.
@@ -87,7 +86,7 @@ public interface WritableMemory extends Memory {
   }
 
   /**
-   * Maps the specified portion of the given file into Memory for write operations with a ResourceScope.
+   * Maps the specified portion of the given file into Memory for write operations with Arena.ofConfined().
    * @param file the given file to map. It must be non-null with a non-negative length and writable.
    * @param fileOffsetBytes the position in the given file in bytes. It must not be negative.
    * @param capacityBytes the size of the mapped Memory. It must be &ge; 0.
@@ -168,35 +167,6 @@ public interface WritableMemory extends Memory {
       Arena arena,
       long capacityBytes,
       long alignmentBytes,
-      ByteOrder byteOrder,
-      MemoryRequestServer memReqSvr) {
-    return WritableMemoryImpl.wrapDirect(arena, capacityBytes, alignmentBytes, byteOrder, memReqSvr);
-  }
-
-  /**
-   * Allocates and provides access to capacityBytes directly in native (off-heap) memory with a ResourceScope.
-   * The allocated memory will be aligned to the given <i>alignmentBytes</i>.
-   *
-   * <p><b>NOTICE:</b> It is the responsibility of the using application to
-   * call <i>close()</i> when done.</p>
-   *
-   * @param arena the given arena to map. It must be non-null.
-   * @param capacityBytes the size of the desired memory in bytes.
-   * @param alignmentBytes requested segment alignment. Typically 1, 2, 4 or 8.
-   * @param scope the given ResourceScope.
-   * It must be non-null.
-   * Typically use <i>ResourceScope.newConfinedScope()</i>.
-   * Warning: specifying a <i>newSharedScope()</i> is not supported.
-   * @param byteOrder the byte order to be used.  It must be non-null.
-   * @param memReqSvr A user-specified MemoryRequestServer, which may be null.
-   * This is a callback mechanism for a user client of direct memory to request more memory.
-   * @return WritableMemory
-   */
-  static WritableMemory allocateDirect(
-      Arena arena,
-      long capacityBytes,
-      long alignmentBytes,
-      Scope scope,
       ByteOrder byteOrder,
       MemoryRequestServer memReqSvr) {
     return WritableMemoryImpl.wrapDirect(arena, capacityBytes, alignmentBytes, byteOrder, memReqSvr);

--- a/src/main/java/org/apache/datasketches/memory/internal/CompareAndCopy.java
+++ b/src/main/java/org/apache/datasketches/memory/internal/CompareAndCopy.java
@@ -19,9 +19,8 @@
 
 package org.apache.datasketches.memory.internal;
 
-import static jdk.incubator.foreign.MemoryAccess.getByteAtOffset;
-
-import jdk.incubator.foreign.MemorySegment;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 
 /**
  * @author Lee Rhodes
@@ -39,7 +38,9 @@ final class CompareAndCopy {
     if (mm == -1) { return 0; }
     if ((lengthBytes1 > mm) && (lengthBytes2 > mm)) {
       return Integer.compare(
-          getByteAtOffset(slice1, mm) & 0XFF, getByteAtOffset(slice2, mm) & 0XFF);
+          slice1.get(ValueLayout.JAVA_BYTE, mm) & 0XFF,
+          slice2.get(ValueLayout.JAVA_BYTE, mm) & 0XFF
+      );
     }
     if (lengthBytes1 == mm) { return -1; }
     return +1;

--- a/src/main/java/org/apache/datasketches/memory/internal/MurmurHash3v4.java
+++ b/src/main/java/org/apache/datasketches/memory/internal/MurmurHash3v4.java
@@ -21,12 +21,11 @@ package org.apache.datasketches.memory.internal;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.util.Objects;
 
 import org.apache.datasketches.memory.Memory;
-
-import jdk.incubator.foreign.MemoryAccess;
-import jdk.incubator.foreign.MemorySegment;
 
 /**
  * <p>The MurmurHash3 is a fast, non-cryptographic, 128-bit hash function that has
@@ -44,12 +43,12 @@ import jdk.incubator.foreign.MemorySegment;
  * <p>This implementation produces exactly the same hash result as the
  * MurmurHash3 function in datasketches-java given compatible inputs.</p>
  *
- * <p>This version 3 of the implementation leverages the jdk.incubator.foreign package of JDK-17 in place of
+ * <p>This version 4 of the implementation leverages the java.lang.foreign package of JDK-21 in place of
  * the Unsafe class.
  *
  * @author Lee Rhodes
  */
-public final class MurmurHash3v3 {
+public final class MurmurHash3v4 {
   private static final long C1 = 0x87c37b91114253d5L;
   private static final long C2 = 0x4cf5ad432745937fL;
 
@@ -211,8 +210,8 @@ public final class MurmurHash3v3 {
 
     // Process the 128-bit blocks (the body) into the hash
     while (rem >= 16L) {
-      final long k1 = MemoryAccess.getLongAtOffset(seg, cumOff);     //0, 16, 32, ...
-      final long k2 = MemoryAccess.getLongAtOffset(seg, cumOff + 8); //8, 24, 40, ...
+      final long k1 = seg.get(ValueLayout.JAVA_LONG_UNALIGNED, cumOff);     //0, 16, 32, ...
+      final long k2 = seg.get(ValueLayout.JAVA_LONG_UNALIGNED, cumOff + 8); //8, 24, 40, ...
       cumOff += 16L;
       rem -= 16L;
 
@@ -233,75 +232,75 @@ public final class MurmurHash3v3 {
       long k2 = 0;
       switch ((int) rem) {
         case 15: {
-          k2 ^= (MemoryAccess.getByteAtOffset(seg, cumOff + 14) & 0xFFL) << 48;
+          k2 ^= (seg.get(ValueLayout.JAVA_BYTE, cumOff + 14) & 0xFFL) << 48;
         }
         //$FALL-THROUGH$
         case 14: {
-          k2 ^= (MemoryAccess.getShortAtOffset(seg, cumOff + 12) & 0xFFFFL) << 32;
-          k2 ^= (MemoryAccess.getIntAtOffset(seg, cumOff + 8) & 0xFFFFFFFFL);
-          k1 = MemoryAccess.getLongAtOffset(seg, cumOff);
+          k2 ^= (seg.get(ValueLayout.JAVA_SHORT_UNALIGNED, cumOff + 12) & 0xFFFFL) << 32;
+          k2 ^= seg.get(ValueLayout.JAVA_INT_UNALIGNED, cumOff + 8) & 0xFFFFFFFFL;
+          k1 = seg.get(ValueLayout.JAVA_LONG_UNALIGNED, cumOff);
           break;
         }
 
         case 13: {
-          k2 ^= (MemoryAccess.getByteAtOffset(seg, cumOff + 12) & 0xFFL) << 32;
+          k2 ^= (seg.get(ValueLayout.JAVA_BYTE, cumOff + 12) & 0xFFFFL) << 32;
         }
         //$FALL-THROUGH$
         case 12: {
-          k2 ^= (MemoryAccess.getIntAtOffset(seg, cumOff + 8) & 0xFFFFFFFFL);
-          k1 = MemoryAccess.getLongAtOffset(seg, cumOff);
+          k2 ^= seg.get(ValueLayout.JAVA_INT_UNALIGNED, cumOff + 8) & 0xFFFFFFFFL;
+          k1 = seg.get(ValueLayout.JAVA_LONG_UNALIGNED, cumOff);
           break;
         }
 
         case 11: {
-          k2 ^= (MemoryAccess.getByteAtOffset(seg, cumOff + 10) & 0xFFL) << 16;
+          k2 ^= (seg.get(ValueLayout.JAVA_BYTE, cumOff + 10) & 0xFFL) << 16;
         }
         //$FALL-THROUGH$
         case 10: {
-          k2 ^= (MemoryAccess.getShortAtOffset(seg, cumOff +  8) & 0xFFFFL);
-          k1 = MemoryAccess.getLongAtOffset(seg, cumOff);
+          k2 ^= seg.get(ValueLayout.JAVA_SHORT_UNALIGNED, cumOff + 8) & 0xFFFFL;
+          k1 = seg.get(ValueLayout.JAVA_LONG_UNALIGNED, cumOff);
           break;
         }
 
         case  9: {
-          k2 ^= (MemoryAccess.getByteAtOffset(seg, cumOff +  8) & 0xFFL);
+          k2 ^= seg.get(ValueLayout.JAVA_BYTE, cumOff + 8) & 0xFFL;
         }
         //$FALL-THROUGH$
         case  8: {
-          k1 = MemoryAccess.getLongAtOffset(seg, cumOff);
+          k1 = seg.get(ValueLayout.JAVA_LONG_UNALIGNED, cumOff);
           break;
         }
 
         case  7: {
-          k1 ^= (MemoryAccess.getByteAtOffset(seg, cumOff +  6) & 0xFFL) << 48;
+          k1 ^= (seg.get(ValueLayout.JAVA_BYTE, cumOff + 6) & 0xFFL) << 48;
         }
         //$FALL-THROUGH$
         case  6: {
-          k1 ^= (MemoryAccess.getShortAtOffset(seg, cumOff +  4) & 0xFFFFL) << 32;
-          k1 ^= (MemoryAccess.getIntAtOffset(seg, cumOff) & 0xFFFFFFFFL);
+          k1 ^= (seg.get(ValueLayout.JAVA_SHORT_UNALIGNED, cumOff + 4) & 0xFFFFL) << 32;
+          k1 ^= seg.get(ValueLayout.JAVA_INT_UNALIGNED, cumOff) & 0xFFFFFFFFL;
           break;
         }
 
         case  5: {
-          k1 ^= (MemoryAccess.getByteAtOffset(seg, cumOff +  4) & 0xFFL) << 32;
+          k1 ^= (seg.get(ValueLayout.JAVA_BYTE, cumOff + 4) & 0xFFL) << 32;
         }
         //$FALL-THROUGH$
         case  4: {
-          k1 ^= (MemoryAccess.getIntAtOffset(seg, cumOff) & 0xFFFFFFFFL);
+          k1 ^= seg.get(ValueLayout.JAVA_INT_UNALIGNED, cumOff) & 0xFFFFFFFFL;
           break;
         }
 
         case  3: {
-          k1 ^= (MemoryAccess.getByteAtOffset(seg, cumOff +  2) & 0xFFL) << 16;
+          k1 ^= (seg.get(ValueLayout.JAVA_BYTE, cumOff + 2) & 0xFFL) << 16;
         }
         //$FALL-THROUGH$
         case  2: {
-          k1 ^= (MemoryAccess.getShortAtOffset(seg, cumOff) & 0xFFFFL);
+          k1 ^= seg.get(ValueLayout.JAVA_SHORT_UNALIGNED, cumOff) & 0xFFFFL;
           break;
         }
 
         case  1: {
-          k1 ^= (MemoryAccess.getByteAtOffset(seg, cumOff) & 0xFFL);
+          k1 ^= seg.get(ValueLayout.JAVA_BYTE, cumOff) & 0xFFL;
           break;
         }
         default: break; //can't happen
@@ -381,5 +380,7 @@ public final class MurmurHash3v3 {
     hashOut[1] = h2;
     return hashOut;
   }
+
+  private MurmurHash3v4() { }
 
 }

--- a/src/main/java/org/apache/datasketches/memory/internal/NativeWritableBufferImpl.java
+++ b/src/main/java/org/apache/datasketches/memory/internal/NativeWritableBufferImpl.java
@@ -19,11 +19,12 @@
 
 package org.apache.datasketches.memory.internal;
 
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+
 import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.WritableBuffer;
-
-import jdk.incubator.foreign.MemoryAccess;
-import jdk.incubator.foreign.MemorySegment;
 
 /*
  * Developer notes: The heavier methods, such as put/get arrays, duplicate, region, clear, fill,
@@ -46,10 +47,11 @@ import jdk.incubator.foreign.MemorySegment;
 final class NativeWritableBufferImpl extends WritableBufferImpl {
 
   NativeWritableBufferImpl(
+      final Arena arena,
       final MemorySegment seg,
       final int typeId,
       final MemoryRequestServer memReqSvr) {
-    super(seg, typeId, memReqSvr);
+    super(arena, seg, typeId, memReqSvr);
   }
 
   //PRIMITIVE getX() and getXArray()
@@ -57,12 +59,12 @@ final class NativeWritableBufferImpl extends WritableBufferImpl {
   public char getChar() {
     final long pos = getPosition();
     setPosition(pos + Character.BYTES);
-    return MemoryAccess.getCharAtOffset(seg, pos);
+    return seg.get(ValueLayout.JAVA_CHAR_UNALIGNED, pos);
   }
 
   @Override
   public char getChar(final long offsetBytes) {
-    return MemoryAccess.getCharAtOffset(seg, offsetBytes);
+    return seg.get(ValueLayout.JAVA_CHAR_UNALIGNED, offsetBytes);
   }
 
   @Override
@@ -79,12 +81,12 @@ final class NativeWritableBufferImpl extends WritableBufferImpl {
   public double getDouble() {
     final long pos = getPosition();
     setPosition(pos + Double.BYTES);
-    return MemoryAccess.getDoubleAtOffset(seg, pos);
+    return seg.get(ValueLayout.JAVA_DOUBLE_UNALIGNED, pos);
   }
 
   @Override
   public double getDouble(final long offsetBytes) {
-    return MemoryAccess.getDoubleAtOffset(seg, offsetBytes);
+    return seg.get(ValueLayout.JAVA_DOUBLE_UNALIGNED, offsetBytes);
   }
 
   @Override
@@ -101,12 +103,12 @@ final class NativeWritableBufferImpl extends WritableBufferImpl {
   public float getFloat() {
     final long pos = getPosition();
     setPosition(pos + Float.BYTES);
-    return MemoryAccess.getFloatAtOffset(seg, pos);
+    return seg.get(ValueLayout.JAVA_FLOAT_UNALIGNED, pos);
   }
 
   @Override
   public float getFloat(final long offsetBytes) {
-    return MemoryAccess.getFloatAtOffset(seg, offsetBytes);
+    return seg.get(ValueLayout.JAVA_FLOAT_UNALIGNED, offsetBytes);
   }
 
   @Override
@@ -123,12 +125,12 @@ final class NativeWritableBufferImpl extends WritableBufferImpl {
   public int getInt() {
     final long pos = getPosition();
     setPosition(pos + Integer.BYTES);
-    return MemoryAccess.getIntAtOffset(seg, pos);
+    return seg.get(ValueLayout.JAVA_INT_UNALIGNED, pos);
   }
 
   @Override
   public int getInt(final long offsetBytes) {
-    return MemoryAccess.getIntAtOffset(seg, offsetBytes);
+    return seg.get(ValueLayout.JAVA_INT_UNALIGNED, offsetBytes);
   }
 
   @Override
@@ -145,12 +147,12 @@ final class NativeWritableBufferImpl extends WritableBufferImpl {
   public long getLong() {
     final long pos = getPosition();
     setPosition(pos + Long.BYTES);
-    return MemoryAccess.getLongAtOffset(seg, pos);
+    return seg.get(ValueLayout.JAVA_LONG_UNALIGNED, pos);
   }
 
   @Override
   public long getLong(final long offsetBytes) {
-    return MemoryAccess.getLongAtOffset(seg, offsetBytes);
+    return seg.get(ValueLayout.JAVA_LONG_UNALIGNED, offsetBytes);
   }
 
   @Override
@@ -167,12 +169,12 @@ final class NativeWritableBufferImpl extends WritableBufferImpl {
   public short getShort() {
     final long pos = getPosition();
     setPosition(pos + Short.BYTES);
-    return MemoryAccess.getShortAtOffset(seg, pos);
+    return seg.get(ValueLayout.JAVA_SHORT_UNALIGNED, pos);
   }
 
   @Override
   public short getShort(final long offsetBytes) {
-    return MemoryAccess.getShortAtOffset(seg, offsetBytes);
+    return seg.get(ValueLayout.JAVA_SHORT_UNALIGNED, offsetBytes);
   }
 
   @Override
@@ -190,12 +192,12 @@ final class NativeWritableBufferImpl extends WritableBufferImpl {
   public void putChar(final char value) {
     final long pos = getPosition();
     setPosition(pos + Character.BYTES);
-    MemoryAccess.setCharAtOffset(seg, pos, value);
+    seg.set(ValueLayout.JAVA_CHAR_UNALIGNED, pos, value);
   }
 
   @Override
   public void putChar(final long offsetBytes, final char value) {
-    MemoryAccess.setCharAtOffset(seg, offsetBytes, value);
+    seg.set(ValueLayout.JAVA_CHAR_UNALIGNED, offsetBytes, value);
   }
 
   @Override
@@ -212,12 +214,12 @@ final class NativeWritableBufferImpl extends WritableBufferImpl {
   public void putDouble(final double value) {
     final long pos = getPosition();
     setPosition(pos + Double.BYTES);
-    MemoryAccess.setDoubleAtOffset(seg, pos, value);
+    seg.set(ValueLayout.JAVA_DOUBLE_UNALIGNED, pos, value);
   }
 
   @Override
   public void putDouble(final long offsetBytes, final double value) {
-    MemoryAccess.setDoubleAtOffset(seg, offsetBytes, value);
+    seg.set(ValueLayout.JAVA_DOUBLE_UNALIGNED, offsetBytes, value);
   }
 
   @Override
@@ -234,12 +236,12 @@ final class NativeWritableBufferImpl extends WritableBufferImpl {
   public void putFloat(final float value) {
     final long pos = getPosition();
     setPosition(pos + Float.BYTES);
-    MemoryAccess.setFloatAtOffset(seg, pos, value);
+    seg.set(ValueLayout.JAVA_FLOAT_UNALIGNED, pos, value);
   }
 
   @Override
   public void putFloat(final long offsetBytes, final float value) {
-    MemoryAccess.setFloatAtOffset(seg, offsetBytes, value);
+    seg.set(ValueLayout.JAVA_FLOAT_UNALIGNED, offsetBytes, value);
   }
 
   @Override
@@ -256,12 +258,12 @@ final class NativeWritableBufferImpl extends WritableBufferImpl {
   public void putInt(final int value) {
     final long pos = getPosition();
     setPosition(pos + Integer.BYTES);
-    MemoryAccess.setIntAtOffset(seg, pos, value);
+    seg.set(ValueLayout.JAVA_INT_UNALIGNED, pos, value);
   }
 
   @Override
   public void putInt(final long offsetBytes, final int value) {
-    MemoryAccess.setIntAtOffset(seg, offsetBytes, value);
+    seg.set(ValueLayout.JAVA_INT_UNALIGNED, offsetBytes, value);
   }
 
   @Override
@@ -278,12 +280,12 @@ final class NativeWritableBufferImpl extends WritableBufferImpl {
   public void putLong(final long value) {
     final long pos = getPosition();
     setPosition(pos + Long.BYTES);
-    MemoryAccess.setLongAtOffset(seg, pos, value);
+    seg.set(ValueLayout.JAVA_LONG_UNALIGNED, pos, value);
   }
 
   @Override
   public void putLong(final long offsetBytes, final long value) {
-    MemoryAccess.setLongAtOffset(seg, offsetBytes, value);
+    seg.set(ValueLayout.JAVA_LONG_UNALIGNED, offsetBytes, value);
   }
 
   @Override
@@ -300,12 +302,12 @@ final class NativeWritableBufferImpl extends WritableBufferImpl {
   public void putShort(final short value) {
     final long pos = getPosition();
     setPosition(pos + Short.BYTES);
-    MemoryAccess.setShortAtOffset(seg, pos, value);
+    seg.set(ValueLayout.JAVA_SHORT_UNALIGNED, pos, value);
   }
 
   @Override
   public void putShort(final long offsetBytes, final short value) {
-    MemoryAccess.setShortAtOffset(seg, offsetBytes, value);
+    seg.set(ValueLayout.JAVA_SHORT_UNALIGNED, offsetBytes, value);
   }
 
   @Override

--- a/src/main/java/org/apache/datasketches/memory/internal/NativeWritableMemoryImpl.java
+++ b/src/main/java/org/apache/datasketches/memory/internal/NativeWritableMemoryImpl.java
@@ -19,11 +19,12 @@
 
 package org.apache.datasketches.memory.internal;
 
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+
 import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.WritableMemory;
-
-import jdk.incubator.foreign.MemoryAccess;
-import jdk.incubator.foreign.MemorySegment;
 
 /**
  * Implementation of {@link WritableMemory} for native endian byte order.
@@ -34,16 +35,17 @@ final class NativeWritableMemoryImpl extends WritableMemoryImpl {
 
   //Pass-through constructor
   NativeWritableMemoryImpl(
+      final Arena arena,
       final MemorySegment seg,
       final int typeId,
       final MemoryRequestServer memReqSvr) {
-    super(seg, typeId, memReqSvr);
+    super(arena, seg, typeId, memReqSvr);
   }
 
   ///PRIMITIVE getX() and getXArray()
   @Override
   public char getChar(final long offsetBytes) {
-    return MemoryAccess.getCharAtOffset(seg, offsetBytes);
+    return seg.get(ValueLayout.JAVA_CHAR_UNALIGNED, offsetBytes);
   }
 
   @Override
@@ -56,7 +58,7 @@ final class NativeWritableMemoryImpl extends WritableMemoryImpl {
 
   @Override
   public double getDouble(final long offsetBytes) {
-    return MemoryAccess.getDoubleAtOffset(seg, offsetBytes);
+    return seg.get(ValueLayout.JAVA_DOUBLE_UNALIGNED, offsetBytes);
   }
 
   @Override
@@ -69,7 +71,7 @@ final class NativeWritableMemoryImpl extends WritableMemoryImpl {
 
   @Override
   public float getFloat(final long offsetBytes) {
-    return MemoryAccess.getFloatAtOffset(seg, offsetBytes);
+    return seg.get(ValueLayout.JAVA_FLOAT_UNALIGNED, offsetBytes);
   }
 
   @Override
@@ -82,7 +84,7 @@ final class NativeWritableMemoryImpl extends WritableMemoryImpl {
 
   @Override
   public int getInt(final long offsetBytes) {
-    return MemoryAccess.getIntAtOffset(seg, offsetBytes);
+    return seg.get(ValueLayout.JAVA_INT_UNALIGNED, offsetBytes);
   }
 
   @Override
@@ -95,7 +97,7 @@ final class NativeWritableMemoryImpl extends WritableMemoryImpl {
 
   @Override
   public long getLong(final long offsetBytes) {
-    return MemoryAccess.getLongAtOffset(seg, offsetBytes);
+    return seg.get(ValueLayout.JAVA_LONG_UNALIGNED, offsetBytes);
   }
 
   @Override
@@ -108,7 +110,7 @@ final class NativeWritableMemoryImpl extends WritableMemoryImpl {
 
   @Override
   public short getShort(final long offsetBytes) {
-    return MemoryAccess.getShortAtOffset(seg, offsetBytes);
+    return seg.get(ValueLayout.JAVA_SHORT_UNALIGNED, offsetBytes);
   }
 
   @Override
@@ -122,7 +124,7 @@ final class NativeWritableMemoryImpl extends WritableMemoryImpl {
   //PRIMITIVE putX() and putXArray() implementations
   @Override
   public void putChar(final long offsetBytes, final char value) {
-    MemoryAccess.setCharAtOffset(seg, offsetBytes, value);
+    seg.set(ValueLayout.JAVA_CHAR_UNALIGNED, offsetBytes, value);
   }
 
   @Override
@@ -135,7 +137,7 @@ final class NativeWritableMemoryImpl extends WritableMemoryImpl {
 
   @Override
   public void putDouble(final long offsetBytes, final double value) {
-    MemoryAccess.setDoubleAtOffset(seg, offsetBytes, value);
+    seg.set(ValueLayout.JAVA_DOUBLE_UNALIGNED, offsetBytes, value);
   }
 
   @Override
@@ -148,7 +150,7 @@ final class NativeWritableMemoryImpl extends WritableMemoryImpl {
 
   @Override
   public void putFloat(final long offsetBytes, final float value) {
-    MemoryAccess.setFloatAtOffset(seg, offsetBytes, value);
+    seg.set(ValueLayout.JAVA_FLOAT_UNALIGNED, offsetBytes, value);
   }
 
   @Override
@@ -161,7 +163,7 @@ final class NativeWritableMemoryImpl extends WritableMemoryImpl {
 
   @Override
   public void putInt(final long offsetBytes, final int value) {
-    MemoryAccess.setIntAtOffset(seg, offsetBytes, value);
+    seg.set(ValueLayout.JAVA_INT_UNALIGNED, offsetBytes, value);
   }
 
   @Override
@@ -174,7 +176,7 @@ final class NativeWritableMemoryImpl extends WritableMemoryImpl {
 
   @Override
   public void putLong(final long offsetBytes, final long value) {
-    MemoryAccess.setLongAtOffset(seg, offsetBytes, value);
+    seg.set(ValueLayout.JAVA_LONG_UNALIGNED, offsetBytes, value);
   }
 
   @Override
@@ -187,7 +189,7 @@ final class NativeWritableMemoryImpl extends WritableMemoryImpl {
 
   @Override
   public void putShort(final long offsetBytes, final short value) {
-    MemoryAccess.setShortAtOffset(seg, offsetBytes, value);
+    seg.set(ValueLayout.JAVA_SHORT_UNALIGNED, offsetBytes, value);
   }
 
   @Override

--- a/src/main/java/org/apache/datasketches/memory/internal/NonNativeValueLayouts.java
+++ b/src/main/java/org/apache/datasketches/memory/internal/NonNativeValueLayouts.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.datasketches.memory.internal;
+
+import java.lang.foreign.ValueLayout;
+import static org.apache.datasketches.memory.internal.ResourceImpl.NON_NATIVE_BYTE_ORDER;
+
+public class NonNativeValueLayouts {
+
+  private NonNativeValueLayouts() { }
+
+  static final ValueLayout.OfChar JAVA_CHAR_UNALIGNED_NON_NATIVE = ValueLayout.JAVA_CHAR_UNALIGNED
+    .withOrder(NON_NATIVE_BYTE_ORDER);
+  static final ValueLayout.OfDouble JAVA_DOUBLE_UNALIGNED_NON_NATIVE = ValueLayout.JAVA_DOUBLE_UNALIGNED
+    .withOrder(NON_NATIVE_BYTE_ORDER);
+  static final ValueLayout.OfFloat JAVA_FLOAT_UNALIGNED_NON_NATIVE = ValueLayout.JAVA_FLOAT_UNALIGNED
+    .withOrder(NON_NATIVE_BYTE_ORDER);
+  static final ValueLayout.OfInt JAVA_INT_UNALIGNED_NON_NATIVE = ValueLayout.JAVA_INT_UNALIGNED
+    .withOrder(NON_NATIVE_BYTE_ORDER);
+  static final ValueLayout.OfLong JAVA_LONG_UNALIGNED_NON_NATIVE = ValueLayout.JAVA_LONG_UNALIGNED
+    .withOrder(NON_NATIVE_BYTE_ORDER);
+  static final ValueLayout.OfShort JAVA_SHORT_UNALIGNED_NON_NATIVE = ValueLayout.JAVA_SHORT_UNALIGNED
+    .withOrder(NON_NATIVE_BYTE_ORDER);
+  
+}

--- a/src/main/java/org/apache/datasketches/memory/internal/NonNativeWritableBufferImpl.java
+++ b/src/main/java/org/apache/datasketches/memory/internal/NonNativeWritableBufferImpl.java
@@ -19,11 +19,18 @@
 
 package org.apache.datasketches.memory.internal;
 
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+
 import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.WritableBuffer;
-
-import jdk.incubator.foreign.MemoryAccess;
-import jdk.incubator.foreign.MemorySegment;
+import static org.apache.datasketches.memory.internal.NonNativeValueLayouts.JAVA_CHAR_UNALIGNED_NON_NATIVE;
+import static org.apache.datasketches.memory.internal.NonNativeValueLayouts.JAVA_DOUBLE_UNALIGNED_NON_NATIVE;
+import static org.apache.datasketches.memory.internal.NonNativeValueLayouts.JAVA_FLOAT_UNALIGNED_NON_NATIVE;
+import static org.apache.datasketches.memory.internal.NonNativeValueLayouts.JAVA_INT_UNALIGNED_NON_NATIVE;
+import static org.apache.datasketches.memory.internal.NonNativeValueLayouts.JAVA_LONG_UNALIGNED_NON_NATIVE;
+import static org.apache.datasketches.memory.internal.NonNativeValueLayouts.JAVA_SHORT_UNALIGNED_NON_NATIVE;
 
 /*
  * Developer notes: The heavier methods, such as put/get arrays, duplicate, region, clear, fill,
@@ -47,10 +54,11 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
 
   //Pass-through ctor
   NonNativeWritableBufferImpl(
+      final Arena arena,
       final MemorySegment seg,
       final int typeId,
       final MemoryRequestServer memReqSvr) {
-    super(seg, typeId, memReqSvr);
+    super(arena, seg, typeId, memReqSvr);
   }
 
   //PRIMITIVE getX() and getXArray()
@@ -58,12 +66,12 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
   public char getChar() {
     final long pos = getPosition();
     setPosition(pos + Character.BYTES);
-    return MemoryAccess.getCharAtOffset(seg, pos, NON_NATIVE_BYTE_ORDER);
+    return seg.get(JAVA_CHAR_UNALIGNED_NON_NATIVE, pos);
   }
 
   @Override
   public char getChar(final long offsetBytes) {
-    return MemoryAccess.getCharAtOffset(seg, offsetBytes, NON_NATIVE_BYTE_ORDER);
+    return seg.get(JAVA_CHAR_UNALIGNED_NON_NATIVE, offsetBytes);
   }
 
   @Override
@@ -73,8 +81,8 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
     final MemorySegment srcSlice = seg.asSlice(pos, copyBytes);
     final MemorySegment dstSlice = MemorySegment.ofArray(dstArray).asSlice(dstOffsetChars << CHAR_SHIFT, copyBytes);
     for (int index = 0; index < lengthChars; index++) {
-      final char aChar = MemoryAccess.getCharAtIndex(srcSlice, index,  NON_NATIVE_BYTE_ORDER);
-      MemoryAccess.setCharAtIndex(dstSlice, index, NATIVE_BYTE_ORDER, aChar);
+      final char aChar = srcSlice.getAtIndex(JAVA_CHAR_UNALIGNED_NON_NATIVE, index);
+      dstSlice.setAtIndex(ValueLayout.JAVA_CHAR_UNALIGNED, index, aChar);
     }
     setPosition(pos + copyBytes);
   }
@@ -83,12 +91,12 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
   public double getDouble() {
     final long pos = getPosition();
     setPosition(pos + Double.BYTES);
-    return MemoryAccess.getDoubleAtOffset(seg, pos, NON_NATIVE_BYTE_ORDER);
+    return seg.get(JAVA_DOUBLE_UNALIGNED_NON_NATIVE, pos);
   }
 
   @Override
   public double getDouble(final long offsetBytes) {
-    return MemoryAccess.getDoubleAtOffset(seg, offsetBytes, NON_NATIVE_BYTE_ORDER);
+    return seg.get(JAVA_DOUBLE_UNALIGNED_NON_NATIVE, offsetBytes);
   }
 
   @Override
@@ -98,8 +106,8 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
     final MemorySegment srcSlice = seg.asSlice(pos, copyBytes);
     final MemorySegment dstSlice = MemorySegment.ofArray(dstArray).asSlice(dstOffsetDoubles << DOUBLE_SHIFT, copyBytes);
     for (int index = 0; index < lengthDoubles; index++) {
-      final double dbl = MemoryAccess.getDoubleAtIndex(srcSlice, index,  NON_NATIVE_BYTE_ORDER);
-      MemoryAccess.setDoubleAtIndex(dstSlice, index, NATIVE_BYTE_ORDER, dbl);
+      final double dbl = srcSlice.getAtIndex(JAVA_DOUBLE_UNALIGNED_NON_NATIVE, index);
+      dstSlice.setAtIndex(ValueLayout.JAVA_DOUBLE_UNALIGNED, index, dbl);
     }
     setPosition(pos + copyBytes);
   }
@@ -108,12 +116,12 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
   public float getFloat() {
     final long pos = getPosition();
     setPosition(pos + Float.BYTES);
-    return MemoryAccess.getFloatAtOffset(seg, pos, NON_NATIVE_BYTE_ORDER);
+    return seg.get(JAVA_FLOAT_UNALIGNED_NON_NATIVE, pos);
   }
 
   @Override
   public float getFloat(final long offsetBytes) {
-    return MemoryAccess.getFloatAtOffset(seg, offsetBytes, NON_NATIVE_BYTE_ORDER);
+    return seg.get(JAVA_FLOAT_UNALIGNED_NON_NATIVE, offsetBytes);
   }
 
   @Override
@@ -123,8 +131,8 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
     final MemorySegment srcSlice = seg.asSlice(pos, copyBytes);
     final MemorySegment dstSlice = MemorySegment.ofArray(dstArray).asSlice(dstOffsetFloats << FLOAT_SHIFT, copyBytes);
     for (int index = 0; index < lengthFloats; index++) {
-      final float flt = MemoryAccess.getFloatAtIndex(srcSlice, index,  NON_NATIVE_BYTE_ORDER);
-      MemoryAccess.setFloatAtIndex(dstSlice, index, NATIVE_BYTE_ORDER, flt);
+      final float flt = srcSlice.getAtIndex(JAVA_FLOAT_UNALIGNED_NON_NATIVE, index);
+      dstSlice.setAtIndex(ValueLayout.JAVA_FLOAT_UNALIGNED, index, flt);
     }
     setPosition(pos + copyBytes);
   }
@@ -133,12 +141,12 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
   public int getInt() {
     final long pos = getPosition();
     setPosition(pos + Integer.BYTES);
-    return MemoryAccess.getIntAtOffset(seg, pos, NON_NATIVE_BYTE_ORDER);
+    return seg.get(JAVA_INT_UNALIGNED_NON_NATIVE, pos);
   }
 
   @Override
   public int getInt(final long offsetBytes) {
-    return MemoryAccess.getIntAtOffset(seg, offsetBytes, NON_NATIVE_BYTE_ORDER);
+    return seg.get(JAVA_INT_UNALIGNED_NON_NATIVE, offsetBytes);
   }
 
   @Override
@@ -148,8 +156,8 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
     final MemorySegment srcSlice = seg.asSlice(pos, copyBytes);
     final MemorySegment dstSlice = MemorySegment.ofArray(dstArray).asSlice(dstOffsetInts << INT_SHIFT, copyBytes);
     for (int index = 0; index < lengthInts; index++) {
-      final int anInt = MemoryAccess.getIntAtIndex(srcSlice, index,  NON_NATIVE_BYTE_ORDER);
-      MemoryAccess.setIntAtIndex(dstSlice, index, NATIVE_BYTE_ORDER, anInt);
+      final int anInt = srcSlice.getAtIndex(JAVA_INT_UNALIGNED_NON_NATIVE, index);
+      dstSlice.setAtIndex(ValueLayout.JAVA_INT_UNALIGNED, index, anInt);
     }
     setPosition(pos + copyBytes);
   }
@@ -158,12 +166,12 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
   public long getLong() {
     final long pos = getPosition();
     setPosition(pos + Long.BYTES);
-    return MemoryAccess.getLongAtOffset(seg, pos, NON_NATIVE_BYTE_ORDER);
+    return seg.get(JAVA_LONG_UNALIGNED_NON_NATIVE, pos);
   }
 
   @Override
   public long getLong(final long offsetBytes) {
-    return MemoryAccess.getLongAtOffset(seg, offsetBytes, NON_NATIVE_BYTE_ORDER);
+    return seg.get(JAVA_LONG_UNALIGNED_NON_NATIVE, offsetBytes);
   }
 
   @Override
@@ -173,8 +181,8 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
     final MemorySegment srcSlice = seg.asSlice(pos, copyBytes);
     final MemorySegment dstSlice = MemorySegment.ofArray(dstArray).asSlice(dstOffsetLongs << LONG_SHIFT, copyBytes);
     for (int index = 0; index < lengthLongs; index++) {
-      final long aLong = MemoryAccess.getLongAtIndex(srcSlice, index,  NON_NATIVE_BYTE_ORDER);
-      MemoryAccess.setLongAtIndex(dstSlice, index, NATIVE_BYTE_ORDER, aLong);
+      final long aLong = srcSlice.getAtIndex(JAVA_LONG_UNALIGNED_NON_NATIVE, index);
+      dstSlice.setAtIndex(ValueLayout.JAVA_LONG_UNALIGNED, index, aLong);
     }
     setPosition(pos + copyBytes);
   }
@@ -183,12 +191,12 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
   public short getShort() {
     final long pos = getPosition();
     setPosition(pos + Short.BYTES);
-    return MemoryAccess.getShortAtOffset(seg, pos, NON_NATIVE_BYTE_ORDER);
+    return seg.get(JAVA_SHORT_UNALIGNED_NON_NATIVE, pos);
   }
 
   @Override
   public short getShort(final long offsetBytes) {
-    return MemoryAccess.getShortAtOffset(seg, offsetBytes, NON_NATIVE_BYTE_ORDER);
+    return seg.get(JAVA_SHORT_UNALIGNED_NON_NATIVE, offsetBytes);
   }
 
   @Override
@@ -198,8 +206,8 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
     final MemorySegment srcSlice = seg.asSlice(pos, copyBytes);
     final MemorySegment dstSlice = MemorySegment.ofArray(dstArray).asSlice(dstOffsetShorts << SHORT_SHIFT, copyBytes);
     for (int index = 0; index < lengthShorts; index++) {
-      final short aShort = MemoryAccess.getShortAtIndex(srcSlice, index,  NON_NATIVE_BYTE_ORDER);
-      MemoryAccess.setShortAtIndex(dstSlice, index, NATIVE_BYTE_ORDER, aShort);
+      final short aShort = srcSlice.getAtIndex(JAVA_SHORT_UNALIGNED_NON_NATIVE, index);
+      dstSlice.setAtIndex(ValueLayout.JAVA_SHORT_UNALIGNED, index, aShort);
     }
     setPosition(pos + copyBytes);
   }
@@ -208,13 +216,13 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
   @Override
   public void putChar(final char value) {
     final long pos = getPosition();
-    MemoryAccess.setCharAtOffset(seg, pos, NON_NATIVE_BYTE_ORDER, value);
+    seg.set(JAVA_CHAR_UNALIGNED_NON_NATIVE, pos, value);
     setPosition(pos + Character.BYTES);
   }
 
   @Override
   public void putChar(final long offsetBytes, final char value) {
-    MemoryAccess.setCharAtOffset(seg, offsetBytes, NON_NATIVE_BYTE_ORDER, value);
+    seg.set(JAVA_CHAR_UNALIGNED_NON_NATIVE, offsetBytes, value);
   }
 
   @Override
@@ -224,8 +232,8 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
     final MemorySegment srcSlice = MemorySegment.ofArray(srcArray).asSlice(srcOffsetChars << CHAR_SHIFT, copyBytes);
     final MemorySegment dstSlice = seg.asSlice(pos, copyBytes);
     for (int index = 0; index < lengthChars; index++) {
-      final char aChar = MemoryAccess.getCharAtIndex(srcSlice, index,  NATIVE_BYTE_ORDER);
-      MemoryAccess.setCharAtIndex(dstSlice, index, NON_NATIVE_BYTE_ORDER, aChar);
+      final char aChar = srcSlice.getAtIndex(ValueLayout.JAVA_CHAR_UNALIGNED, index);
+      dstSlice.setAtIndex(JAVA_CHAR_UNALIGNED_NON_NATIVE, index, aChar);
     }
     setPosition(pos + copyBytes);
   }
@@ -233,13 +241,13 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
   @Override
   public void putDouble(final double value) {
     final long pos = getPosition();
-    MemoryAccess.setDoubleAtOffset(seg, pos, NON_NATIVE_BYTE_ORDER, value);
+    seg.set(JAVA_DOUBLE_UNALIGNED_NON_NATIVE, pos, value);
     setPosition(pos + Double.BYTES);
   }
 
   @Override
   public void putDouble(final long offsetBytes, final double value) {
-    MemoryAccess.setDoubleAtOffset(seg, offsetBytes, NON_NATIVE_BYTE_ORDER, value);
+    seg.set(JAVA_DOUBLE_UNALIGNED_NON_NATIVE, offsetBytes, value);
   }
 
   @Override
@@ -249,8 +257,8 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
     final MemorySegment srcSlice = MemorySegment.ofArray(srcArray).asSlice(srcOffsetDoubles << DOUBLE_SHIFT, copyBytes);
     final MemorySegment dstSlice = seg.asSlice(pos, copyBytes);
     for (int index = 0; index < lengthDoubles; index++) {
-      final double dbl = MemoryAccess.getDoubleAtIndex(srcSlice, index,  NATIVE_BYTE_ORDER);
-      MemoryAccess.setDoubleAtIndex(dstSlice, index, NON_NATIVE_BYTE_ORDER, dbl);
+      final double dbl = srcSlice.getAtIndex(ValueLayout.JAVA_DOUBLE_UNALIGNED, index);
+      dstSlice.setAtIndex(JAVA_DOUBLE_UNALIGNED_NON_NATIVE, index, dbl);
     }
     setPosition(pos + copyBytes);
   }
@@ -258,13 +266,13 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
   @Override
   public void putFloat(final float value) {
     final long pos = getPosition();
-    MemoryAccess.setFloatAtOffset(seg, pos, NON_NATIVE_BYTE_ORDER, value);
+    seg.set(JAVA_FLOAT_UNALIGNED_NON_NATIVE, pos, value);
     setPosition(pos + Float.BYTES);
   }
 
   @Override
   public void putFloat(final long offsetBytes, final float value) {
-    MemoryAccess.setFloatAtOffset(seg, offsetBytes, NON_NATIVE_BYTE_ORDER, value);
+    seg.set(JAVA_FLOAT_UNALIGNED_NON_NATIVE, offsetBytes, value);
   }
 
   @Override
@@ -274,8 +282,8 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
     final MemorySegment srcSlice = MemorySegment.ofArray(srcArray).asSlice(srcOffsetFloats << FLOAT_SHIFT, copyBytes);
     final MemorySegment dstSlice = seg.asSlice(pos, copyBytes);
     for (int index = 0; index < lengthFloats; index++) {
-      final float flt = MemoryAccess.getFloatAtIndex(srcSlice, index,  NATIVE_BYTE_ORDER);
-      MemoryAccess.setFloatAtIndex(dstSlice, index, NON_NATIVE_BYTE_ORDER, flt);
+      final float flt = srcSlice.getAtIndex(ValueLayout.JAVA_FLOAT_UNALIGNED, index);
+      dstSlice.setAtIndex(JAVA_FLOAT_UNALIGNED_NON_NATIVE, index, flt);
     }
     setPosition(pos + copyBytes);
   }
@@ -283,13 +291,13 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
   @Override
   public void putInt(final int value) {
     final long pos = getPosition();
-    MemoryAccess.setIntAtOffset(seg, pos, NON_NATIVE_BYTE_ORDER, value);
+    seg.set(JAVA_INT_UNALIGNED_NON_NATIVE, pos, value);
     setPosition(pos + Integer.BYTES);
   }
 
   @Override
   public void putInt(final long offsetBytes, final int value) {
-    MemoryAccess.setIntAtOffset(seg, offsetBytes, NON_NATIVE_BYTE_ORDER, value);
+    seg.set(JAVA_INT_UNALIGNED_NON_NATIVE, offsetBytes, value);
   }
 
   @Override
@@ -299,8 +307,8 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
     final  MemorySegment srcSlice = MemorySegment.ofArray(srcArray).asSlice(srcOffsetInts << INT_SHIFT, copyBytes);
     final MemorySegment dstSlice = seg.asSlice(pos, copyBytes);
     for (int index = 0; index < lengthInts; index++) {
-      final int anInt = MemoryAccess.getIntAtIndex(srcSlice, index,  NATIVE_BYTE_ORDER);
-      MemoryAccess.setIntAtIndex(dstSlice, index, NON_NATIVE_BYTE_ORDER, anInt);
+      final int anInt = srcSlice.getAtIndex(ValueLayout.JAVA_INT_UNALIGNED, index);
+      dstSlice.setAtIndex(JAVA_INT_UNALIGNED_NON_NATIVE, index, anInt);
     }
     setPosition(pos + copyBytes);
   }
@@ -308,13 +316,13 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
   @Override
   public void putLong(final long value) {
     final long pos = getPosition();
-    MemoryAccess.setLongAtOffset(seg, pos, NON_NATIVE_BYTE_ORDER, value);
+    seg.set(JAVA_LONG_UNALIGNED_NON_NATIVE, pos, value);
     setPosition(pos + Long.BYTES);
   }
 
   @Override
   public void putLong(final long offsetBytes, final long value) {
-    MemoryAccess.setLongAtOffset(seg, offsetBytes, NON_NATIVE_BYTE_ORDER, value);
+    seg.set(JAVA_LONG_UNALIGNED_NON_NATIVE, offsetBytes, value);
   }
 
   @Override
@@ -324,8 +332,8 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
     final MemorySegment srcSlice = MemorySegment.ofArray(srcArray).asSlice(srcOffsetLongs << LONG_SHIFT, copyBytes);
     final MemorySegment dstSlice = seg.asSlice(pos, copyBytes);
     for (int index = 0; index < lengthLongs; index++) {
-      final long aLong = MemoryAccess.getLongAtIndex(srcSlice, index,  NATIVE_BYTE_ORDER);
-      MemoryAccess.setLongAtIndex(dstSlice, index, NON_NATIVE_BYTE_ORDER, aLong);
+      final long aLong = srcSlice.getAtIndex(ValueLayout.JAVA_LONG_UNALIGNED, index);
+      dstSlice.setAtIndex(JAVA_LONG_UNALIGNED_NON_NATIVE, index, aLong);
     }
     setPosition(pos + copyBytes);
   }
@@ -333,13 +341,13 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
   @Override
   public void putShort(final short value) {
     final long pos = getPosition();
-    MemoryAccess.setShortAtOffset(seg, pos, NON_NATIVE_BYTE_ORDER, value);
+    seg.set(JAVA_SHORT_UNALIGNED_NON_NATIVE, pos, value);
     setPosition(pos + Short.BYTES);
   }
 
   @Override
   public void putShort(final long offsetBytes, final short value) {
-    MemoryAccess.setShortAtOffset(seg, offsetBytes, NON_NATIVE_BYTE_ORDER, value);
+    seg.set(JAVA_SHORT_UNALIGNED_NON_NATIVE, offsetBytes, value);
   }
 
   @Override
@@ -349,8 +357,8 @@ final class NonNativeWritableBufferImpl extends WritableBufferImpl {
     final MemorySegment srcSlice = MemorySegment.ofArray(srcArray).asSlice(srcOffsetShorts << SHORT_SHIFT, copyBytes);
     final MemorySegment dstSlice = seg.asSlice(pos, copyBytes);
     for (int index = 0; index < lengthShorts; index++) {
-      final short aShort = MemoryAccess.getShortAtIndex(srcSlice, index,  NATIVE_BYTE_ORDER);
-      MemoryAccess.setShortAtIndex(dstSlice, index, NON_NATIVE_BYTE_ORDER, aShort);
+      final short aShort = srcSlice.getAtIndex(ValueLayout.JAVA_SHORT_UNALIGNED, index);
+      dstSlice.setAtIndex(JAVA_SHORT_UNALIGNED_NON_NATIVE, index, aShort);
     }
     setPosition(pos + copyBytes);
   }

--- a/src/main/java/org/apache/datasketches/memory/internal/NonNativeWritableMemoryImpl.java
+++ b/src/main/java/org/apache/datasketches/memory/internal/NonNativeWritableMemoryImpl.java
@@ -19,11 +19,19 @@
 
 package org.apache.datasketches.memory.internal;
 
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+
 import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.WritableMemory;
+import static org.apache.datasketches.memory.internal.NonNativeValueLayouts.JAVA_CHAR_UNALIGNED_NON_NATIVE;
+import static org.apache.datasketches.memory.internal.NonNativeValueLayouts.JAVA_DOUBLE_UNALIGNED_NON_NATIVE;
+import static org.apache.datasketches.memory.internal.NonNativeValueLayouts.JAVA_FLOAT_UNALIGNED_NON_NATIVE;
+import static org.apache.datasketches.memory.internal.NonNativeValueLayouts.JAVA_INT_UNALIGNED_NON_NATIVE;
+import static org.apache.datasketches.memory.internal.NonNativeValueLayouts.JAVA_LONG_UNALIGNED_NON_NATIVE;
+import static org.apache.datasketches.memory.internal.NonNativeValueLayouts.JAVA_SHORT_UNALIGNED_NON_NATIVE;
 
-import jdk.incubator.foreign.MemoryAccess;
-import jdk.incubator.foreign.MemorySegment;
 
 /**
  * Implementation of {@link WritableMemory} for non-native endian byte order.
@@ -34,16 +42,17 @@ final class NonNativeWritableMemoryImpl extends WritableMemoryImpl {
 
   //Pass-through ctor
   NonNativeWritableMemoryImpl(
+      final Arena arena,
       final MemorySegment seg,
       final int typeId,
       final MemoryRequestServer memReqSvr) {
-    super(seg, typeId, memReqSvr);
+    super(arena, seg, typeId, memReqSvr);
   }
 
   ///PRIMITIVE getX() and getXArray()
   @Override
   public char getChar(final long offsetBytes) {
-    return MemoryAccess.getCharAtOffset(seg, offsetBytes, NON_NATIVE_BYTE_ORDER);
+    return seg.get(JAVA_CHAR_UNALIGNED_NON_NATIVE, offsetBytes);
   }
 
   @Override
@@ -52,14 +61,14 @@ final class NonNativeWritableMemoryImpl extends WritableMemoryImpl {
     final MemorySegment srcSlice = seg.asSlice(offsetBytes, copyBytes);
     final MemorySegment dstSlice = MemorySegment.ofArray(dstArray).asSlice(dstOffsetChars << CHAR_SHIFT, copyBytes);
     for (int index = 0; index < lengthChars; index++) {
-      final char aChar = MemoryAccess.getCharAtIndex(srcSlice, index,  NON_NATIVE_BYTE_ORDER);
-      MemoryAccess.setCharAtIndex(dstSlice, index, NATIVE_BYTE_ORDER, aChar);
+      final char aChar = srcSlice.getAtIndex(JAVA_CHAR_UNALIGNED_NON_NATIVE, index);
+      dstSlice.setAtIndex(ValueLayout.JAVA_CHAR_UNALIGNED, index, aChar);
     }
   }
 
   @Override
   public double getDouble(final long offsetBytes) {
-    return MemoryAccess.getDoubleAtOffset(seg, offsetBytes, NON_NATIVE_BYTE_ORDER);
+    return seg.get(JAVA_DOUBLE_UNALIGNED_NON_NATIVE, offsetBytes);
   }
 
   @Override
@@ -68,14 +77,14 @@ final class NonNativeWritableMemoryImpl extends WritableMemoryImpl {
     final MemorySegment srcSlice = seg.asSlice(offsetBytes, copyBytes);
     final MemorySegment dstSlice = MemorySegment.ofArray(dstArray).asSlice(dstOffsetDoubles << DOUBLE_SHIFT, copyBytes);
     for (int index = 0; index < lengthDoubles; index++) {
-      final double dbl = MemoryAccess.getDoubleAtIndex(srcSlice, index,  NON_NATIVE_BYTE_ORDER);
-      MemoryAccess.setDoubleAtIndex(dstSlice, index, NATIVE_BYTE_ORDER, dbl);
+      final double dbl = srcSlice.getAtIndex(JAVA_DOUBLE_UNALIGNED_NON_NATIVE, index);
+      dstSlice.setAtIndex(ValueLayout.JAVA_DOUBLE_UNALIGNED, index, dbl);
     }
   }
 
   @Override
   public float getFloat(final long offsetBytes) {
-    return MemoryAccess.getFloatAtOffset(seg, offsetBytes, NON_NATIVE_BYTE_ORDER);
+    return seg.get(JAVA_FLOAT_UNALIGNED_NON_NATIVE, offsetBytes);
   }
 
   @Override
@@ -84,14 +93,14 @@ final class NonNativeWritableMemoryImpl extends WritableMemoryImpl {
     final MemorySegment srcSlice = seg.asSlice(offsetBytes, copyBytes);
     final MemorySegment dstSlice = MemorySegment.ofArray(dstArray).asSlice(dstOffsetFloats << FLOAT_SHIFT, copyBytes);
     for (int index = 0; index < lengthFloats; index++) {
-      final float flt = MemoryAccess.getFloatAtIndex(srcSlice, index,  NON_NATIVE_BYTE_ORDER);
-      MemoryAccess.setFloatAtIndex(dstSlice, index, NATIVE_BYTE_ORDER, flt);
+      final float flt = srcSlice.getAtIndex(JAVA_FLOAT_UNALIGNED_NON_NATIVE, index);
+      dstSlice.setAtIndex(ValueLayout.JAVA_FLOAT_UNALIGNED, index, flt);
     }
   }
 
   @Override
   public int getInt(final long offsetBytes) {
-    return MemoryAccess.getIntAtOffset(seg, offsetBytes, NON_NATIVE_BYTE_ORDER);
+    return seg.get(JAVA_INT_UNALIGNED_NON_NATIVE, offsetBytes);
   }
 
   @Override
@@ -100,14 +109,14 @@ final class NonNativeWritableMemoryImpl extends WritableMemoryImpl {
     final MemorySegment srcSlice = seg.asSlice(offsetBytes, copyBytes);
     final MemorySegment dstSlice = MemorySegment.ofArray(dstArray).asSlice(dstOffsetInts << INT_SHIFT, copyBytes);
     for (int index = 0; index < lengthInts; index++) {
-      final int anInt = MemoryAccess.getIntAtIndex(srcSlice, index,  NON_NATIVE_BYTE_ORDER);
-      MemoryAccess.setIntAtIndex(dstSlice, index, NATIVE_BYTE_ORDER, anInt);
+      final int anInt = srcSlice.getAtIndex(JAVA_INT_UNALIGNED_NON_NATIVE, index);
+      dstSlice.setAtIndex(ValueLayout.JAVA_INT_UNALIGNED, index, anInt);
     }
   }
 
   @Override
   public long getLong(final long offsetBytes) {
-    return MemoryAccess.getLongAtOffset(seg, offsetBytes, NON_NATIVE_BYTE_ORDER);
+    return seg.get(JAVA_LONG_UNALIGNED_NON_NATIVE, offsetBytes);
   }
 
   @Override
@@ -116,14 +125,14 @@ final class NonNativeWritableMemoryImpl extends WritableMemoryImpl {
     final MemorySegment srcSlice = seg.asSlice(offsetBytes, copyBytes);
     final MemorySegment dstSlice = MemorySegment.ofArray(dstArray).asSlice(dstOffsetLongs << LONG_SHIFT, copyBytes);
     for (int index = 0; index < lengthLongs; index++) {
-      final long aLong = MemoryAccess.getLongAtIndex(srcSlice, index,  NON_NATIVE_BYTE_ORDER);
-      MemoryAccess.setLongAtIndex(dstSlice, index, NATIVE_BYTE_ORDER, aLong);
+      final long aLong = srcSlice.getAtIndex(JAVA_LONG_UNALIGNED_NON_NATIVE, index);
+      dstSlice.setAtIndex(ValueLayout.JAVA_LONG_UNALIGNED, index, aLong);
     }
   }
 
   @Override
   public short getShort(final long offsetBytes) {
-    return MemoryAccess.getShortAtOffset(seg, offsetBytes, NON_NATIVE_BYTE_ORDER);
+    return seg.get(JAVA_SHORT_UNALIGNED_NON_NATIVE, offsetBytes);
   }
 
   @Override
@@ -132,15 +141,15 @@ final class NonNativeWritableMemoryImpl extends WritableMemoryImpl {
     final MemorySegment srcSlice = seg.asSlice(offsetBytes, copyBytes);
     final MemorySegment dstSlice = MemorySegment.ofArray(dstArray).asSlice(dstOffsetShorts << SHORT_SHIFT, copyBytes);
     for (int index = 0; index < lengthShorts; index++) {
-      final short aShort = MemoryAccess.getShortAtIndex(srcSlice, index,  NON_NATIVE_BYTE_ORDER);
-      MemoryAccess.setShortAtIndex(dstSlice, index, NATIVE_BYTE_ORDER, aShort);
+      final short aShort = srcSlice.getAtIndex(JAVA_SHORT_UNALIGNED_NON_NATIVE, index);
+      dstSlice.setAtIndex(ValueLayout.JAVA_SHORT_UNALIGNED, index, aShort);
     }
   }
 
   //PRIMITIVE putX() and putXArray() implementations
   @Override
   public void putChar(final long offsetBytes, final char value) {
-    MemoryAccess.setCharAtOffset(seg, offsetBytes, NON_NATIVE_BYTE_ORDER, value);
+    seg.set(JAVA_CHAR_UNALIGNED_NON_NATIVE, offsetBytes, value);
   }
 
   @Override
@@ -149,14 +158,14 @@ final class NonNativeWritableMemoryImpl extends WritableMemoryImpl {
     final MemorySegment srcSlice = MemorySegment.ofArray(srcArray).asSlice(srcOffsetChars << CHAR_SHIFT, copyBytes);
     final MemorySegment dstSlice = seg.asSlice(offsetBytes, copyBytes);
     for (int index = 0; index < lengthChars; index++) {
-      final char aChar = MemoryAccess.getCharAtIndex(srcSlice, index,  NATIVE_BYTE_ORDER);
-      MemoryAccess.setCharAtIndex(dstSlice, index, NON_NATIVE_BYTE_ORDER, aChar);
+      final char aChar = srcSlice.getAtIndex(ValueLayout.JAVA_CHAR_UNALIGNED, index);
+      dstSlice.setAtIndex(JAVA_CHAR_UNALIGNED_NON_NATIVE, index, aChar);
     }
   }
 
   @Override
   public void putDouble(final long offsetBytes, final double value) {
-    MemoryAccess.setDoubleAtOffset(seg, offsetBytes, NON_NATIVE_BYTE_ORDER, value);
+    seg.set(JAVA_DOUBLE_UNALIGNED_NON_NATIVE, offsetBytes, value);
   }
 
   @Override
@@ -165,14 +174,14 @@ final class NonNativeWritableMemoryImpl extends WritableMemoryImpl {
     final MemorySegment srcSlice = MemorySegment.ofArray(srcArray).asSlice(srcOffsetDoubles << DOUBLE_SHIFT, copyBytes);
     final MemorySegment dstSlice = seg.asSlice(offsetBytes, copyBytes);
     for (int index = 0; index < lengthDoubles; index++) {
-      final double dbl = MemoryAccess.getDoubleAtIndex(srcSlice, index,  NATIVE_BYTE_ORDER);
-      MemoryAccess.setDoubleAtIndex(dstSlice, index, NON_NATIVE_BYTE_ORDER, dbl);
+      final double dbl = srcSlice.getAtIndex(ValueLayout.JAVA_DOUBLE_UNALIGNED, index);
+      dstSlice.setAtIndex(JAVA_DOUBLE_UNALIGNED_NON_NATIVE, index, dbl);
     }
   }
 
   @Override
   public void putFloat(final long offsetBytes, final float value) {
-    MemoryAccess.setFloatAtOffset(seg, offsetBytes, NON_NATIVE_BYTE_ORDER, value);
+    seg.set(JAVA_FLOAT_UNALIGNED_NON_NATIVE, offsetBytes, value);
   }
 
   @Override
@@ -181,14 +190,14 @@ final class NonNativeWritableMemoryImpl extends WritableMemoryImpl {
     final MemorySegment srcSlice = MemorySegment.ofArray(srcArray).asSlice(srcOffsetFloats << FLOAT_SHIFT, copyBytes);
     final MemorySegment dstSlice = seg.asSlice(offsetBytes, copyBytes);
     for (int index = 0; index < lengthFloats; index++) {
-      final float flt = MemoryAccess.getFloatAtIndex(srcSlice, index,  NATIVE_BYTE_ORDER);
-      MemoryAccess.setFloatAtIndex(dstSlice, index, NON_NATIVE_BYTE_ORDER, flt);
+      final float flt = srcSlice.getAtIndex(ValueLayout.JAVA_FLOAT_UNALIGNED, index);
+      dstSlice.setAtIndex(JAVA_FLOAT_UNALIGNED_NON_NATIVE, index, flt);
     }
   }
 
   @Override
   public void putInt(final long offsetBytes, final int value) {
-    MemoryAccess.setIntAtOffset(seg, offsetBytes, NON_NATIVE_BYTE_ORDER, value);
+    seg.set(JAVA_INT_UNALIGNED_NON_NATIVE, offsetBytes, value);
   }
 
   @Override
@@ -197,14 +206,14 @@ final class NonNativeWritableMemoryImpl extends WritableMemoryImpl {
     final MemorySegment srcSlice = MemorySegment.ofArray(srcArray).asSlice(srcOffsetInts << INT_SHIFT, copyBytes);
     final MemorySegment dstSlice = seg.asSlice(offsetBytes, copyBytes);
     for (int index = 0; index < lengthInts; index++) {
-      final int anInt = MemoryAccess.getIntAtIndex(srcSlice, index,  NATIVE_BYTE_ORDER);
-      MemoryAccess.setIntAtIndex(dstSlice, index, NON_NATIVE_BYTE_ORDER, anInt);
+      final int anInt = srcSlice.getAtIndex(ValueLayout.JAVA_INT_UNALIGNED, index);
+      dstSlice.setAtIndex(JAVA_INT_UNALIGNED_NON_NATIVE, index, anInt);
     }
   }
 
   @Override
   public void putLong(final long offsetBytes, final long value) {
-    MemoryAccess.setLongAtOffset(seg, offsetBytes, NON_NATIVE_BYTE_ORDER, value);
+    seg.set(JAVA_LONG_UNALIGNED_NON_NATIVE, offsetBytes, value);
   }
 
   @Override
@@ -213,14 +222,14 @@ final class NonNativeWritableMemoryImpl extends WritableMemoryImpl {
     final MemorySegment srcSlice = MemorySegment.ofArray(srcArray).asSlice(srcOffsetLongs << LONG_SHIFT, copyBytes);
     final MemorySegment dstSlice = seg.asSlice(offsetBytes, copyBytes);
     for (int index = 0; index < lengthLongs; index++) {
-      final long aLong = MemoryAccess.getLongAtIndex(srcSlice, index,  NATIVE_BYTE_ORDER);
-      MemoryAccess.setLongAtIndex(dstSlice, index, NON_NATIVE_BYTE_ORDER, aLong);
+      final long aLong = srcSlice.getAtIndex(ValueLayout.JAVA_LONG_UNALIGNED, index);
+      dstSlice.setAtIndex(JAVA_LONG_UNALIGNED_NON_NATIVE, index, aLong);
     }
   }
 
   @Override
   public void putShort(final long offsetBytes, final short value) {
-    MemoryAccess.setShortAtOffset(seg, offsetBytes, NON_NATIVE_BYTE_ORDER, value);
+    seg.set(JAVA_SHORT_UNALIGNED_NON_NATIVE, offsetBytes, value);
   }
 
   @Override
@@ -229,8 +238,8 @@ final class NonNativeWritableMemoryImpl extends WritableMemoryImpl {
     final MemorySegment srcSlice = MemorySegment.ofArray(srcArray).asSlice(srcOffsetShorts << SHORT_SHIFT, copyBytes);
     final MemorySegment dstSlice = seg.asSlice(offsetBytes, copyBytes);
     for (int index = 0; index < lengthShorts; index++) {
-      final short aShort = MemoryAccess.getShortAtIndex(srcSlice, index,  NATIVE_BYTE_ORDER);
-      MemoryAccess.setShortAtIndex(dstSlice, index, NON_NATIVE_BYTE_ORDER, aShort);
+      final short aShort = srcSlice.getAtIndex(ValueLayout.JAVA_SHORT_UNALIGNED, index);
+      dstSlice.setAtIndex(JAVA_SHORT_UNALIGNED_NON_NATIVE, index, aShort);
     }
   }
 

--- a/src/main/java/org/apache/datasketches/memory/internal/PositionalImpl.java
+++ b/src/main/java/org/apache/datasketches/memory/internal/PositionalImpl.java
@@ -19,11 +19,13 @@
 
 package org.apache.datasketches.memory.internal;
 
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+
 import org.apache.datasketches.memory.BufferPositionInvariantsException;
 import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.Positional;
 
-import jdk.incubator.foreign.MemorySegment;
 
 /**
  * This implements the positional API.
@@ -51,10 +53,11 @@ abstract class PositionalImpl extends ResourceImpl implements Positional {
 
   //Pass-through constructor
   PositionalImpl(
+      final Arena arena,
       final MemorySegment seg,
       final int typeId,
       final MemoryRequestServer memReqSvr) {
-    super(seg, typeId, memReqSvr);
+    super(arena, seg, typeId, memReqSvr);
     capacity = end = seg.byteSize();
   }
 

--- a/src/main/java/org/apache/datasketches/memory/internal/WritableMemoryImpl.java
+++ b/src/main/java/org/apache/datasketches/memory/internal/WritableMemoryImpl.java
@@ -140,8 +140,8 @@ public abstract class WritableMemoryImpl extends ResourceImpl implements Writabl
    * @param fileOffsetBytes the file starting offset in bytes. It must be &ge; 0.
    * @param capacityBytes the capacity of the mapped memory. It must be &ge; 0.
    * It must be non-null.
-   * Typically use <i>ResourceScope.newConfinedScope()</i>.
-   * Warning: specifying a <i>newSharedScope()</i> is not supported.
+   * Typically use <i>Arena.ofConfined()</i>.
+   * Warning: specifying a <i>Arena.ofShared()</i> is not supported.
    * @param localReadOnly true if read-only is being imposed locally, even if the given file is writable..
    * @param byteOrder the given <i>ByteOrder</i>. It must be non-null.
    * @return a <i>WritableMemory</i>
@@ -196,7 +196,7 @@ public abstract class WritableMemoryImpl extends ResourceImpl implements Writabl
    * @param arena the given arena. It must be non-null.
    * @param capacityBytes the requested capacity for the Direct (off-heap) memory.  It must be &ge; 0.
    * @param alignmentBytes requested segment alignment. Typically 1, 2, 4 or 8.
-   * Warning: specifying a <i>newSharedScope()</i> is not supported.
+   * Warning: specifying a <i>Arena.ofShared()</i> is not supported.
    * @param byteOrder the byte order to be used.  It must be non-null.
    * @param memReqSvr A user-specified MemoryRequestServer, which may be null.
    * This is a callback mechanism for a user client of direct memory to request more memory.

--- a/src/main/java/org/apache/datasketches/memory/internal/WritableMemoryImpl.java
+++ b/src/main/java/org/apache/datasketches/memory/internal/WritableMemoryImpl.java
@@ -25,20 +25,22 @@ import static java.nio.channels.FileChannel.MapMode.READ_WRITE;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
+import java.nio.file.OpenOption;
+import java.nio.file.StandardOpenOption;
 import java.util.Objects;
+import java.util.Set;
 
 import org.apache.datasketches.memory.Buffer;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.WritableBuffer;
 import org.apache.datasketches.memory.WritableMemory;
-
-import jdk.incubator.foreign.MemoryAccess;
-import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.ResourceScope;
 
 /**
  * Common base of native-ordered and non-native-ordered {@link WritableMemory} implementations.
@@ -48,10 +50,11 @@ public abstract class WritableMemoryImpl extends ResourceImpl implements Writabl
 
   //Pass-through constructor
   WritableMemoryImpl(
+      final Arena arena,
       final MemorySegment seg,
       final int typeId,
       final MemoryRequestServer memReqSvr) {
-    super(seg, typeId, memReqSvr);
+    super(arena, seg, typeId, memReqSvr);
   }
 
   //WRAP HEAP ARRAY RESOURCE
@@ -72,9 +75,9 @@ public abstract class WritableMemoryImpl extends ResourceImpl implements Writabl
         | (seg.isReadOnly() ? READONLY : 0);
     if (byteOrder == NON_NATIVE_BYTE_ORDER) {
       type |= NONNATIVE_BO;
-      return new NonNativeWritableMemoryImpl(seg, type, memReqSvr);
+      return new NonNativeWritableMemoryImpl(null, seg, type, memReqSvr);
     }
-    return new NativeWritableMemoryImpl(seg, type, memReqSvr);
+    return new NativeWritableMemoryImpl(null, seg, type, memReqSvr);
   }
 
   //BYTE BUFFER RESOURCE
@@ -112,7 +115,7 @@ public abstract class WritableMemoryImpl extends ResourceImpl implements Writabl
       byteBufView = byteBuffer.duplicate();
     }
     byteBufView.clear(); //resets position to zero and limit to capacity. Does not impact data.
-    final MemorySegment seg = MemorySegment.ofByteBuffer(byteBufView); //from 0 to capacity
+    final MemorySegment seg = MemorySegment.ofBuffer(byteBufView); //from 0 to capacity
     int type = MEMORY | BYTEBUF
         | (localReadOnly ? READONLY : 0)
         | (seg.isNative() ? DIRECT : 0)
@@ -120,9 +123,9 @@ public abstract class WritableMemoryImpl extends ResourceImpl implements Writabl
     final WritableMemory wmem;
     if (byteOrder == NON_NATIVE_BYTE_ORDER) {
       type |= NONNATIVE_BO;
-      wmem = new NonNativeWritableMemoryImpl(seg, type, memReqSvr);
+      wmem = new NonNativeWritableMemoryImpl(null, seg, type, memReqSvr);
     } else {
-      wmem = new NativeWritableMemoryImpl(seg, type, memReqSvr);
+      wmem = new NativeWritableMemoryImpl(null, seg, type, memReqSvr);
     }
     return wmem;
   }
@@ -132,10 +135,10 @@ public abstract class WritableMemoryImpl extends ResourceImpl implements Writabl
   /**
    * The implementation of <i>wrapMap</i> for <i>WritableMemory</i>.
    * This method is also used for read-only operations when localReadOnly is false.
+   * @param arena the given arena. It must be non-null.
    * @param file the given file to map. It must be non-null.
    * @param fileOffsetBytes the file starting offset in bytes. It must be &ge; 0.
    * @param capacityBytes the capacity of the mapped memory. It must be &ge; 0.
-   * @param scope the given scope.
    * It must be non-null.
    * Typically use <i>ResourceScope.newConfinedScope()</i>.
    * Warning: specifying a <i>newSharedScope()</i> is not supported.
@@ -146,16 +149,16 @@ public abstract class WritableMemoryImpl extends ResourceImpl implements Writabl
    * @throws IOException if mapping is not successful.
    */
   public static WritableMemory wrapMap(
+      final Arena arena,
       final File file,
       final long fileOffsetBytes,
       final long capacityBytes,
-      final ResourceScope scope,
       final boolean localReadOnly,
       final ByteOrder byteOrder)
           throws IllegalArgumentException, IOException {
+    Objects.requireNonNull(arena, "Arena must be non-null.");
     Objects.requireNonNull(file, "File must be non-null.");
     Objects.requireNonNull(byteOrder, "ByteOrder must be non-null.");
-    Objects.requireNonNull(scope, "ResourceScope must be non-null.");
     final FileChannel.MapMode mapMode;
     final boolean fileCanRead = file.canRead();
     if (localReadOnly) {
@@ -167,25 +170,32 @@ public abstract class WritableMemoryImpl extends ResourceImpl implements Writabl
         throw new IllegalArgumentException("File must be readable and writable.");
       }
     }
-    final MemorySegment seg = MemorySegment.mapFile(file.toPath(), fileOffsetBytes, capacityBytes, mapMode, scope);
+
+    final Set<OpenOption> openOptions = READ_WRITE.equals(mapMode) ?
+      Set.of(StandardOpenOption.READ, StandardOpenOption.WRITE) :
+      Set.of(StandardOpenOption.READ);
+
     final boolean nativeBOType = byteOrder == ByteOrder.nativeOrder();
     final int type = MEMORY | MAP | DIRECT
-        | (localReadOnly ? READONLY : 0)
-        | (nativeBOType ? NATIVE_BO : NONNATIVE_BO);
-    return nativeBOType
-        ? new NativeWritableMemoryImpl(seg, type, null)
-        : new NonNativeWritableMemoryImpl(seg, type, null);
+          | (localReadOnly ? READONLY : 0)
+          | (nativeBOType ? NATIVE_BO : NONNATIVE_BO);
+
+    try (final FileChannel fileChannel = FileChannel.open(file.toPath(), openOptions)) {
+      final MemorySegment seg = fileChannel.map(mapMode, fileOffsetBytes, capacityBytes, arena);
+
+      return nativeBOType
+          ? new NativeWritableMemoryImpl(arena, seg, type, null)
+          : new NonNativeWritableMemoryImpl(arena, seg, type, null);
+    }
   }
 
   //DIRECT RESOURCE
 
   /**
    * The static constructor that chooses the correct Direct leaf node based on the byte order.
+   * @param arena the given arena. It must be non-null.
    * @param capacityBytes the requested capacity for the Direct (off-heap) memory.  It must be &ge; 0.
    * @param alignmentBytes requested segment alignment. Typically 1, 2, 4 or 8.
-   * @param scope ResourceScope for the backing MemorySegment.
-   * It must be non-null.
-   * Typically use <i>ResourceScope.newConfinedScope()</i>.
    * Warning: specifying a <i>newSharedScope()</i> is not supported.
    * @param byteOrder the byte order to be used.  It must be non-null.
    * @param memReqSvr A user-specified MemoryRequestServer, which may be null.
@@ -193,23 +203,20 @@ public abstract class WritableMemoryImpl extends ResourceImpl implements Writabl
    * @return WritableMemory
    */
   public static WritableMemory wrapDirect(
+      final Arena arena,
       final long capacityBytes,
       final long alignmentBytes,
-      final ResourceScope scope,
       final ByteOrder byteOrder,
       final MemoryRequestServer memReqSvr) {
-    Objects.requireNonNull(scope, "ResourceScope must be non-null");
+    Objects.requireNonNull(arena, "Arena must be non-null");
     Objects.requireNonNull(byteOrder, "ByteOrder must be non-null");
-    final MemorySegment seg = MemorySegment.allocateNative(
-        capacityBytes,
-        alignmentBytes,
-        scope);
+    final MemorySegment seg = arena.allocate(capacityBytes, alignmentBytes);
     final boolean nativeBOType = byteOrder == ByteOrder.nativeOrder();
     final int type = MEMORY | DIRECT
         | (nativeBOType ? NATIVE_BO : NONNATIVE_BO);
     return nativeBOType
-        ? new NativeWritableMemoryImpl(seg, type, memReqSvr)
-        : new NonNativeWritableMemoryImpl(seg, type, memReqSvr);
+        ? new NativeWritableMemoryImpl(arena, seg, type, memReqSvr)
+        : new NonNativeWritableMemoryImpl(arena, seg, type, memReqSvr);
   }
 
   //REGION DERIVED
@@ -305,7 +312,7 @@ public abstract class WritableMemoryImpl extends ResourceImpl implements Writabl
 
   @Override
   public final byte getByte(final long offsetBytes) {
-    return MemoryAccess.getByteAtOffset(seg, offsetBytes);
+    return seg.get(ValueLayout.JAVA_BYTE, offsetBytes);
   }
 
   @Override
@@ -350,7 +357,7 @@ public abstract class WritableMemoryImpl extends ResourceImpl implements Writabl
 
   @Override
   public final void putByte(final long offsetBytes, final byte value) {
-    MemoryAccess.setByteAtOffset(seg, offsetBytes, value);
+    seg.set(ValueLayout.JAVA_BYTE, offsetBytes, value);
   }
 
   @Override
@@ -376,8 +383,8 @@ public abstract class WritableMemoryImpl extends ResourceImpl implements Writabl
 
   @Override
   public final void clearBits(final long offsetBytes, final byte bitMask) {
-    final byte b = MemoryAccess.getByteAtOffset(seg, offsetBytes);
-    MemoryAccess.setByteAtOffset(seg, offsetBytes, (byte)(b & ~bitMask));
+    final byte b = seg.get(ValueLayout.JAVA_BYTE, offsetBytes);
+    seg.set(ValueLayout.JAVA_BYTE, offsetBytes, (byte)(b & ~bitMask));
   }
 
   @Override
@@ -393,13 +400,13 @@ public abstract class WritableMemoryImpl extends ResourceImpl implements Writabl
 
   @Override
   public final byte[] getArray() {
-    return seg.toByteArray();
+    return seg.toArray(ValueLayout.JAVA_BYTE);
   }
 
   @Override
   public final void setBits(final long offsetBytes, final byte bitMask) {
-    final byte b = MemoryAccess.getByteAtOffset(seg, offsetBytes);
-    MemoryAccess.setByteAtOffset(seg, offsetBytes, (byte)(b | bitMask));
+    final byte b = seg.get(ValueLayout.JAVA_BYTE, offsetBytes);
+    seg.set(ValueLayout.JAVA_BYTE, offsetBytes, (byte)(b | bitMask));
   }
 
 }

--- a/src/main/java/org/apache/datasketches/memory/internal/XxHash64.java
+++ b/src/main/java/org/apache/datasketches/memory/internal/XxHash64.java
@@ -19,9 +19,6 @@
 
 package org.apache.datasketches.memory.internal;
 
-import static jdk.incubator.foreign.MemoryAccess.getByteAtOffset;
-import static jdk.incubator.foreign.MemoryAccess.getIntAtOffset;
-import static jdk.incubator.foreign.MemoryAccess.getLongAtOffset;
 import static org.apache.datasketches.memory.internal.ResourceImpl.CHAR_SHIFT;
 import static org.apache.datasketches.memory.internal.ResourceImpl.DOUBLE_SHIFT;
 import static org.apache.datasketches.memory.internal.ResourceImpl.FLOAT_SHIFT;
@@ -29,7 +26,8 @@ import static org.apache.datasketches.memory.internal.ResourceImpl.INT_SHIFT;
 import static org.apache.datasketches.memory.internal.ResourceImpl.LONG_SHIFT;
 import static org.apache.datasketches.memory.internal.ResourceImpl.SHORT_SHIFT;
 
-import jdk.incubator.foreign.MemorySegment;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 
 /**
  * The XxHash is a fast, non-cryptographic, 64-bit hash function that has
@@ -77,19 +75,19 @@ public class XxHash64 {
       long v4 = seed - P1;
 
       do {
-        v1 += getLongAtOffset(seg, offsetBytes) * P2;
+        v1 += seg.get(ValueLayout.JAVA_LONG_UNALIGNED, offsetBytes) * P2;
         v1 = Long.rotateLeft(v1, 31);
         v1 *= P1;
 
-        v2 += getLongAtOffset(seg, offsetBytes + 8L) * P2;
+        v2 += seg.get(ValueLayout.JAVA_LONG_UNALIGNED, offsetBytes+ 8L) * P2;
         v2 = Long.rotateLeft(v2, 31);
         v2 *= P1;
 
-        v3 += getLongAtOffset(seg, offsetBytes + 16L) * P2;
+        v3 += seg.get(ValueLayout.JAVA_LONG_UNALIGNED, offsetBytes + 16L) * P2;
         v3 = Long.rotateLeft(v3, 31);
         v3 *= P1;
 
-        v4 += getLongAtOffset(seg, offsetBytes + 24L) * P2;
+        v4 += seg.get(ValueLayout.JAVA_LONG_UNALIGNED, offsetBytes + 24L) * P2;
         v4 = Long.rotateLeft(v4, 31);
         v4 *= P1;
 
@@ -133,7 +131,7 @@ public class XxHash64 {
     hash += lengthBytes;
 
     while (remaining >= 8) {
-      long k1 = getLongAtOffset(seg, offsetBytes);
+      long k1 = seg.get(ValueLayout.JAVA_LONG_UNALIGNED, offsetBytes);
       k1 *= P2;
       k1 = Long.rotateLeft(k1, 31);
       k1 *= P1;
@@ -144,14 +142,14 @@ public class XxHash64 {
     }
 
     if (remaining >= 4) { //treat as unsigned ints
-      hash ^= (getIntAtOffset(seg, offsetBytes) & 0XFFFF_FFFFL) * P1;
+      hash ^= (seg.get(ValueLayout.JAVA_INT_UNALIGNED, offsetBytes) & 0XFFFF_FFFFL) * P1;
       hash = (Long.rotateLeft(hash, 23) * P2) + P3;
       offsetBytes += 4;
       remaining -= 4;
     }
 
     while (remaining != 0) { //treat as unsigned bytes
-      hash ^= (getByteAtOffset(seg, offsetBytes) & 0XFFL) * P5;
+      hash ^= (seg.get(ValueLayout.JAVA_BYTE, offsetBytes) & 0XFFL) * P5;
       hash = Long.rotateLeft(hash, 11) * P1;
       --remaining;
       ++offsetBytes;

--- a/src/main/java/org/apache/datasketches/memory/internal/XxHash64.java
+++ b/src/main/java/org/apache/datasketches/memory/internal/XxHash64.java
@@ -306,4 +306,5 @@ public class XxHash64 {
     return hash(seg, offsetChars << CHAR_SHIFT, lengthChars << CHAR_SHIFT, seed);
   }
 
+  private XxHash64() { }
 }

--- a/src/test/java/org/apache/datasketches/memory/internal/AllocateDirectWritableMapMemoryTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/AllocateDirectWritableMapMemoryTest.java
@@ -127,7 +127,7 @@ public class AllocateDirectWritableMapMemoryTest {
   public void testMapExceptionNoTWR()
       throws IllegalArgumentException, InvalidPathException, IllegalStateException, UnsupportedOperationException,
       IOException, SecurityException {
-    File dummy = createFile("dummy.txt", ""); //zero length
+    File dummy = createTempFile("dummy", ".txt" , ""); //zero length
     try (Arena arena = Arena.ofConfined()) {
       Memory.map(arena, dummy, 0, dummy.length(), ByteOrder.nativeOrder());
     }
@@ -161,7 +161,7 @@ public class AllocateDirectWritableMapMemoryTest {
       throws IllegalArgumentException, InvalidPathException, IllegalStateException, UnsupportedOperationException,
       IOException, SecurityException {
     String origStr = "Corectng spellng mistks";
-    File origFile = createFile("force_original.txt", origStr); //23
+    File origFile = createTempFile("force_original", ".txt", origStr); //23
     assertTrue(origFile.setWritable(true, false));
     long origBytes = origFile.length();
     String correctStr = "Correcting spelling mistakes"; //28
@@ -194,8 +194,9 @@ public class AllocateDirectWritableMapMemoryTest {
     }
   }
 
-  private static File createFile(String fileName, String text) throws FileNotFoundException {
-    File file = new File(fileName);
+  private static File createTempFile(String fileNamePrefix, String fileNameSuffix, String text)
+          throws FileNotFoundException, IOException {
+    File file = File.createTempFile(fileNamePrefix, fileNameSuffix);
     file.deleteOnExit();
     PrintWriter writer;
     try {

--- a/src/test/java/org/apache/datasketches/memory/internal/AllocateDirectWritableMapMemoryTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/AllocateDirectWritableMapMemoryTest.java
@@ -36,6 +36,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
+import java.lang.foreign.Arena;
 import java.nio.ByteOrder;
 import java.nio.file.InvalidPathException;
 
@@ -45,8 +46,6 @@ import org.apache.datasketches.memory.Resource;
 import org.apache.datasketches.memory.WritableMemory;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import jdk.incubator.foreign.ResourceScope;
 
 public class AllocateDirectWritableMapMemoryTest {
   private final MemoryRequestServer memReqSvr = Resource.defaultMemReqSvr;
@@ -60,8 +59,8 @@ public class AllocateDirectWritableMapMemoryTest {
   public void simpleMap() throws IllegalArgumentException, InvalidPathException, IllegalStateException,
       UnsupportedOperationException, IOException, SecurityException {
     File file = getResourceFile("GettysburgAddress.txt");
-    Memory mem = null;
-    try (ResourceScope scope = (mem = Memory.map(file)).scope()) {
+
+    try (Memory mem = Memory.map(Arena.ofConfined(), file)) {
       byte[] byteArr = new byte[(int)mem.getCapacity()];
       mem.getByteArray(0, byteArr, 0, byteArr.length);
       String text = new String(byteArr, UTF_8);
@@ -88,9 +87,9 @@ public class AllocateDirectWritableMapMemoryTest {
 
     WritableMemory dstMem = null;
     WritableMemory srcMem = null;
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) { //this scope manages two Memory objects
-      dstMem = WritableMemory.writableMap(file, 0, numBytes, scope, ByteOrder.nativeOrder());
-      srcMem = WritableMemory.allocateDirect(numBytes, 8, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) { //this scope manages two Memory objects
+      dstMem = WritableMemory.writableMap(arena, file, 0, numBytes, ByteOrder.nativeOrder());
+      srcMem = WritableMemory.allocateDirect(arena, numBytes, 8, ByteOrder.nativeOrder(), memReqSvr);
 
       //load source with consecutive longs
       for (long i = 0; i < numLongs; i++) {
@@ -119,11 +118,9 @@ public class AllocateDirectWritableMapMemoryTest {
 
     final long bytes = 8;
     WritableMemory wmem = null;
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      wmem = WritableMemory.writableMap(file, 0L, bytes, scope, NON_NATIVE_BYTE_ORDER);
-      wmem.putChar(0, (char) 1);
-      assertEquals(wmem.getByte(1), (byte) 1);
-    }
+    wmem = WritableMemory.writableMap(file, 0L, bytes, NON_NATIVE_BYTE_ORDER);
+    wmem.putChar(0, (char) 1);
+    assertEquals(wmem.getByte(1), (byte) 1);
   }
 
   @Test
@@ -131,9 +128,9 @@ public class AllocateDirectWritableMapMemoryTest {
       throws IllegalArgumentException, InvalidPathException, IllegalStateException, UnsupportedOperationException,
       IOException, SecurityException {
     File dummy = createFile("dummy.txt", ""); //zero length
-    ResourceScope scope = ResourceScope.newConfinedScope();
-    Memory.map(dummy, 0, dummy.length(), scope, ByteOrder.nativeOrder());
-    scope.close();
+    try (Arena arena = Arena.ofConfined()) {
+      Memory.map(arena, dummy, 0, dummy.length(), ByteOrder.nativeOrder());
+    }
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
@@ -143,8 +140,8 @@ public class AllocateDirectWritableMapMemoryTest {
     File file = getResourceFile("GettysburgAddress.txt");
     assertTrue(file.canRead());
     assertFalse(file.canWrite());
-    WritableMemory wmem = null;
-    try (ResourceScope scope = (wmem = WritableMemory.writableMap(file)).scope()) { //assumes file is writable!
+    try (Arena arena = Arena.ofConfined();
+         WritableMemory wmem = WritableMemory.writableMap(file)) { //assumes file is writable!
       wmem.getCapacity();
     }
   }
@@ -155,10 +152,8 @@ public class AllocateDirectWritableMapMemoryTest {
       IOException, SecurityException {
     File file = getResourceFile("GettysburgAddress.txt");
     WritableMemory wmem = null;
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      wmem = WritableMemory.writableMap(file, 0, 1 << 20, scope, ByteOrder.nativeOrder());
-      wmem.getCapacity();
-    }
+    wmem = WritableMemory.writableMap(file, 0, 1 << 20, ByteOrder.nativeOrder());
+    wmem.getCapacity();
   }
 
   @Test
@@ -175,8 +170,8 @@ public class AllocateDirectWritableMapMemoryTest {
 
     Memory mem = null;
     WritableMemory wmem = null;
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      mem = Memory.map(origFile, 0, origBytes, scope, ByteOrder.nativeOrder());
+    try (Arena arena = Arena.ofConfined()) {
+      mem = Memory.map(arena, origFile, 0, origBytes, ByteOrder.nativeOrder());
       mem.load();
       //assertTrue(mem.isLoaded()); //incompatible with Windows
       //confirm orig string
@@ -185,7 +180,7 @@ public class AllocateDirectWritableMapMemoryTest {
       String bufStr = new String(buf, UTF_8);
       assertEquals(bufStr, origStr);
 
-      wmem = WritableMemory.writableMap(origFile, 0, correctBytesLen, scope, ByteOrder.nativeOrder());
+      wmem = WritableMemory.writableMap(origFile, 0, correctBytesLen, ByteOrder.nativeOrder());
       wmem.load();
       //assertTrue(wmem.isLoaded()); //incompatible with Windows
       // over write content

--- a/src/test/java/org/apache/datasketches/memory/internal/Buffer2Test.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/Buffer2Test.java
@@ -24,6 +24,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
+import java.lang.foreign.Arena;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -33,8 +34,6 @@ import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.WritableBuffer;
 import org.apache.datasketches.memory.WritableMemory;
 import org.testng.annotations.Test;
-
-import jdk.incubator.foreign.ResourceScope;
 
 public class Buffer2Test {
 
@@ -83,19 +82,19 @@ public class Buffer2Test {
       byteArray[i] = i;
     }
 
-    Buffer buffer = Memory.wrap(byteArray).asBuffer();
-    int i = 0;
-    while (buffer.hasRemaining()) {
-      assertEquals(byteArray[i++], buffer.getByte());
+      Buffer buffer = Memory.wrap(byteArray).asBuffer();
+      int i = 0;
+      while (buffer.hasRemaining()) {
+        assertEquals(byteArray[i++], buffer.getByte());
+      }
+
+      buffer.setPosition(0);
+      byte[] copyByteArray = new byte[64];
+      buffer.getByteArray(copyByteArray, 0, 64);
+      assertEquals(byteArray, copyByteArray);
+
+      assertEquals(false, buffer.hasByteBuffer());
     }
-
-    buffer.setPosition(0);
-    byte[] copyByteArray = new byte[64];
-    buffer.getByteArray(copyByteArray, 0, 64);
-    assertEquals(byteArray, copyByteArray);
-
-    assertEquals(false, buffer.hasByteBuffer());
-  }
 
   @Test
   public void testWrapCharArray() {
@@ -106,16 +105,16 @@ public class Buffer2Test {
     }
 
     Buffer buffer = Memory.wrap(charArray).asBuffer();
-    int i = 0;
-    while (buffer.hasRemaining()) {
-      assertEquals(charArray[i++], buffer.getChar());
-    }
+      int i = 0;
+      while (buffer.hasRemaining()) {
+        assertEquals(charArray[i++], buffer.getChar());
+      }
 
-    buffer.setPosition(0);
-    char[] copyCharArray = new char[64];
-    buffer.getCharArray(copyCharArray, 0, 64);
-    assertEquals(charArray, copyCharArray);
-  }
+      buffer.setPosition(0);
+      char[] copyCharArray = new char[64];
+      buffer.getCharArray(copyCharArray, 0, 64);
+      assertEquals(charArray, copyCharArray);
+    }
 
   @Test
   public void testWrapShortArray() {
@@ -126,16 +125,16 @@ public class Buffer2Test {
     }
 
     Buffer buffer = Memory.wrap(shortArray).asBuffer();
-    int i = 0;
-    while (buffer.hasRemaining()) {
-      assertEquals(shortArray[i++], buffer.getShort());
-    }
+      int i = 0;
+      while (buffer.hasRemaining()) {
+        assertEquals(shortArray[i++], buffer.getShort());
+      }
 
-    buffer.setPosition(0);
-    short[] copyShortArray = new short[64];
-    buffer.getShortArray(copyShortArray, 0, 64);
-    assertEquals(shortArray, copyShortArray);
-  }
+      buffer.setPosition(0);
+      short[] copyShortArray = new short[64];
+      buffer.getShortArray(copyShortArray, 0, 64);
+      assertEquals(shortArray, copyShortArray);
+    }
 
   @Test
   public void testWrapIntArray() {
@@ -146,16 +145,16 @@ public class Buffer2Test {
     }
 
     Buffer buffer = Memory.wrap(intArray).asBuffer();
-    int i = 0;
-    while (buffer.hasRemaining()) {
-      assertEquals(intArray[i++], buffer.getInt());
-    }
+      int i = 0;
+      while (buffer.hasRemaining()) {
+        assertEquals(intArray[i++], buffer.getInt());
+      }
 
-    buffer.setPosition(0);
-    int[] copyIntArray = new int[64];
-    buffer.getIntArray(copyIntArray, 0, 64);
-    assertEquals(intArray, copyIntArray);
-  }
+      buffer.setPosition(0);
+      int[] copyIntArray = new int[64];
+      buffer.getIntArray(copyIntArray, 0, 64);
+      assertEquals(intArray, copyIntArray);
+    }
 
   @Test
   public void testWrapLongArray() {
@@ -166,16 +165,16 @@ public class Buffer2Test {
     }
 
     Buffer buffer = Memory.wrap(longArray).asBuffer();
-    int i = 0;
-    while (buffer.hasRemaining()) {
-      assertEquals(longArray[i++], buffer.getLong());
-    }
+      int i = 0;
+      while (buffer.hasRemaining()) {
+        assertEquals(longArray[i++], buffer.getLong());
+      }
 
-    buffer.setPosition(0);
-    long[] copyLongArray = new long[64];
-    buffer.getLongArray(copyLongArray, 0, 64);
-    assertEquals(longArray, copyLongArray);
-  }
+      buffer.setPosition(0);
+      long[] copyLongArray = new long[64];
+      buffer.getLongArray(copyLongArray, 0, 64);
+      assertEquals(longArray, copyLongArray);
+    }
 
   @Test
   public void testWrapFloatArray() {
@@ -186,16 +185,16 @@ public class Buffer2Test {
     }
 
     Buffer buffer = Memory.wrap(floatArray).asBuffer();
-    int i = 0;
-    while (buffer.hasRemaining()) {
-      assertEquals(floatArray[i++], buffer.getFloat());
-    }
+      int i = 0;
+      while (buffer.hasRemaining()) {
+        assertEquals(floatArray[i++], buffer.getFloat());
+      }
 
-    buffer.setPosition(0);
-    float[] copyFloatArray = new float[64];
-    buffer.getFloatArray(copyFloatArray, 0, 64);
-    assertEquals(floatArray, copyFloatArray);
-  }
+      buffer.setPosition(0);
+      float[] copyFloatArray = new float[64];
+      buffer.getFloatArray(copyFloatArray, 0, 64);
+      assertEquals(floatArray, copyFloatArray);
+    }
 
   @Test
   public void testWrapDoubleArray() {
@@ -206,16 +205,16 @@ public class Buffer2Test {
     }
 
     Buffer buffer = Memory.wrap(doubleArray).asBuffer();
-    int i = 0;
-    while (buffer.hasRemaining()) {
-      assertEquals(doubleArray[i++], buffer.getDouble());
-    }
+      int i = 0;
+      while (buffer.hasRemaining()) {
+        assertEquals(doubleArray[i++], buffer.getDouble());
+      }
 
-    buffer.setPosition(0);
-    double[] copyDoubleArray = new double[64];
-    buffer.getDoubleArray(copyDoubleArray, 0, 64);
-    assertEquals(doubleArray, copyDoubleArray);
-  }
+      buffer.setPosition(0);
+      double[] copyDoubleArray = new double[64];
+      buffer.getDoubleArray(copyDoubleArray, 0, 64);
+      assertEquals(doubleArray, copyDoubleArray);
+    }
 
   @Test
   public void testByteBufferPositionPreservation() {
@@ -400,23 +399,24 @@ public class Buffer2Test {
   @Test
   public void checkIndependence() {
     int cap = 64;
-    ResourceScope scope = ResourceScope.newImplicitScope();
-    WritableMemory wmem = WritableMemory.allocateDirect(cap, 8, scope, ByteOrder.nativeOrder(), null);
-    WritableBuffer wbuf1 = wmem.asWritableBuffer();
-    WritableBuffer wbuf2 = wmem.asWritableBuffer();
-    assertFalse(wbuf1 == wbuf2);
-    assertTrue(wbuf1.nativeOverlap(wbuf2) == cap);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory wmem = WritableMemory.allocateDirect(arena, cap, 8, ByteOrder.nativeOrder(), null);
+      WritableBuffer wbuf1 = wmem.asWritableBuffer();
+      WritableBuffer wbuf2 = wmem.asWritableBuffer();
+      assertFalse(wbuf1 == wbuf2);
+      assertTrue(wbuf1.nativeOverlap(wbuf2) == cap);
 
-    WritableMemory reg1 = wmem.writableRegion(0, cap);
-    WritableMemory reg2 = wmem.writableRegion(0, cap);
-    assertFalse(reg1 == reg2);
-    assertTrue(reg1.nativeOverlap(reg2) == cap);
+      WritableMemory reg1 = wmem.writableRegion(0, cap);
+      WritableMemory reg2 = wmem.writableRegion(0, cap);
+      assertFalse(reg1 == reg2);
+      assertTrue(reg1.nativeOverlap(reg2) == cap);
 
 
-    WritableBuffer wbuf3 = wbuf1.writableRegion();
-    WritableBuffer wbuf4 = wbuf1.writableRegion();
-    assertFalse(wbuf3 == wbuf4);
-    assertTrue(wbuf3.nativeOverlap(wbuf4) == cap);
+      WritableBuffer wbuf3 = wbuf1.writableRegion();
+      WritableBuffer wbuf4 = wbuf1.writableRegion();
+      assertFalse(wbuf3 == wbuf4);
+      assertTrue(wbuf3.nativeOverlap(wbuf4) == cap);
+    }
   }
 
   @Test

--- a/src/test/java/org/apache/datasketches/memory/internal/BufferInvariantsTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/BufferInvariantsTest.java
@@ -22,6 +22,7 @@ package org.apache.datasketches.memory.internal;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
+import java.lang.foreign.Arena;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -32,8 +33,6 @@ import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.WritableBuffer;
 import org.apache.datasketches.memory.WritableMemory;
 import org.testng.annotations.Test;
-
-import jdk.incubator.foreign.ResourceScope;
 
 /**
  * @author Lee Rhodes
@@ -167,8 +166,8 @@ public class BufferInvariantsTest {
 
   @Test
   public void checkLimitsDirect() throws Exception {
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory wmem = WritableMemory.allocateDirect(100, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory wmem = WritableMemory.allocateDirect(arena, 100, 1, ByteOrder.nativeOrder(), memReqSvr);
       Buffer buf = wmem.asBuffer();
       buf.setStartPositionEnd(40, 45, 50);
       buf.setStartPositionEnd(0, 0, 100);
@@ -238,43 +237,43 @@ public class BufferInvariantsTest {
   @Test
   public void testBufDirect() throws Exception {
     int n = 25;
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-    WritableMemory wmem = WritableMemory.allocateDirect(n, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
-    WritableBuffer buf = wmem.asWritableBuffer();
-    for (byte i = 0; i < n; i++) { buf.putByte(i); }
-    buf.setPosition(0);
-    assertEquals(buf.getPosition(), 0);
-    assertEquals(buf.getEnd(), 25);
-    assertEquals(buf.getCapacity(), 25);
-//    print("Orig  : ");
-//    printbuf(buf);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory wmem = WritableMemory.allocateDirect(arena, n, 1, ByteOrder.nativeOrder(), memReqSvr);
+      WritableBuffer buf = wmem.asWritableBuffer();
+      for (byte i = 0; i < n; i++) { buf.putByte(i); }
+      buf.setPosition(0);
+      assertEquals(buf.getPosition(), 0);
+      assertEquals(buf.getEnd(), 25);
+      assertEquals(buf.getCapacity(), 25);
+  //    print("Orig  : ");
+  //    printbuf(buf);
 
-    buf.setStartPositionEnd(0, 5, 20);
-    assertEquals(buf.getRemaining(), 15);
-    assertEquals(buf.getCapacity(), 25);
-    assertEquals(buf.getByte(), 5);
-    buf.setPosition(5);
-//    print("Set   : ");
-//    printbuf(buf);
+      buf.setStartPositionEnd(0, 5, 20);
+      assertEquals(buf.getRemaining(), 15);
+      assertEquals(buf.getCapacity(), 25);
+      assertEquals(buf.getByte(), 5);
+      buf.setPosition(5);
+  //    print("Set   : ");
+  //    printbuf(buf);
 
-    Buffer dup = buf.duplicate();
-    assertEquals(dup.getRemaining(), 15);
-    assertEquals(dup.getCapacity(), 25);
-    assertEquals(dup.getByte(), 5);
-    dup.setPosition(5);
-//    print("Dup   : ");
-//    printbuf(dup);
+      Buffer dup = buf.duplicate();
+      assertEquals(dup.getRemaining(), 15);
+      assertEquals(dup.getCapacity(), 25);
+      assertEquals(dup.getByte(), 5);
+      dup.setPosition(5);
+  //    print("Dup   : ");
+  //    printbuf(dup);
 
 
-    Buffer reg = buf.region();
-    assertEquals(reg.getPosition(), 0);
-    assertEquals(reg.getEnd(), 15);
-    assertEquals(reg.getRemaining(), 15);
-    assertEquals(reg.getCapacity(), 15);
-    assertEquals(reg.getByte(), 5);
-    reg.setPosition(0);
-//    print("Region: ");
-//    printbuf(reg);
+      Buffer reg = buf.region();
+      assertEquals(reg.getPosition(), 0);
+      assertEquals(reg.getEnd(), 15);
+      assertEquals(reg.getRemaining(), 15);
+      assertEquals(reg.getCapacity(), 15);
+      assertEquals(reg.getByte(), 5);
+      reg.setPosition(0);
+  //    print("Region: ");
+  //    printbuf(reg);
     }
   }
 

--- a/src/test/java/org/apache/datasketches/memory/internal/BufferTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/BufferTest.java
@@ -22,6 +22,7 @@ package org.apache.datasketches.memory.internal;
 import static org.apache.datasketches.memory.internal.ResourceImpl.NON_NATIVE_BYTE_ORDER;
 import static org.testng.Assert.assertEquals;
 
+import java.lang.foreign.Arena;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
@@ -35,15 +36,13 @@ import org.apache.datasketches.memory.WritableMemory;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
 
-import jdk.incubator.foreign.ResourceScope;
-
 public class BufferTest {
   private final MemoryRequestServer memReqSvr = Resource.defaultMemReqSvr;
   @Test
   public void checkDirectRoundTrip() throws Exception {
     int n = 1024; //longs
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-    WritableMemory wmem = WritableMemory.allocateDirect(n * 8, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory wmem = WritableMemory.allocateDirect(arena, n * 8, 1, ByteOrder.nativeOrder(), memReqSvr);
       WritableBuffer wbuf = wmem.asWritableBuffer();
       for (int i = 0; i < n; i++) {
         wbuf.putLong(i);
@@ -60,44 +59,44 @@ public class BufferTest {
   public void checkAutoHeapRoundTrip() {
     int n = 1024; //longs
     WritableBuffer wbuf = WritableMemory.allocate(n * 8).asWritableBuffer();
-    for (int i = 0; i < n; i++) {
-      wbuf.putLong(i);
+      for (int i = 0; i < n; i++) {
+        wbuf.putLong(i);
+      }
+      wbuf.resetPosition();
+      for (int i = 0; i < n; i++) {
+        long v = wbuf.getLong();
+        assertEquals(v, i);
+      }
     }
-    wbuf.resetPosition();
-    for (int i = 0; i < n; i++) {
-      long v = wbuf.getLong();
-      assertEquals(v, i);
-    }
-  }
 
   @Test
   public void checkArrayWrap() {
     int n = 1024; //longs
     byte[] arr = new byte[n * 8];
     WritableBuffer wbuf = WritableMemory.writableWrap(arr).asWritableBuffer();
-    for (int i = 0; i < n; i++) {
-      wbuf.putLong(i);
-    }
-    wbuf.resetPosition();
-    for (int i = 0; i < n; i++) {
-      long v = wbuf.getLong();
-      assertEquals(v, i);
-    }
+      for (int i = 0; i < n; i++) {
+        wbuf.putLong(i);
+      }
+      wbuf.resetPosition();
+      for (int i = 0; i < n; i++) {
+        long v = wbuf.getLong();
+        assertEquals(v, i);
+      }
     Buffer buf = Memory.wrap(arr).asBuffer();
-    buf.resetPosition();
-    for (int i = 0; i < n; i++) {
-      long v = buf.getLong();
-      assertEquals(v, i);
-    }
-    // Check Zero length array wraps
+      buf.resetPosition();
+      for (int i = 0; i < n; i++) {
+        long v = buf.getLong();
+        assertEquals(v, i);
+      }
+      // Check Zero length array wraps
     Memory mem = Memory.wrap(new byte[0]);
-    Buffer buffZeroLengthArrayWrap = mem.asBuffer();
-    assertEquals(buffZeroLengthArrayWrap.getCapacity(), 0);
-    // check 0 length array wraps
-    List<Buffer> buffersToCheck = Lists.newArrayList();
+      Buffer buffZeroLengthArrayWrap = mem.asBuffer();
+      assertEquals(buffZeroLengthArrayWrap.getCapacity(), 0);
+      // check 0 length array wraps
+      List<Buffer> buffersToCheck = Lists.newArrayList();
     buffersToCheck.add(WritableMemory.allocate(0).asBuffer());
     buffersToCheck.add(WritableBuffer.writableWrap(ByteBuffer.allocate(0)));
-    buffersToCheck.add(Buffer.wrap(ByteBuffer.allocate(0)));
+      buffersToCheck.add(Buffer.wrap(ByteBuffer.allocate(0)));
     buffersToCheck.add(Memory.wrap(new byte[0]).asBuffer());
     buffersToCheck.add(Memory.wrap(new char[0]).asBuffer());
     buffersToCheck.add(Memory.wrap(new short[0]).asBuffer());
@@ -105,11 +104,11 @@ public class BufferTest {
     buffersToCheck.add(Memory.wrap(new long[0]).asBuffer());
     buffersToCheck.add(Memory.wrap(new float[0]).asBuffer());
     buffersToCheck.add(Memory.wrap(new double[0]).asBuffer());
-    //Check the buffer lengths
-    for (Buffer buffer : buffersToCheck) {
-      assertEquals(buffer.getCapacity(), 0);
+      //Check the buffer lengths
+      for (Buffer buffer : buffersToCheck) {
+        assertEquals(buffer.getCapacity(), 0);
+      }
     }
-  }
 
   @Test
   public void simpleBBTest() {
@@ -119,19 +118,19 @@ public class BufferTest {
     bb.order(ByteOrder.nativeOrder());
 
     WritableBuffer wbuf = WritableBuffer.writableWrap(bb);
-    for (int i = 0; i < n; i++) { //write to wbuf
-      wbuf.putLong(i);
+      for (int i = 0; i < n; i++) { //write to wbuf
+        wbuf.putLong(i);
+      }
+      wbuf.resetPosition();
+      for (int i = 0; i < n; i++) { //read from wbuf
+        long v = wbuf.getLong();
+        assertEquals(v, i);
+      }
+      for (int i = 0; i < n; i++) { //read from BB
+        long v = bb.getLong();
+        assertEquals(v, i);
+      }
     }
-    wbuf.resetPosition();
-    for (int i = 0; i < n; i++) { //read from wbuf
-      long v = wbuf.getLong();
-      assertEquals(v, i);
-    }
-    for (int i = 0; i < n; i++) { //read from BB
-      long v = bb.getLong();
-      assertEquals(v, i);
-    }
-  }
 
   @Test
   public void checkByteBufHeap() {
@@ -234,14 +233,14 @@ public class BufferTest {
     for (int i = 0; i < n; i++) { arr[i] = i; }
 
     WritableBuffer wbuf = WritableMemory.allocate(n * 8).asWritableBuffer();
-    wbuf.putLongArray(arr, 0, n);
-    long[] arr2 = new long[n];
-    wbuf.resetPosition();
-    wbuf.getLongArray(arr2, 0, n);
-    for (int i = 0; i < n; i++) {
-      assertEquals(arr2[i], i);
+      wbuf.putLongArray(arr, 0, n);
+      long[] arr2 = new long[n];
+      wbuf.resetPosition();
+      wbuf.getLongArray(arr2, 0, n);
+      for (int i = 0; i < n; i++) {
+        assertEquals(arr2[i], i);
+      }
     }
-  }
 
   @Test
   public void checkRORegions() {
@@ -251,14 +250,14 @@ public class BufferTest {
     for (int i = 0; i < n; i++) { arr[i] = i; }
 
     Buffer buf = Memory.wrap(arr).asBuffer();
-    buf.setPosition(n2 * 8);
-    Buffer reg = buf.region();
-    for (int i = 0; i < n2; i++) {
-      long v = reg.getLong();
-      assertEquals(v, i + n2);
-      //println("" + v);
+      buf.setPosition(n2 * 8);
+      Buffer reg = buf.region();
+      for (int i = 0; i < n2; i++) {
+        long v = reg.getLong();
+        assertEquals(v, i + n2);
+        //println("" + v);
+      }
     }
-  }
 
   @Test
   public void checkWRegions() {
@@ -285,29 +284,33 @@ public class BufferTest {
   @Test(expectedExceptions = IllegalStateException.class)
   public void checkParentUseAfterFree() throws Exception {
     int bytes = 64 * 8;
-    WritableMemory wmem = WritableMemory.allocateDirect(bytes, 1, ResourceScope.newConfinedScope(), ByteOrder.nativeOrder(), memReqSvr);
-    WritableBuffer wbuf = wmem.asWritableBuffer();
-    wbuf.close();
-    //with -ea assert: Memory not alive.
-    //with -da sometimes segfaults, sometimes passes!
-    wbuf.getLong();
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory wmem = WritableMemory.allocateDirect(arena, bytes, 1, ByteOrder.nativeOrder(), memReqSvr);
+      WritableBuffer wbuf = wmem.asWritableBuffer();
+      wmem.close();
+      //with -ea assert: Memory not alive.
+      //with -da sometimes segfaults, sometimes passes!
+      wbuf.getLong();
+    }
   }
 
   @Test(expectedExceptions = IllegalStateException.class)
   public void checkRegionUseAfterFree() throws Exception {
     int bytes = 64;
-    WritableMemory wmem = WritableMemory.allocateDirect(bytes, 1, ResourceScope.newConfinedScope(), ByteOrder.nativeOrder(), memReqSvr);
-    Buffer region = wmem.asBuffer().region();
-    region.close();
-    //with -ea assert: Memory not alive.
-    //with -da sometimes segfaults, sometimes passes!
-    region.getByte();
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory wmem = WritableMemory.allocateDirect(arena, bytes, 1, ByteOrder.nativeOrder(), memReqSvr);
+      Buffer region = wmem.asBuffer().region();
+      wmem.close();
+      //with -ea assert: Memory not alive.
+      //with -da sometimes segfaults, sometimes passes!
+      region.getByte();
+    }
   }
 
   @Test
   public void checkCheckNotAliveAfterTWR() {
     Buffer buf;
-    try (WritableMemory wmem = WritableMemory.allocateDirect(100)) {
+    try (WritableMemory wmem = WritableMemory.allocateDirect(Arena.ofConfined(), 100)) {
       buf = wmem.asBuffer();
     }
     try {

--- a/src/test/java/org/apache/datasketches/memory/internal/CommonBufferTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/CommonBufferTest.java
@@ -21,6 +21,7 @@ package org.apache.datasketches.memory.internal;
 
 import static org.testng.Assert.assertEquals;
 
+import java.lang.foreign.Arena;
 import java.nio.ByteOrder;
 
 import org.apache.datasketches.memory.Resource;
@@ -29,15 +30,13 @@ import org.apache.datasketches.memory.WritableBuffer;
 import org.apache.datasketches.memory.WritableMemory;
 import org.testng.annotations.Test;
 
-import jdk.incubator.foreign.ResourceScope;
-
 public class CommonBufferTest {
   private final MemoryRequestServer memReqSvr = Resource.defaultMemReqSvr;
   @Test
   public void checkSetGet() throws Exception {
     int memCapacity = 60; //must be at least 60
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory mem = WritableMemory.allocateDirect(memCapacity, 1, scope,ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory mem = WritableMemory.allocateDirect(arena, memCapacity, 1, ByteOrder.nativeOrder(), memReqSvr);
       WritableBuffer buf = mem.asWritableBuffer();
       assertEquals(buf.getCapacity(), memCapacity);
       setGetTests(buf);
@@ -138,8 +137,8 @@ public class CommonBufferTest {
   @Test
   public void checkSetGetArrays() throws Exception {
     int memCapacity = 32;
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory mem = WritableMemory.allocateDirect(memCapacity, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory mem = WritableMemory.allocateDirect(arena, memCapacity, 1, ByteOrder.nativeOrder(), memReqSvr);
       WritableBuffer buf = mem.asWritableBuffer();
       assertEquals(buf.getCapacity(), memCapacity);
       setGetArraysTests(buf);
@@ -223,8 +222,8 @@ public class CommonBufferTest {
   @Test
   public void checkSetGetPartialArraysWithOffset() throws Exception {
     int memCapacity = 32;
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory mem = WritableMemory.allocateDirect(memCapacity, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory mem = WritableMemory.allocateDirect(arena, memCapacity, 1, ByteOrder.nativeOrder(), memReqSvr);
       WritableBuffer buf = mem.asWritableBuffer();
       assertEquals(buf.getCapacity(), memCapacity);
       setGetPartialArraysWithOffsetTests(buf);
@@ -308,8 +307,8 @@ public class CommonBufferTest {
   @Test
   public void checkSetClearMemoryRegions() throws Exception {
     int memCapacity = 64; //must be 64
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory mem = WritableMemory.allocateDirect(memCapacity, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory mem = WritableMemory.allocateDirect(arena, memCapacity, 1, ByteOrder.nativeOrder(), memReqSvr);
       WritableBuffer buf = mem.asWritableBuffer();
       assertEquals(buf.getCapacity(), memCapacity);
 
@@ -397,8 +396,8 @@ public class CommonBufferTest {
   @Test
   public void checkToHexStringAllMem() throws Exception {
     int memCapacity = 48; //must be 48
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory mem = WritableMemory.allocateDirect(memCapacity, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory mem = WritableMemory.allocateDirect(arena, memCapacity, 1, ByteOrder.nativeOrder(), memReqSvr);
       WritableBuffer buf = mem.asWritableBuffer();
       assertEquals(buf.getCapacity(), memCapacity);
       toHexStringAllMemTests(buf); //requires println enabled to visually check

--- a/src/test/java/org/apache/datasketches/memory/internal/CommonMemoryTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/CommonMemoryTest.java
@@ -27,6 +27,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+import java.lang.foreign.Arena;
 import java.nio.ByteOrder;
 
 import org.apache.datasketches.memory.Resource;
@@ -34,15 +35,13 @@ import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.WritableMemory;
 import org.testng.annotations.Test;
 
-import jdk.incubator.foreign.ResourceScope;
-
 public class CommonMemoryTest {
   private final MemoryRequestServer memReqSvr = Resource.defaultMemReqSvr;
   @Test
   public void checkSetGet() throws Exception {
     int memCapacity = 16; //must be at least 8
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory mem = WritableMemory.allocateDirect(memCapacity, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory mem = WritableMemory.allocateDirect(arena, memCapacity, 1, ByteOrder.nativeOrder(), memReqSvr);
       assertEquals(mem.getCapacity(), memCapacity);
       setGetTests(mem);
     }
@@ -93,8 +92,8 @@ public class CommonMemoryTest {
   @Test
   public void checkSetGetArrays() throws Exception {
     int memCapacity = 32;
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory mem = WritableMemory.allocateDirect(memCapacity, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory mem = WritableMemory.allocateDirect(arena, memCapacity, 1, ByteOrder.nativeOrder(), memReqSvr);
       assertEquals(memCapacity, mem.getCapacity());
       setGetArraysTests(mem);
     }
@@ -163,8 +162,8 @@ public class CommonMemoryTest {
   @Test
   public void checkSetGetPartialArraysWithOffset() throws Exception {
     int memCapacity = 32;
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory mem = WritableMemory.allocateDirect(memCapacity, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory mem = WritableMemory.allocateDirect(arena, memCapacity, 1, ByteOrder.nativeOrder(), memReqSvr);
       assertEquals(memCapacity, mem.getCapacity());
       setGetPartialArraysWithOffsetTests(mem);
     }
@@ -233,8 +232,8 @@ public class CommonMemoryTest {
   @Test
   public void checkSetClearIsBits() throws Exception {
     int memCapacity = 8;
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory mem = WritableMemory.allocateDirect(memCapacity, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory mem = WritableMemory.allocateDirect(arena, memCapacity, 1, ByteOrder.nativeOrder(), memReqSvr);
       assertEquals(memCapacity, mem.getCapacity());
       mem.clear();
       setClearIsBitsTests(mem);
@@ -274,8 +273,8 @@ public class CommonMemoryTest {
   @Test
   public void checkSetClearMemoryRegions() throws Exception {
     int memCapacity = 64; //must be 64
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory mem = WritableMemory.allocateDirect(memCapacity, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory mem = WritableMemory.allocateDirect(arena, memCapacity, 1, ByteOrder.nativeOrder(), memReqSvr);
 
       setClearMemoryRegionsTests(mem); //requires println enabled to visually check
       for (int i = 0; i < memCapacity; i++) {
@@ -345,8 +344,8 @@ public class CommonMemoryTest {
   @Test
   public void checkToHexStringAllMem() throws Exception {
     int memCapacity = 48; //must be 48
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory mem = WritableMemory.allocateDirect(memCapacity, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory mem = WritableMemory.allocateDirect(arena, memCapacity, 1, ByteOrder.nativeOrder(), memReqSvr);
       toHexStringAllMemTests(mem); //requires println enabled to visually check
     }
   }

--- a/src/test/java/org/apache/datasketches/memory/internal/CopyMemoryOverlapTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/CopyMemoryOverlapTest.java
@@ -21,6 +21,7 @@ package org.apache.datasketches.memory.internal;
 
 import static org.testng.Assert.assertEquals;
 
+import java.lang.foreign.Arena;
 import java.nio.ByteOrder;
 
 import org.apache.datasketches.memory.Resource;
@@ -28,8 +29,6 @@ import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.WritableMemory;
 import org.testng.annotations.Test;
-
-import jdk.incubator.foreign.ResourceScope;
 
 /**
  * @author Lee Rhodes
@@ -98,8 +97,8 @@ public class CopyMemoryOverlapTest {
     println("CopyUp       : " + copyUp);
     println("Backing longs: " + backingLongs + "\t bytes: " + backingBytes);
 
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory backingMem = WritableMemory.allocateDirect(backingBytes,  1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory backingMem = WritableMemory.allocateDirect(arena, backingBytes,  1, ByteOrder.nativeOrder(), memReqSvr);
       fill(backingMem); //fill mem with 0 thru copyLongs -1
       //listMem(backingMem, "Original");
       backingMem.copyTo(fromOffsetBytes, backingMem, toOffsetBytes, copyBytes);
@@ -138,8 +137,8 @@ public class CopyMemoryOverlapTest {
     println("CopyUp       : " + copyUp);
     println("Backing longs: " + backingLongs + "\t bytes: " + backingBytes);
 
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory backingMem = WritableMemory.allocateDirect(backingBytes, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory backingMem = WritableMemory.allocateDirect(arena, backingBytes, 1, ByteOrder.nativeOrder(), memReqSvr);
       fill(backingMem); //fill mem with 0 thru copyLongs -1
       //listMem(backingMem, "Original");
       WritableMemory reg1 = backingMem.writableRegion(fromOffsetBytes, copyBytes);

--- a/src/test/java/org/apache/datasketches/memory/internal/CopyMemoryTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/CopyMemoryTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.datasketches.memory.internal;
 
+import java.lang.foreign.Arena;
 import static org.testng.Assert.assertEquals;
 
 import java.nio.ByteOrder;
@@ -30,8 +31,6 @@ import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.WritableMemory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import jdk.incubator.foreign.ResourceScope;
 
 public class CopyMemoryTest {
   private static final MemoryRequestServer memReqSvr = Resource.defaultMemReqSvr;
@@ -78,7 +77,7 @@ public class CopyMemoryTest {
     srcMem.copyTo(0, dstMem, k1 << 3, k1 << 3);
     check(dstMem, k1, k1, 1);
     srcMem.close();
-  }
+    }
 
   @Test
   public void heapWSrcRegion() {
@@ -112,7 +111,6 @@ public class CopyMemoryTest {
     Memory baseMem = genWmem(k1, false);
     //gen src region of k1/2 longs, off= k1/2
     Memory srcReg = baseMem.region((k1/2) << 3, (k1/2) << 3);
-
     WritableMemory dstMem = genMem(2 * k1, true); //empty
     srcReg.copyTo(0, dstMem, k1 << 3, (k1/2) << 3);
     check(dstMem, k1, k1/2, (k1/2) + 1);
@@ -138,10 +136,10 @@ public class CopyMemoryTest {
     byte[] referenceBytes = bytes.clone();
     Memory referenceMem = Memory.wrap(referenceBytes);
     WritableMemory mem = WritableMemory.writableWrap(bytes);
-    long copyLen = (1 << 20) * 2;
-    mem.copyTo((1 << 20) / 2, mem, 0, copyLen);
-    Assert.assertEquals(0, mem.compareTo(0, copyLen, referenceMem, (1 << 20) / 2, copyLen));
-  }
+      long copyLen = (1 << 20) * 2;
+      mem.copyTo((1 << 20) / 2, mem, 0, copyLen);
+      Assert.assertEquals(0, mem.compareTo(0, copyLen, referenceMem, (1 << 20) / 2, copyLen));
+    }
 
   private static void check(Memory mem, int offsetLongs, int lengthLongs, int startValue) {
     int offBytes = offsetLongs << 3;
@@ -151,7 +149,7 @@ public class CopyMemoryTest {
   }
 
   private static WritableMemory genWmem(int longs, boolean empty) {
-    WritableMemory wmem = WritableMemory.allocateDirect(longs << 3, 1, ResourceScope.newConfinedScope(), ByteOrder.nativeOrder(), memReqSvr);
+    WritableMemory wmem = WritableMemory.allocateDirect(Arena.ofConfined(), longs << 3, 1, ByteOrder.nativeOrder(), memReqSvr);
     if (empty) {
       wmem.clear();
     } else {

--- a/src/test/java/org/apache/datasketches/memory/internal/ExampleMemoryRequestServerTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/ExampleMemoryRequestServerTest.java
@@ -19,14 +19,13 @@
 
 package org.apache.datasketches.memory.internal;
 
+import java.lang.foreign.Arena;
 import java.nio.ByteOrder;
 
 import org.apache.datasketches.memory.DefaultMemoryRequestServer;
 import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.WritableMemory;
 import org.testng.annotations.Test;
-
-import jdk.incubator.foreign.ResourceScope;
 
 /**
  * Example of how to use the MemoryRequestServer with a memory hungry client.
@@ -45,15 +44,20 @@ public class ExampleMemoryRequestServerTest {
   @Test
   public void checkExampleMemoryRequestServer1() {
 
+    long workingMemBytes = 8;
+    long alignmentBytes = 8;
+
+    Arena arena = Arena.ofConfined();
     //Configure the default memReqSvr to create new memory off-heap and copy data from old to new
     MemoryRequestServer memReqSvr = new DefaultMemoryRequestServer(true, true);
 
-    long workingMemBytes = 8;
-    long alignmentBytes = 8;
-    ResourceScope scope = ResourceScope.newConfinedScope();
-
     //Create the initial working memory for the client
-    WritableMemory workingMem = WritableMemory.allocateDirect(workingMemBytes, alignmentBytes, scope, ByteOrder.nativeOrder(), memReqSvr);
+    WritableMemory workingMem = WritableMemory.allocateDirect(
+      arena,
+      workingMemBytes,
+      alignmentBytes,
+      ByteOrder.nativeOrder(),
+      memReqSvr);
 
     MemoryHungryClient client = new MemoryHungryClient(workingMem);
     client.process();

--- a/src/test/java/org/apache/datasketches/memory/internal/IgnoredArrayOverflowTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/IgnoredArrayOverflowTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.datasketches.memory.internal;
 
+import java.lang.foreign.Arena;
 import java.nio.ByteOrder;
 
 import org.apache.datasketches.memory.Resource;
@@ -28,8 +29,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import jdk.incubator.foreign.ResourceScope;
-
 public class IgnoredArrayOverflowTest {
   private static final MemoryRequestServer memReqSvr = Resource.defaultMemReqSvr;
 
@@ -38,8 +37,7 @@ public class IgnoredArrayOverflowTest {
 
   @BeforeClass
   public void allocate() {
-    ResourceScope scope = ResourceScope.newConfinedScope();
-    memory = WritableMemory.allocateDirect(MAX_SIZE, 8L, scope, ByteOrder.nativeOrder(), memReqSvr);
+     memory = WritableMemory.allocateDirect(Arena.ofConfined(), MAX_SIZE, 8L, ByteOrder.nativeOrder(), memReqSvr);
   }
 
   @AfterClass

--- a/src/test/java/org/apache/datasketches/memory/internal/InvalidAllocationTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/InvalidAllocationTest.java
@@ -21,6 +21,7 @@ package org.apache.datasketches.memory.internal;
 
 import static org.testng.Assert.assertEquals;
 
+import java.lang.foreign.Arena;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -31,16 +32,14 @@ import org.apache.datasketches.memory.WritableMemory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import jdk.incubator.foreign.ResourceScope;
-
 /**
  * @author Lee Rhodes
  */
-public class ZeroCapacityTest {
+public class InvalidAllocationTest {
   private static final MemoryRequestServer memReqSvr = Resource.defaultMemReqSvr;
 
   @Test
-  public void checkZeroCapacity() throws Exception {
+  public void checkInvalidCapacity() throws Exception {
     WritableMemory wmem = WritableMemory.allocate(0);
     assertEquals(wmem.getCapacity(), 0);
 
@@ -49,9 +48,29 @@ public class ZeroCapacityTest {
     Memory mem3 = Memory.wrap(ByteBuffer.allocateDirect(0));
     mem3.region(0, 0);
     WritableMemory nullMem = null;
-    ResourceScope scope = ResourceScope.newConfinedScope();
-    try { //Invalid allocation size : 0
-      nullMem = WritableMemory.allocateDirect(0, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) { //Invalid allocation size : -1
+      nullMem = WritableMemory.allocateDirect(arena, -1, 1, ByteOrder.nativeOrder(), memReqSvr);
+      Assert.fail();
+    } catch (IllegalArgumentException ignore) {
+      if (nullMem != null) {
+        nullMem.close();
+      }
+      // expected
+    }
+  }
+
+  @Test
+  public void checkInvalidAlignment() throws Exception {
+    WritableMemory wmem = WritableMemory.allocate(0);
+    assertEquals(wmem.getCapacity(), 0);
+
+    Memory.wrap(new byte[0]);
+    Memory.wrap(ByteBuffer.allocate(0));
+    Memory mem3 = Memory.wrap(ByteBuffer.allocateDirect(0));
+    mem3.region(0, 0);
+    WritableMemory nullMem = null;
+    try (Arena arena = Arena.ofConfined()) { //Invalid alignment : 3 
+      nullMem = WritableMemory.allocateDirect(arena, 0, 3, ByteOrder.nativeOrder(), memReqSvr);
       Assert.fail();
     } catch (IllegalArgumentException ignore) {
       if (nullMem != null) {

--- a/src/test/java/org/apache/datasketches/memory/internal/LeafImplTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/LeafImplTest.java
@@ -113,11 +113,8 @@ public class LeafImplTest {
   public void checkMapLeafs() throws IOException {
     long off = 0;
     long cap = 128;
-    File file = new File("TestFile2.bin");
-    if (file.exists()) {
-      java.nio.file.Files.delete(file.toPath());
-    }
-    assertTrue(file.createNewFile());
+    File file = File.createTempFile("TestFile2", "bin");
+    file.deleteOnExit();
     assertTrue(file.setWritable(true, false)); //writable=true, ownerOnly=false
     assertTrue(file.isFile());
     file.deleteOnExit();  //comment out if you want to examine the file.

--- a/src/test/java/org/apache/datasketches/memory/internal/LeafImplTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/LeafImplTest.java
@@ -26,6 +26,7 @@ import static org.testng.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.foreign.Arena;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -34,8 +35,6 @@ import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.WritableBuffer;
 import org.apache.datasketches.memory.WritableMemory;
 import org.testng.annotations.Test;
-
-import jdk.incubator.foreign.ResourceScope;
 
 /**
  * @author Lee Rhodes
@@ -54,15 +53,15 @@ public class LeafImplTest {
     long off = 0;
     long cap = 128;
     // Off Heap, Native order, No ByteBuffer, has MemReqSvr
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory memNO = WritableMemory.allocateDirect(cap, 8, scope, NBO, myMemReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory memNO = WritableMemory.allocateDirect(arena, cap, 8, NBO, myMemReqSvr);
       memNO.putShort(0, (short) 1);
       assertTrue(memNO.isDirect());
       checkCombinations(memNO, off, cap, memNO.isDirect(), NBO, false, true);
     }
     // Off Heap, Non Native order, No ByteBuffer, has MemReqSvr
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory memNNO = WritableMemory.allocateDirect(cap, 8, scope, NNBO, myMemReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory memNNO = WritableMemory.allocateDirect(arena, cap, 8, NNBO, myMemReqSvr);
       memNNO.putShort(0, (short) 1);
       assertTrue(memNNO.isDirect());
       checkCombinations(memNNO, off, cap, memNNO.isDirect(), NNBO, false, true);
@@ -123,15 +122,15 @@ public class LeafImplTest {
     assertTrue(file.isFile());
     file.deleteOnExit();  //comment out if you want to examine the file.
     // Off Heap, Native order, No ByteBuffer, No MemReqSvr
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory memNO = WritableMemory.writableMap(file, off, cap, scope, NBO);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory memNO = WritableMemory.writableMap(arena, file, off, cap, NBO);
       memNO.putShort(0, (short) 1);
       assertTrue(memNO.isDirect());
       checkCombinations(memNO, off, cap, memNO.isDirect(), NBO, false, false);
     }
     // Off heap, Non Native order, No ByteBuffer, no MemReqSvr
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory memNNO = WritableMemory.writableMap(file, off, cap, scope, NNBO);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory memNNO = WritableMemory.writableMap(arena, file, off, cap, NNBO);
       memNNO.putShort(0, (short) 1);
       assertTrue(memNNO.isDirect());
       checkCombinations(memNNO, off, cap, memNNO.isDirect(), NNBO, false, false);

--- a/src/test/java/org/apache/datasketches/memory/internal/MemoryBoundaryCheckTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/MemoryBoundaryCheckTest.java
@@ -19,15 +19,28 @@
 
 package org.apache.datasketches.memory.internal;
 
+import java.lang.foreign.Arena;
 import static org.testng.Assert.fail;
 
 import org.apache.datasketches.memory.WritableBuffer;
 import org.apache.datasketches.memory.WritableMemory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class MemoryBoundaryCheckTest {
 
-  private final WritableBuffer writableBuffer = WritableMemory.allocate(8).asWritableBuffer();
+  private WritableBuffer writableBuffer;
+
+  @BeforeClass
+  public void allocate() {
+     writableBuffer = WritableMemory.allocate(8).asWritableBuffer();
+  }
+
+  @AfterClass
+  public void close() throws Exception {
+    writableBuffer.close();
+  }
 
   @Test
   public void testGetByte() {

--- a/src/test/java/org/apache/datasketches/memory/internal/MemoryWriteToTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/MemoryWriteToTest.java
@@ -24,6 +24,7 @@ import static org.testng.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.lang.foreign.Arena;
 import java.nio.ByteOrder;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -32,8 +33,6 @@ import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.WritableMemory;
 import org.testng.annotations.Test;
-
-import jdk.incubator.foreign.ResourceScope;
 
 public class MemoryWriteToTest {
   private static final MemoryRequestServer memReqSvr = Resource.defaultMemReqSvr;
@@ -60,8 +59,8 @@ public class MemoryWriteToTest {
 
   @Test
   public void testOffHeap() throws Exception {
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory mem = WritableMemory.allocateDirect(((1 << 20) * 5) + 10, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory mem = WritableMemory.allocateDirect(arena, ((1 << 20) * 5) + 10, 1, ByteOrder.nativeOrder(), memReqSvr);
       testWriteTo(mem.region(0, 0));
       testOffHeap(mem, 7);
       testOffHeap(mem, 1023);

--- a/src/test/java/org/apache/datasketches/memory/internal/MurmurHash3v3Test.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/MurmurHash3v3Test.java
@@ -23,6 +23,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.datasketches.memory.MurmurHash3.*;
 import static org.testng.Assert.fail;
 
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
 import java.nio.ByteOrder;
 
 import org.apache.datasketches.memory.Resource;
@@ -31,9 +33,6 @@ import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.WritableMemory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.ResourceScope;
 
 /**
  * Tests the MurmurHash3 against specific, known hash results given known
@@ -205,7 +204,7 @@ public class MurmurHash3v3Test {
       0x72, 0x20, 0x74, 0x68, 0x65, 0x20, 0x6c, 0x61, 0x7a, 0x79, 0x20, 0x64, 0x6f, 0x67,
       (byte) 0xff, 0x64, 0x6f, 0x67, 0x00
     };
-    long[] result = MurmurHash3v3.hash(key, 0);
+    long[] result = MurmurHash3v4.hash(key, 0);
 
     //Should be:
     long h1 = 0xe88abda785929c9eL;
@@ -276,8 +275,8 @@ public class MurmurHash3v3Test {
       Memory mem = Memory.wrap(new byte[0]);
       out = hash(mem, 0L, 4L, 1L, out);
     } catch (final IllegalArgumentException e) { }
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      Memory mem = WritableMemory.allocateDirect(8, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      Memory mem = WritableMemory.allocateDirect(arena, 8, 1, ByteOrder.nativeOrder(), memReqSvr);
       long[] out = new long[2];
       out = hash(mem, 0L, 4L, 1L, out);
     } catch (Exception ee) {}

--- a/src/test/java/org/apache/datasketches/memory/internal/ResourceTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/ResourceTest.java
@@ -19,10 +19,12 @@
 
 package org.apache.datasketches.memory.internal;
 
+import java.lang.foreign.Arena;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+import java.lang.foreign.MemorySegment;
 import java.nio.ByteOrder;
 
 import org.apache.datasketches.memory.Buffer;
@@ -30,45 +32,44 @@ import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.WritableMemory;
 import org.testng.annotations.Test;
 
-import jdk.incubator.foreign.MemorySegment;
-import jdk.incubator.foreign.ResourceScope;
-
 public class ResourceTest {
 
   @Test
   public void checkNativeOverlap() {
-    MemorySegment par = MemorySegment.allocateNative(100, ResourceScope.newImplicitScope());
-    //Equal sizes
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 20), getSeg(par, 40, 60)),   0);
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 20), getSeg(par, 20, 40)),   0);
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 20), getSeg(par,  0, 20)),  20);
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 20), getSeg(par, 10, 30)),  10);
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par, 10, 30), getSeg(par,  0, 20)), -10);
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par, 20, 40), getSeg(par,  0, 20)),   0);
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0,  0), getSeg(par,  0,  0)),   0);
-    //Unequal Sizes A > B
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 40), getSeg(par, 60, 80)),   0);
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 40), getSeg(par, 40, 60)),   0);
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 40), getSeg(par, 30, 50)),  10);
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 40), getSeg(par, 20, 40)),  20);
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 40), getSeg(par, 10, 30)),  20);
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 40), getSeg(par,  0, 20)),  20);
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par, 10, 50), getSeg(par,  0, 20)), -10);
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par, 20, 60), getSeg(par,  0, 20)),   0);
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par, 40, 80), getSeg(par,  0, 20)),   0);
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par, 40, 80), getSeg(par,  0,  0)),   0);
+    try (Arena arena = Arena.ofConfined()) {
+      MemorySegment par = arena.allocate(100);
+      //Equal sizes
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 20), getSeg(par, 40, 60)),   0);
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 20), getSeg(par, 20, 40)),   0);
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 20), getSeg(par,  0, 20)),  20);
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 20), getSeg(par, 10, 30)),  10);
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par, 10, 30), getSeg(par,  0, 20)), -10);
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par, 20, 40), getSeg(par,  0, 20)),   0);
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0,  0), getSeg(par,  0,  0)),   0);
+      //Unequal Sizes A > B
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 40), getSeg(par, 60, 80)),   0);
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 40), getSeg(par, 40, 60)),   0);
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 40), getSeg(par, 30, 50)),  10);
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 40), getSeg(par, 20, 40)),  20);
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 40), getSeg(par, 10, 30)),  20);
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 40), getSeg(par,  0, 20)),  20);
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par, 10, 50), getSeg(par,  0, 20)), -10);
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par, 20, 60), getSeg(par,  0, 20)),   0);
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par, 40, 80), getSeg(par,  0, 20)),   0);
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par, 40, 80), getSeg(par,  0,  0)),   0);
 
-    //Unequal Sizes B > A
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par, 60, 80), getSeg(par,  0, 40)),   0);
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par, 40, 60), getSeg(par,  0, 40)),   0);
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par, 30, 50), getSeg(par,  0, 40)), -10);
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par, 20, 40), getSeg(par,  0, 40)), -20);
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par, 10, 30), getSeg(par,  0, 40)), -20);
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 20), getSeg(par,  0, 40)),  20);
-    assertEquals(ResourceImpl.nativeOverlap( getSeg(par, 0, 20), getSeg(par, 10, 50)),  10);
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 20), getSeg(par, 20, 60)),   0);
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 20), getSeg(par, 40, 80)),   0);
-    assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0,  0), getSeg(par, 40, 80)),   0);
+      //Unequal Sizes B > A
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par, 60, 80), getSeg(par,  0, 40)),   0);
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par, 40, 60), getSeg(par,  0, 40)),   0);
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par, 30, 50), getSeg(par,  0, 40)), -10);
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par, 20, 40), getSeg(par,  0, 40)), -20);
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par, 10, 30), getSeg(par,  0, 40)), -20);
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 20), getSeg(par,  0, 40)),  20);
+      assertEquals(ResourceImpl.nativeOverlap( getSeg(par, 0, 20), getSeg(par, 10, 50)),  10);
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 20), getSeg(par, 20, 60)),   0);
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0, 20), getSeg(par, 40, 80)),   0);
+      assertEquals(ResourceImpl.nativeOverlap(getSeg(par,  0,  0), getSeg(par, 40, 80)),   0);
+    }
   }
 
   private static MemorySegment getSeg(MemorySegment parent, long left, long right) {

--- a/src/test/java/org/apache/datasketches/memory/internal/SpecificLeafTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/SpecificLeafTest.java
@@ -27,6 +27,7 @@ import static org.testng.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.foreign.Arena;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -36,8 +37,6 @@ import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.Resource;
 import org.apache.datasketches.memory.WritableMemory;
 import org.testng.annotations.Test;
-
-import jdk.incubator.foreign.ResourceScope;
 
 /**
  * @author Lee Rhodes
@@ -76,8 +75,8 @@ public class SpecificLeafTest {
   @Test
   public void checkDirectLeafs() throws Exception {
     int bytes = 128;
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory wmem = WritableMemory.allocateDirect(bytes, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory wmem = WritableMemory.allocateDirect(arena, bytes, 1, ByteOrder.nativeOrder(), memReqSvr);
       assertFalse(((ResourceImpl)wmem).isReadOnly());
       assertTrue(wmem.isDirect());
       assertFalse(wmem.isHeap());
@@ -114,8 +113,8 @@ public class SpecificLeafTest {
     file.deleteOnExit();  //comment out if you want to examine the file.
 
     final long bytes = 128;
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory mem = WritableMemory.writableMap(file, 0L, bytes, scope, ByteOrder.nativeOrder());
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory mem = WritableMemory.writableMap(arena, file, 0L, bytes, ByteOrder.nativeOrder());
       assertTrue(mem.isMapped());
       assertFalse(mem.isReadOnly());
       checkCrossLeafTypeIds(mem);

--- a/src/test/java/org/apache/datasketches/memory/internal/SpecificLeafTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/SpecificLeafTest.java
@@ -103,11 +103,9 @@ public class SpecificLeafTest {
 
   @Test
   public void checkMapLeafs() throws IOException {
-    File file = new File("TestFile2.bin");
-    if (file.exists()) {
-      java.nio.file.Files.delete(file.toPath());
-    }
-    assertTrue(file.createNewFile());
+    File file = File.createTempFile("TestFile2", "bin");
+    file.deleteOnExit();
+
     assertTrue(file.setWritable(true, false)); //writable=true, ownerOnly=false
     assertTrue(file.isFile());
     file.deleteOnExit();  //comment out if you want to examine the file.

--- a/src/test/java/org/apache/datasketches/memory/internal/WritableDirectCopyTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/WritableDirectCopyTest.java
@@ -22,6 +22,7 @@ package org.apache.datasketches.memory.internal;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
+import java.lang.foreign.Arena;
 import java.nio.ByteOrder;
 
 import org.apache.datasketches.memory.Resource;
@@ -29,8 +30,6 @@ import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.WritableMemory;
 import org.testng.annotations.Test;
-
-import jdk.incubator.foreign.ResourceScope;
 
 /**
  * @author Lee Rhodes
@@ -44,8 +43,8 @@ public class WritableDirectCopyTest {
   public void checkCopyWithinNativeSmall() throws Exception {
     int memCapacity = 64;
     int half = memCapacity / 2;
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory mem = WritableMemory.allocateDirect(memCapacity, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory mem = WritableMemory.allocateDirect(arena, memCapacity, 1, ByteOrder.nativeOrder(), memReqSvr);
       mem.clear();
 
       for (int i = 0; i < half; i++) { //fill first half
@@ -66,8 +65,8 @@ public class WritableDirectCopyTest {
     int memCapLongs = memCapacity / 8;
     int halfBytes = memCapacity / 2;
     int halfLongs = memCapLongs / 2;
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory mem = WritableMemory.allocateDirect(memCapacity, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory mem = WritableMemory.allocateDirect(arena, memCapacity, 1, ByteOrder.nativeOrder(), memReqSvr);
       mem.clear();
 
       for (int i = 0; i < halfLongs; i++) {
@@ -85,8 +84,8 @@ public class WritableDirectCopyTest {
   @Test
   public void checkCopyWithinNativeOverlap() throws Exception {
     int memCapacity = 64;
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory mem = WritableMemory.allocateDirect(memCapacity, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory mem = WritableMemory.allocateDirect(arena, memCapacity, 1, ByteOrder.nativeOrder(), memReqSvr);
       mem.clear();
       //println(mem.toHexString("Clear 64", 0, memCapacity));
 
@@ -101,8 +100,8 @@ public class WritableDirectCopyTest {
   @Test
   public void checkCopyWithinNativeSrcBound() throws Exception {
     int memCapacity = 64;
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory mem = WritableMemory.allocateDirect(memCapacity, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory mem = WritableMemory.allocateDirect(arena, memCapacity, 1, ByteOrder.nativeOrder(), memReqSvr);
       mem.copyTo(32, mem, 32, 33);  //hit source bound check
       fail("Did Not Catch Assertion Error: source bound");
     } catch (IndexOutOfBoundsException e) {
@@ -113,8 +112,8 @@ public class WritableDirectCopyTest {
   @Test
   public void checkCopyWithinNativeDstBound() throws Exception {
     int memCapacity = 64;
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory mem = WritableMemory.allocateDirect(memCapacity, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory mem = WritableMemory.allocateDirect(arena, memCapacity, 1, ByteOrder.nativeOrder(), memReqSvr);
       mem.copyTo(0, mem, 32, 33);  //hit dst bound check
       fail("Did Not Catch Assertion Error: dst bound");
     } catch (IndexOutOfBoundsException e) {
@@ -126,9 +125,9 @@ public class WritableDirectCopyTest {
   public void checkCopyCrossNativeSmall() throws Exception {
     int memCapacity = 64;
 
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory mem1 = WritableMemory.allocateDirect(memCapacity, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
-      WritableMemory mem2 = WritableMemory.allocateDirect(memCapacity, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory mem1 = WritableMemory.allocateDirect(arena, memCapacity, 1, ByteOrder.nativeOrder(), memReqSvr);
+      WritableMemory mem2 = WritableMemory.allocateDirect(arena, memCapacity, 1, ByteOrder.nativeOrder(), memReqSvr);
 
       for (int i = 0; i < memCapacity; i++) {
         mem1.putByte(i, (byte) i);
@@ -147,9 +146,9 @@ public class WritableDirectCopyTest {
     int memCapacity = (2 << 20) + 64;
     int memCapLongs = memCapacity / 8;
 
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory mem1 = WritableMemory.allocateDirect(memCapacity, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
-      WritableMemory mem2 = WritableMemory.allocateDirect(memCapacity, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory mem1 = WritableMemory.allocateDirect(arena, memCapacity, 1, ByteOrder.nativeOrder(), memReqSvr);
+      WritableMemory mem2 = WritableMemory.allocateDirect(arena, memCapacity, 1, ByteOrder.nativeOrder(), memReqSvr);
 
       for (int i = 0; i < memCapLongs; i++) {
         mem1.putLong(i * 8, i);
@@ -167,8 +166,8 @@ public class WritableDirectCopyTest {
   @Test
   public void checkCopyCrossNativeAndByteArray() throws Exception {
     int memCapacity = 64;
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory mem1 = WritableMemory.allocateDirect(memCapacity, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory mem1 = WritableMemory.allocateDirect(arena, memCapacity, 1, ByteOrder.nativeOrder(), memReqSvr);
 
       for (int i = 0; i < mem1.getCapacity(); i++) {
         mem1.putByte(i, (byte) i);
@@ -188,8 +187,8 @@ public class WritableDirectCopyTest {
   public void checkCopyCrossRegionsSameNative() throws Exception {
     int memCapacity = 128;
 
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory mem1 = WritableMemory.allocateDirect(memCapacity, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory mem1 = WritableMemory.allocateDirect(arena, memCapacity, 1, ByteOrder.nativeOrder(), memReqSvr);
 
       for (int i = 0; i < mem1.getCapacity(); i++) {
         mem1.putByte(i, (byte) i);
@@ -214,8 +213,8 @@ public class WritableDirectCopyTest {
   @Test
   public void checkCopyCrossNativeArrayAndHierarchicalRegions() throws Exception {
     int memCapacity = 64;
-    try (ResourceScope scope = ResourceScope.newConfinedScope()) {
-      WritableMemory mem1 = WritableMemory.allocateDirect(memCapacity, 1, scope, ByteOrder.nativeOrder(), memReqSvr);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory mem1 = WritableMemory.allocateDirect(arena, memCapacity, 1, ByteOrder.nativeOrder(), memReqSvr);
 
       for (int i = 0; i < mem1.getCapacity(); i++) { //fill with numbers
         mem1.putByte(i, (byte) i);


### PR DESCRIPTION
The project's minimium java release requirements moved from Java 17 to Java 21.

Package imports changed from `jdk.incubator.foreign` -> `java.lang.foreign` and a number of API changes were required.
Notably, the new `java.lang.foreign.Arena` class needs to be exposed when allocating native memory regions as it controls the scope and lifecycle of allocations.

Respective API docs are as follows:
 - https://docs.oracle.com/en/java/javase/17/docs/api/jdk.incubator.foreign/jdk/incubator/foreign/package-summary.html
 - https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/foreign/package-summary.html