### PR TITLE
Changes to correct issues in 5.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@ under the License.
 
   <groupId>org.apache.datasketches</groupId>
   <artifactId>datasketches-memory</artifactId>
-  <version>5.0.0</version>
+  <version>5.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@ under the License.
 
   <groupId>org.apache.datasketches</groupId>
   <artifactId>datasketches-memory</artifactId>
-  <version>5.0.0-SNAPSHOT</version>
+  <version>5.0.0</version>
   <packaging>jar</packaging>
 
   <name>${project.artifactId}</name>

--- a/src/main/java/org/apache/datasketches/memory/DefaultMemoryRequestServer.java
+++ b/src/main/java/org/apache/datasketches/memory/DefaultMemoryRequestServer.java
@@ -34,8 +34,7 @@ public final class DefaultMemoryRequestServer implements MemoryRequestServer {
   /**
    * Default constructor.
    */
-  public DefaultMemoryRequestServer() {
-  }
+  public DefaultMemoryRequestServer() { }
 
   @Override
   public WritableMemory request(

--- a/src/main/java/org/apache/datasketches/memory/DefaultMemoryRequestServer.java
+++ b/src/main/java/org/apache/datasketches/memory/DefaultMemoryRequestServer.java
@@ -24,72 +24,43 @@ import java.nio.ByteOrder;
 
 /**
  * This example MemoryRequestServer is simple but demonstrates one of many ways to
- * manage continuous requests for larger memory.
+ * manage continuous requests for larger or smaller memory.
  * This capability is only available for writable, non-file-memory-mapping resources.
  *
  * @author Lee Rhodes
  */
 public final class DefaultMemoryRequestServer implements MemoryRequestServer {
-  private final boolean offHeap; //create the new memory off-heap; otherwise, on-heap
-  private final boolean copyOldToNew; //copy data from old memory to new memory.
 
   /**
    * Default constructor.
-   * Create new memory on-heap and do not copy old contents to new memory.
    */
   public DefaultMemoryRequestServer() {
-    this(false, false);
-  }
-
-  /**
-   * Constructor with parameters
-   * @param offHeap if true, the returned new memory will be off heap
-   * @param copyOldToNew if true, the data from the current memory will be copied to the new memory,
-   * starting at address 0, and through the currentMemory capacity.
-   */
-  public DefaultMemoryRequestServer(
-      final boolean offHeap,
-      final boolean copyOldToNew) {
-    this.offHeap = offHeap;
-    this.copyOldToNew = copyOldToNew;
   }
 
   @Override
   public WritableMemory request(
-      final WritableMemory currentWmem,
       final long newCapacityBytes,
+      final long alignmentBytes,
+      final ByteOrder byteOrder,
       final Arena arena) {
-    final ByteOrder order = currentWmem.getTypeByteOrder();
-    final long currentBytes = currentWmem.getCapacity();
     final WritableMemory newWmem;
 
-    if (newCapacityBytes <= currentBytes) {
-      throw new IllegalArgumentException("newCapacityBytes must be &gt; currentBytes");
-    }
-
-    if (offHeap) {
-      newWmem = WritableMemory.allocateDirect(newCapacityBytes, 8, order, this, arena);
+    if (arena != null) {
+      newWmem = WritableMemory.allocateDirect(newCapacityBytes, alignmentBytes, byteOrder, this, arena);
     }
     else { //On-heap
       if (newCapacityBytes > Integer.MAX_VALUE) {
         throw new IllegalArgumentException("Requested capacity exceeds Integer.MAX_VALUE.");
       }
-      newWmem = WritableMemory.allocate((int)newCapacityBytes, order, this);
-    }
-
-    if (copyOldToNew) {
-      currentWmem.copyTo(0, newWmem, 0, currentBytes);
+      newWmem = WritableMemory.allocate((int)newCapacityBytes, byteOrder, this);
     }
 
     return newWmem;
   }
 
   @Override
-  public void requestClose(
-      final WritableMemory memToClose,
-      final WritableMemory newMemory) {
-    //try to make this operation idempotent.
-    if (memToClose.isCloseable()) { memToClose.close(); }
+  public void requestClose(final Arena arena) {
+    if (arena.scope().isAlive()) { arena.close(); }
   }
 
 }

--- a/src/main/java/org/apache/datasketches/memory/MemoryRequestServer.java
+++ b/src/main/java/org/apache/datasketches/memory/MemoryRequestServer.java
@@ -50,6 +50,7 @@ public interface MemoryRequestServer {
 
   /**
    * Request to close the area managing all the related resources, if applicable.
+   * Be careful when you request to close the given Arena, you may be closing other resources as well.
    * @param arena the given arena to use to close all its managed resources.
    */
   void requestClose( Arena arena);

--- a/src/main/java/org/apache/datasketches/memory/MemoryRequestServer.java
+++ b/src/main/java/org/apache/datasketches/memory/MemoryRequestServer.java
@@ -20,9 +20,10 @@
 package org.apache.datasketches.memory;
 
 import java.lang.foreign.Arena;
+import java.nio.ByteOrder;
 
 /**
- * The MemoryRequestServer is a callback interface to provide a means to request more memory
+ * The MemoryRequestServer is a callback interface to provide a means to request more or less memory
  * for heap and off-heap WritableMemory resources that are not file-memory-mapped backed resources.
  *
  * <p>Note: this only works with Java 21.
@@ -32,53 +33,25 @@ import java.lang.foreign.Arena;
 public interface MemoryRequestServer {
 
   /**
-   * Request new WritableMemory with the given newCapacityBytes. The current WritableMemory can be used to
-   * determine the byte order of the returned WritableMemory and other properties. A new confined Arena is
-   * assigned.
-   * @param currentWritableMemory the current writableMemory of the client. It must be non-null.
-   * @param newCapacityBytes The capacity being requested. It must be &gt; the capacity of the currentWritableMemory.
-   * @return new WritableMemory with the requested capacity.
-   */
-  default WritableMemory request(
-      WritableMemory currentWritableMemory,
-      long newCapacityBytes) {
-
-    return request(currentWritableMemory, newCapacityBytes, Arena.ofConfined());
-  }
-
-  /**
-   * Request new WritableMemory with the given newCapacityBytes. The current Writable Memory can be used to
-   * determine the byte order of the returned WritableMemory and other properties.
-   * @param currentWritableMemory the current writableMemory of the client. It must be non-null.
-   * @param newCapacityBytes The capacity being requested. It must be &gt; the capacity of the currentWritableMemory.
-   * @param arena the Arena to be used for the newly allocated memory. It must be non-null.
+   * Request new WritableMemory with the given newCapacityBytes.
+   * @param newCapacityBytes The capacity being requested.
+   * @param alignmentBytes requested segment alignment. Typically 1, 2, 4 or 8.
+   * @param byteOrder the given <i>ByteOrder</i>.  It must be non-null.
+   * @param arena the given arena to manage the new off-heap WritableMemory.
+   * If arena is null, the requested WritableMemory will be off-heap.
    * Warning: This class is not thread-safe. Specifying an Arena that allows multiple threads is not recommended.
    * @return new WritableMemory with the requested capacity.
    */
   WritableMemory request(
-      WritableMemory currentWritableMemory,
       long newCapacityBytes,
+      long alignmentBytes,
+      ByteOrder byteOrder,
       Arena arena);
 
   /**
-   * Request to close the resource, if applicable.
-   *
-   * @param memToClose the relevant WritableMemory to be considered for closing. It must be non-null.
+   * Request to close the area managing all the related resources, if applicable.
+   * @param arena the given arena to use to close all its managed resources.
    */
-  default void requestClose(WritableMemory memToClose) {
-    requestClose(memToClose, null);
-  }
-
-  /**
-   * Request to close the resource, if applicable.
-   *
-   * @param memToClose the relevant WritableMemory to be considered for closing. It must be non-null.
-   * @param newMemory the newly allocated WritableMemory.
-   * The newMemory reference is returned from the client for the convenience of the system that
-   * owns the responsibility of memory allocation. It may be null.
-   */
-  void requestClose(
-      WritableMemory memToClose,
-      WritableMemory newMemory);
+  void requestClose( Arena arena);
 
 }

--- a/src/main/java/org/apache/datasketches/memory/Resource.java
+++ b/src/main/java/org/apache/datasketches/memory/Resource.java
@@ -143,6 +143,13 @@ public interface Resource {
   void force();
 
   /**
+   * Returns the arena used to create this resource and possibly other resources.
+   * Be careful when you close the returned Arena, you may be closing other resources as well.
+   * @return the arena used to create this resource and possibly other resources.
+   */
+  Arena getArena();
+
+  /**
    * Gets the capacity of this object in bytes
    * @return the capacity of this object in bytes
    */
@@ -311,10 +318,14 @@ mismatch(MemorySegment, long, long, MemorySegment, long, long)</a>
   ByteBuffer toByteBuffer(ByteOrder order);
 
   /**
-   * Returns a copy of the underlying MemorySegment.
-   * @return a copy of the underlying MemorySegment.
+   * Returns a copy of the underlying MemorySegment in the given arena.
+   * @param arena the given arena.
+   * If the desired result is to be off-heap, the arena must not be null.
+   * Otherwise, the result will be on-heap.
+   * @param alignment requested segment alignment. Typically 1, 2, 4 or 8.
+   * @return a copy of the underlying MemorySegment in the given arena.
    */
-  MemorySegment toMemorySegment();
+  MemorySegment toMemorySegment(Arena arena, long alignment);
 
   /**
    * Returns a brief description of this object.

--- a/src/main/java/org/apache/datasketches/memory/Resource.java
+++ b/src/main/java/org/apache/datasketches/memory/Resource.java
@@ -20,8 +20,6 @@
 package org.apache.datasketches.memory;
 
 import java.lang.foreign.Arena;
-import java.lang.foreign.FunctionDescriptor;
-import java.lang.foreign.Linker.Option;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySegment.Scope;
 import java.nio.ByteBuffer;
@@ -32,7 +30,7 @@ import java.nio.ByteOrder;
  *
  * @author Lee Rhodes
  */
-public interface Resource extends AutoCloseable {
+public interface Resource {
 
   //MemoryRequestServer logic
 
@@ -91,32 +89,6 @@ public interface Resource extends AutoCloseable {
    * or if its size is greater than Integer.MAX_VALUE.
    */
   ByteBuffer asByteBufferView(ByteOrder order);
-
-  /**
-   * <i>From Java 21 java.lang.foreign.Arena::close():</i>
-   * Closes this arena. If this method completes normally, the arena scope is no longer {@linkplain Scope#isAlive() alive},
-   * and all the memory segments associated with it can no longer be accessed. Furthermore, any off-heap region of memory backing the
-   * segments obtained from this arena are also released.
-   *
-   * <p>This operation is not idempotent; that is, closing an already closed arena <em>always</em> results in an
-   * exception being thrown. This reflects a deliberate design choice: failure to close an arena might reveal a bug
-   * in the underlying application logic.</p>
-   *
-   * <p>If this method completes normally, then {@code java.lang.foreign.Arena.scope().isAlive() == false}.
-   * Implementations are allowed to throw {@link UnsupportedOperationException} if an explicit close operation is
-   * not supported.</p>
-   *
-   * @see java.lang.foreign.MemorySegment.Scope#isAlive()
-   *
-   * @throws IllegalStateException if the arena has already been closed.
-   * @throws IllegalStateException if a segment associated with this arena is being accessed concurrently, e.g.
-   * by a {@linkplain java.lang.foreign.Linker#downcallHandle(FunctionDescriptor, Option...) downcall method handle}.
-   * @throws WrongThreadException if this arena is confined, and this method is called from a thread
-   * other than the arena's owner thread.
-   * @throws UnsupportedOperationException if this arena cannot be closed explicitly.
-   */
-  @Override
-  void close();
 
   /**
    * Compares the bytes of this Resource to <i>that</i> Resource.
@@ -197,13 +169,6 @@ public interface Resource extends AutoCloseable {
    * @return true if this Memory is backed by a ByteBuffer.
    */
   boolean hasByteBuffer();
-
-  /**
-   * Return true if this resource is likely to be closeable, but not guaranteed.
-   * There is no way to determine if the specific type of Arena is explicitly closeable.
-   * @return true if this resource is likely to be closeable.
-   */
-  boolean isCloseable();
 
   /**
    * Is the underlying resource scope alive?

--- a/src/main/java/org/apache/datasketches/memory/WritableMemory.java
+++ b/src/main/java/org/apache/datasketches/memory/WritableMemory.java
@@ -73,40 +73,18 @@ public interface WritableMemory extends Memory {
   /**
    * Maps the entire given file into native-ordered WritableMemory for write operations with Arena.ofConfined().
    * Calling this method is equivalent to calling
-   * {@link #writableMap(File, long, long, ByteOrder) writableMap(file, 0, file.length(), ByteOrder.nativeOrder())}.
+   * {@link #writableMap(File, long, long, ByteOrder, Arena) writableMap(file, 0, file.length(), ByteOrder.nativeOrder(), arena)}.
    * @param file the given file to map. It must be non-null and writable.
+   * @param arena the given arena to manage the new off-heap WritableMemory. It must be non-null.
+   * Warning: This class is not thread-safe. Specifying an Arena that allows multiple threads is not recommended.
    * @return a file-mapped WritableMemory
    * @throws IllegalArgumentException if file is not readable or not writable.
    * @throws IOException if the specified path does not point to an existing file, or if some other I/O error occurs.
    * @throws SecurityException If a security manager is installed and it denies an unspecified permission
    * required by the implementation.
    */
-  static WritableMemory writableMap(File file) throws IOException {
-    return WritableMemoryImpl.wrapMap(file, 0, file.length(), ByteOrder.nativeOrder(), false, Arena.ofConfined());
-  }
-
-  /**
-   * Maps the specified portion of the given file into Memory for write operations with Arena.ofConfined().
-   * Calling this method is equivalent to calling
-   * {@link #writableMap(File, long, long, ByteOrder, Arena)
-   * writableMap(file, fileOffsetBytes, capacityBytes, ByteOrder, Arena.ofConfined())}.
-   * @param file the given file to map. It must be non-null with a non-negative length and writable.
-   * @param fileOffsetBytes the position in the given file in bytes. It must not be negative.
-   * @param capacityBytes the size of the mapped Memory. It must be &ge; 0.
-   * @param byteOrder the byte order to be used. It must be non-null.
-   * @return mapped WritableMemory.
-   * @throws IllegalArgumentException -- if file is not readable or writable.
-   * @throws IllegalArgumentException -- if file is not writable.
-   * @throws IOException - if the specified path does not point to an existing file, or if some other I/O error occurs.
-   * @throws SecurityException - If a security manager is installed and it denies an unspecified permission
-   * required by the implementation.
-   */
-  static WritableMemory writableMap(
-      File file,
-      long fileOffsetBytes,
-      long capacityBytes,
-      ByteOrder byteOrder) throws IOException {
-    return WritableMemoryImpl.wrapMap(file, fileOffsetBytes, capacityBytes, byteOrder, false, Arena.ofConfined());
+  static WritableMemory writableMap(File file, Arena arena) throws IOException {
+    return WritableMemoryImpl.wrapMap(file, 0, file.length(), ByteOrder.nativeOrder(), false, arena);
   }
 
   /**
@@ -115,8 +93,9 @@ public interface WritableMemory extends Memory {
    * @param fileOffsetBytes the position in the given file in bytes. It must not be negative.
    * @param capacityBytes the size of the mapped Memory.
    * @param byteOrder the given <i>ByteOrder</i>. It must be non-null.
-   * @param arena the given arena to map. It must be non-null.
+   * @param arena the given arena to manage the new off-heap WritableMemory. It must be non-null.
    * Warning: This class is not thread-safe. Specifying an Arena that allows multiple threads is not recommended.
+   *
    * @return a file-mapped WritableMemory.
    * @throws IllegalArgumentException if file is not readable or not writable.
    * @throws IOException if the specified path does not point to an existing file, or if some other I/O error occurs.
@@ -139,34 +118,15 @@ public interface WritableMemory extends Memory {
    * The allocated memory will be 8-byte aligned.
    * Native byte order is assumed.
    * A new DefaultMemoryRequestServer() is created.
-   * A new Arena.ofConfined() is created.
    *
    * <p><b>NOTE:</b> Native/Direct memory acquired may have garbage in it.
    * It is the responsibility of the using application to clear this memory, if required,
    * and to call <i>close()</i> when done.</p>
    * @param capacityBytes the size of the desired memory in bytes.
-   * Warning: This class is not thread-safe.
-   *
-   * @return WritableMemory for this off-heap, native resource.
-   */
-  static WritableMemory allocateDirect(long capacityBytes) {
-    return allocateDirect(capacityBytes, 8, ByteOrder.nativeOrder(), new DefaultMemoryRequestServer(), Arena.ofConfined());
-  }
-
-  /**
-   * Allocates and provides access to capacityBytes directly in native (off-heap) memory.
-   * The allocated memory will be 8-byte aligned.
-   * Native byte order is assumed.
-   * A new DefaultMemoryRequestServer() is created.
-   *
-   * <p><b>NOTE:</b> Native/Direct memory acquired may have garbage in it.
-   * It is the responsibility of the using application to clear this memory, if required,
-   * and to call <i>close()</i> when done.</p>
-   * @param capacityBytes the size of the desired memory in bytes.
-   * @param arena the given arena to use. It must be non-null.
+   * @param arena the given arena to manage the new off-heap WritableMemory. It must be non-null.
    * Warning: This class is not thread-safe. Specifying an Arena that allows multiple threads is not recommended.
    *
-   * @return WritableMemory for this off-heap, native resource.
+   * @return a WritableMemory for this off-heap resource.
    */
   static WritableMemory allocateDirect(long capacityBytes, Arena arena) {
     return allocateDirect(capacityBytes, 8, ByteOrder.nativeOrder(), new DefaultMemoryRequestServer(), arena);
@@ -184,7 +144,7 @@ public interface WritableMemory extends Memory {
    * @param byteOrder the given <i>ByteOrder</i>.  It must be non-null.
    * @param memReqSvr A user-specified MemoryRequestServer, which may be null.
    * This is a callback mechanism for a user client of direct memory to request more memory.
-   * @param arena the given arena to use. It must be non-null.
+   * @param arena the given arena to manage the new off-heap WritableMemory. It must be non-null.
    * Warning: This class is not thread-safe. Specifying an Arena that allows multiple threads is not recommended.
    *
    * @return a WritableMemory for this off-heap resource.

--- a/src/main/java/org/apache/datasketches/memory/internal/ResourceImpl.java
+++ b/src/main/java/org/apache/datasketches/memory/internal/ResourceImpl.java
@@ -359,18 +359,6 @@ abstract class ResourceImpl implements Resource {
   }
 
   @Override
-  public void close() {
-    if (arena != null) {
-      try {
-        arena.close();
-      }
-      catch (final UnsupportedOperationException uoe) {
-        // ignored as it seems there's no reliable way to determine if the Arena is closeable or not
-      }
-    } //not idempotent
-  }
-
-  @Override
   public final int compareTo(final long thisOffsetBytes, final long thisLengthBytes,
       final Resource that, final long thatOffsetBytes, final long thatLengthBytes) {
     return ResourceImpl.compare(seg, thisOffsetBytes, thisLengthBytes,
@@ -422,11 +410,6 @@ abstract class ResourceImpl implements Resource {
   public final boolean isByteOrderCompatible(final ByteOrder byteOrder) {
     final ByteOrder typeBO = getTypeByteOrder();
     return typeBO == ByteOrder.nativeOrder() && typeBO == byteOrder;
-  }
-
-  @Override
-  public boolean isCloseable() {
-    return ((seg.isNative() || seg.isMapped()) && seg.scope().isAlive());
   }
 
   @Override

--- a/src/main/java/org/apache/datasketches/memory/internal/ResourceImpl.java
+++ b/src/main/java/org/apache/datasketches/memory/internal/ResourceImpl.java
@@ -93,11 +93,6 @@ abstract class ResourceImpl implements Resource {
   static final ByteOrder NON_NATIVE_BYTE_ORDER =
       (ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN) ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN;
 
-  /**
-   * The alignment of the starting address of new MemorySegments
-   */
-  static final long SEGMENT_ALIGHMENT = 8;
-
   static {
     final String jdkVer = System.getProperty("java.version");
     final int[] p = parseJavaVersion(jdkVer);
@@ -377,6 +372,9 @@ abstract class ResourceImpl implements Resource {
   public void force() { seg.force(); }
 
   @Override
+  public Arena getArena() { return arena; }
+
+  @Override
   public final long getCapacity() {
     return seg.byteSize();
   }
@@ -546,26 +544,16 @@ abstract class ResourceImpl implements Resource {
   }
 
   @Override
-  public String toString() {
-    return toString("", 0, (int)this.getCapacity(), false);
-  }
-
-  @Override
-  public final String toString(final String comment, final long offsetBytes, final int lengthBytes,
-      final boolean withData) {
-    return toHex(this, comment, offsetBytes, lengthBytes, withData);
-  }
-
-  @Override
-  public MemorySegment toMemorySegment() {
+  public MemorySegment toMemorySegment(final Arena arena, final long alignment) {
     final long len = seg.byteSize();
+    final boolean arenaValid = arena != null;
     final MemorySegment out;
-    if (seg.isNative()) { //off-heap
+    if (arenaValid) { //off-heap
       if (len == 0) {
         out = MemorySegment.NULL;
         return out;
       }
-      out = arena.allocate(seg.byteSize(), SEGMENT_ALIGHMENT);
+      out = arena.allocate(seg.byteSize(), alignment);
     }
     else { //on-heap
       if (len == 0) {
@@ -584,6 +572,17 @@ abstract class ResourceImpl implements Resource {
     }
     out.copyFrom(seg);
     return out;
+  }
+
+  @Override
+  public String toString() {
+    return toString("", 0, (int)this.getCapacity(), false);
+  }
+
+  @Override
+  public final String toString(final String comment, final long offsetBytes, final int lengthBytes,
+      final boolean withData) {
+    return toHex(this, comment, offsetBytes, lengthBytes, withData);
   }
 
   @Override

--- a/src/main/java/org/apache/datasketches/memory/internal/WritableMemoryImpl.java
+++ b/src/main/java/org/apache/datasketches/memory/internal/WritableMemoryImpl.java
@@ -138,18 +138,16 @@ public abstract class WritableMemoryImpl extends ResourceImpl implements Writabl
    * This method is also used for read-only operations when localReadOnly is false.
    * @param file the given file to map. It must be non-null.
    * @param fileOffsetBytes the file starting offset in bytes. It must be &ge; 0.
-   * @param capacityBytes the capacity of the mapped memory. It must be &ge; 0.
-   * It must be non-null.
-   * Typically use <i>Arena.ofConfined()</i>.
-   * Warning: This class is not thread-safe. Specifying an Arena that allows multiple threads is not recommended.
+   * @param capacityBytes the capacity of the mapped memory. It must be &ge; 0. It must be non-null.
    * @param byteOrder the given <i>ByteOrder</i>. It must be non-null.
    * @param localReadOnly true if read-only is being imposed locally, even if the given file is writable..
-   * @param arena the given arena. It must be non-null.
+   * @param arena the given arena. It must be non-null. Typically use <i>Arena.ofConfined()</i>.
    * Warning: This class is not thread-safe. Specifying an Arena that allows multiple threads is not recommended.
    * @return a <i>WritableMemory</i>
    * @throws IllegalArgumentException if file is not readable.
    * @throws IOException if mapping is not successful.
    */
+  @SuppressWarnings("resource")
   public static WritableMemory wrapMap(
       final File file,
       final long fileOffsetBytes,
@@ -204,6 +202,7 @@ public abstract class WritableMemoryImpl extends ResourceImpl implements Writabl
    * Warning: This class is not thread-safe. Specifying an Arena that allows multiple threads is not recommended.
    * @return WritableMemory
    */
+  @SuppressWarnings("resource")
   public static WritableMemory wrapDirect(
       final long capacityBytes,
       final long alignmentBytes,

--- a/src/test/java/org/apache/datasketches/memory/internal/AllocateDirectMemoryTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/AllocateDirectMemoryTest.java
@@ -25,6 +25,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import java.lang.foreign.Arena;
+import java.nio.ByteOrder;
 
 import org.apache.datasketches.memory.MemoryRequestServer;
 import org.apache.datasketches.memory.Resource;
@@ -39,7 +40,8 @@ public class AllocateDirectMemoryTest {
   public void simpleAllocateDirect() {
     int longs = 32;
     WritableMemory wMem2 = null;
-    try (WritableMemory wMem = WritableMemory.allocateDirect(longs << 3, Arena.ofConfined())) {
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory wMem = WritableMemory.allocateDirect(longs << 3, arena);
       wMem2 = wMem;
       for (int i = 0; i<longs; i++) {
         wMem.putLong(i << 3, i);
@@ -56,7 +58,8 @@ public class AllocateDirectMemoryTest {
   public void checkDefaultMemoryRequestServer() {
     int longs1 = 32;
     int bytes1 = longs1 << 3;
-    try (WritableMemory origWmem = WritableMemory.allocateDirect(bytes1, Arena.ofConfined())) {
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory origWmem = WritableMemory.allocateDirect(bytes1, 8, ByteOrder.LITTLE_ENDIAN, Resource.defaultMemReqSvr, arena);
       for (int i = 0; i < longs1; i++) { //puts data in origWmem
         origWmem.putLong(i << 3, i);
         assertEquals(origWmem.getLong(i << 3), i);
@@ -68,20 +71,20 @@ public class AllocateDirectMemoryTest {
       origWmem.setMemoryRequestServer(Resource.defaultMemReqSvr);
       MemoryRequestServer myMemReqSvr = origWmem.getMemoryRequestServer();
 
-      try (WritableMemory newWmem = myMemReqSvr.request(origWmem, bytes2)) {
-        assertTrue(newWmem.isHeap()); //on heap by default
-        for (int i = 0; i < longs2; i++) {
-          newWmem.putLong(i << 3, i);
-          assertEquals(newWmem.getLong(i << 3), i);
-        }
-      } //allow the TWR to close the newWmem
-    } //allow the TWR to close the direct origWmem
+      WritableMemory newWmem = myMemReqSvr.request(bytes2, 8, ByteOrder.LITTLE_ENDIAN, null); //null -> on-heap
+      assertTrue(newWmem.isHeap());
+      for (int i = 0; i < longs2; i++) {
+        newWmem.putLong(i << 3, i);
+        assertEquals(newWmem.getLong(i << 3), i);
+      }
+    } //allow the TWR to close all resources
   }
 
   @Test
   public void checkNonNativeDirect() {
     MemoryRequestServer myMemReqSvr = Resource.defaultMemReqSvr;
-    try (WritableMemory wmem = WritableMemory.allocateDirect(128, 8, NON_NATIVE_BYTE_ORDER, myMemReqSvr, Arena.ofConfined())) {
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory wmem = WritableMemory.allocateDirect(128, 8, NON_NATIVE_BYTE_ORDER, myMemReqSvr, arena);
       wmem.putChar(0, (char) 1);
       assertEquals(wmem.getByte(1), (byte) 1);
     }
@@ -90,8 +93,9 @@ public class AllocateDirectMemoryTest {
   @Test
   public void checkExplicitCloseNoTWR() {
     final long cap = 128;
-    WritableMemory wmem = WritableMemory.allocateDirect(cap, Arena.ofConfined());
-    wmem.close(); //explicit close
+    Arena arena = Arena.ofConfined();
+    WritableMemory wmem = WritableMemory.allocateDirect(cap, arena);
+    arena.close(); //explicit close
   }
 
   @Test

--- a/src/test/java/org/apache/datasketches/memory/internal/BufferTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/BufferTest.java
@@ -287,7 +287,7 @@ public class BufferTest {
     try (Arena arena = Arena.ofConfined()) {
       WritableMemory wmem = WritableMemory.allocateDirect(bytes, 1, ByteOrder.nativeOrder(), memReqSvr, arena);
       WritableBuffer wbuf = wmem.asWritableBuffer();
-      wmem.close();
+      arena.close();
       //with -ea assert: Memory not alive.
       //with -da sometimes segfaults, sometimes passes!
       wbuf.getLong();
@@ -300,7 +300,7 @@ public class BufferTest {
     try (Arena arena = Arena.ofConfined()) {
       WritableMemory wmem = WritableMemory.allocateDirect(bytes, 1, ByteOrder.nativeOrder(), memReqSvr, arena);
       Buffer region = wmem.asBuffer().region();
-      wmem.close();
+      arena.close();
       //with -ea assert: Memory not alive.
       //with -da sometimes segfaults, sometimes passes!
       region.getByte();
@@ -310,7 +310,8 @@ public class BufferTest {
   @Test
   public void checkCheckNotAliveAfterTWR() {
     Buffer buf;
-    try (WritableMemory wmem = WritableMemory.allocateDirect(100, Arena.ofConfined())) {
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory wmem = WritableMemory.allocateDirect(100, Arena.ofConfined());
       buf = wmem.asBuffer();
     }
     try {

--- a/src/test/java/org/apache/datasketches/memory/internal/IgnoredArrayOverflowTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/IgnoredArrayOverflowTest.java
@@ -42,7 +42,7 @@ public class IgnoredArrayOverflowTest {
 
   @AfterClass
   public void close() throws Exception {
-    memory.close();
+    memory.getArena().close();
   }
 
   @Test

--- a/src/test/java/org/apache/datasketches/memory/internal/InvalidAllocationTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/InvalidAllocationTest.java
@@ -53,7 +53,7 @@ public class InvalidAllocationTest {
       Assert.fail();
     } catch (IllegalArgumentException ignore) {
       if (nullMem != null) {
-        nullMem.close();
+        nullMem.getArena().close();
       }
       // expected
     }
@@ -69,12 +69,12 @@ public class InvalidAllocationTest {
     Memory mem3 = Memory.wrap(ByteBuffer.allocateDirect(0));
     mem3.region(0, 0);
     WritableMemory nullMem = null;
-    try (Arena arena = Arena.ofConfined()) { //Invalid alignment : 3 
+    try (Arena arena = Arena.ofConfined()) { //Invalid alignment : 3
       nullMem = WritableMemory.allocateDirect(0, 3, ByteOrder.nativeOrder(), memReqSvr, arena);
       Assert.fail();
     } catch (IllegalArgumentException ignore) {
       if (nullMem != null) {
-        nullMem.close();
+        nullMem.getArena().close();
       }
       // expected
     }

--- a/src/test/java/org/apache/datasketches/memory/internal/LeafImplTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/LeafImplTest.java
@@ -42,7 +42,7 @@ import org.testng.annotations.Test;
 public class LeafImplTest {
   private static final ByteOrder NBO = ByteOrder.nativeOrder();
   private static final ByteOrder NNBO = NON_NATIVE_BYTE_ORDER;
-  private static final MemoryRequestServer myMemReqSvr = new DefaultMemoryRequestServer(true, true);
+  private static final MemoryRequestServer myMemReqSvr = new DefaultMemoryRequestServer();
 
   public static ByteOrder otherByteOrder(final ByteOrder order) {
     return (order == ByteOrder.nativeOrder()) ? NNBO : ByteOrder.nativeOrder();

--- a/src/test/java/org/apache/datasketches/memory/internal/MemoryBoundaryCheckTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/MemoryBoundaryCheckTest.java
@@ -34,12 +34,7 @@ public class MemoryBoundaryCheckTest {
 
   @BeforeClass
   public void allocate() {
-     writableBuffer = WritableMemory.allocate(8).asWritableBuffer();
-  }
-
-  @AfterClass
-  public void close() throws Exception {
-    writableBuffer.close();
+     writableBuffer = WritableMemory.allocate(8).asWritableBuffer(); //on heap
   }
 
   @Test

--- a/src/test/java/org/apache/datasketches/memory/internal/MemoryReadWriteSafetyTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/MemoryReadWriteSafetyTest.java
@@ -41,13 +41,13 @@ public class MemoryReadWriteSafetyTest {
 
   @BeforeClass
   public void allocate() {
-    mem = (WritableMemory) Memory.wrap(new byte[8]);
+    mem = (WritableMemory) Memory.wrap(new byte[8]); //on heap
   }
 
-  @AfterClass
-  public void close() throws Exception {
-    mem.close();
-  }
+//  @AfterClass
+//  public void close() throws Exception {
+//    mem.close();
+//  }
 
   @Test(expectedExceptions = UnsupportedOperationException.class)
   public void testPutByte() {
@@ -187,7 +187,6 @@ public class MemoryReadWriteSafetyTest {
     mem1.putInt(0, 1);
   }
 
-  //@SuppressWarnings("resource")
   @Test(expectedExceptions = UnsupportedOperationException.class)
   public void testMapFile() throws Exception {
     File tempFile = File.createTempFile("test", null);
@@ -195,10 +194,9 @@ public class MemoryReadWriteSafetyTest {
     try (RandomAccessFile raf = new RandomAccessFile(tempFile, "rw")) {
       raf.setLength(8);
       //System.out.println(UtilTest.getFileAttributes(tempFile));
-      try (Arena arena = Arena.ofConfined();
-           Memory memory = Memory.map(tempFile, arena)) {
-
-          ((WritableMemory) memory).putInt(0, 1);
+      try (Arena arena = Arena.ofConfined()) {
+        Memory memory = Memory.map(tempFile, arena);
+        ((WritableMemory) memory).putInt(0, 1); //cannot write into read only resource
       }
     }
   }

--- a/src/test/java/org/apache/datasketches/memory/internal/MemoryTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/MemoryTest.java
@@ -356,7 +356,7 @@ public class MemoryTest {
     int bytes = 64 * 8;
     try (Arena arena = Arena.ofConfined()) {
       WritableMemory wmem = WritableMemory.allocateDirect(bytes, 1, ByteOrder.nativeOrder(), myMemReqSvr, arena);
-      wmem.close();
+      wmem.getArena().close();
       wmem.getLong(0); //Already closed
     }
   }
@@ -367,7 +367,7 @@ public class MemoryTest {
     try (Arena arena = Arena.ofConfined()) {
       WritableMemory wmem = WritableMemory.allocateDirect(bytes, 1, ByteOrder.nativeOrder(), myMemReqSvr, arena);
       Memory region = wmem.region(0L, bytes);
-      wmem.close();
+      wmem.getArena().close();
       region.getByte(0); //Already closed.
     }
   }

--- a/src/test/java/org/apache/datasketches/memory/internal/NativeWritableBufferImplTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/NativeWritableBufferImplTest.java
@@ -50,9 +50,9 @@ public class NativeWritableBufferImplTest {
     WritableBuffer wbuf = wmem.asWritableBuffer();
     assertEquals(wbuf.getCapacity(), memCapacity);
 
-    wmem.close();
+    wmem.getArena().close();
     assertFalse(wbuf.isAlive());
-    try { wmem.close(); } catch (IllegalStateException e) { }
+    try { wmem.getArena().close(); } catch (IllegalStateException e) { }
   }
 
   //Simple Heap arrays

--- a/src/test/java/org/apache/datasketches/memory/internal/NativeWritableMemoryImplTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/NativeWritableMemoryImplTest.java
@@ -53,9 +53,9 @@ public class NativeWritableMemoryImplTest {
       Arena.ofConfined());
     assertEquals(memCapacity, wmem.getCapacity());
 
-    wmem.close();
+    wmem.getArena().close();
     assertFalse(wmem.isAlive());
-    try { wmem.close(); } catch (IllegalStateException e) { }
+    try { wmem.getArena().close(); } catch (IllegalStateException e) { }
   }
 
   //Simple Native arrays

--- a/src/test/java/org/apache/datasketches/memory/internal/ResourceTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/ResourceTest.java
@@ -123,10 +123,12 @@ public class ResourceTest {
 
   @Test
   public void checkGetRelativeOffset() {
-    WritableMemory wmem = WritableMemory.allocateDirect(1024);
-    WritableMemory reg = wmem.writableRegion(512, 256);
-    long off = wmem.getRelativeOffset(reg);
-    assertEquals(off, 512);
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory wmem = WritableMemory.allocateDirect(1024, arena);
+      WritableMemory reg = wmem.writableRegion(512, 256);
+      long off = wmem.getRelativeOffset(reg);
+      assertEquals(off, 512);
+    }
   }
 
   @Test
@@ -137,9 +139,11 @@ public class ResourceTest {
 
   @Test
   public void checkIsSameResource() {
-    WritableMemory wmem = WritableMemory.allocateDirect(1024);
-    WritableMemory reg = wmem.writableRegion(0, 1024);
-    assertTrue(wmem.isSameResource(reg));
+    try (Arena arena = Arena.ofConfined()) {
+      WritableMemory wmem = WritableMemory.allocateDirect(1024, arena);
+      WritableMemory reg = wmem.writableRegion(0, 1024);
+      assertTrue(wmem.isSameResource(reg));
+    }
   }
 
   @Test
@@ -222,31 +226,31 @@ public class ResourceTest {
     {
       int len = 0;
       WritableMemory mem = WritableMemory.allocate(len);
-      MemorySegment seg = mem.toMemorySegment();
+      MemorySegment seg = mem.toMemorySegment(null, 8);
       assertEquals(seg.byteSize(), len);
     }
     {
       int len = 13 * 8;
       WritableMemory mem = WritableMemory.allocate(len);
-      MemorySegment seg = mem.toMemorySegment();
+      MemorySegment seg = mem.toMemorySegment(null, 8);
       assertEquals(seg.byteSize(), len);
     }
     {
       int len = 13 * 4;
       WritableMemory mem = WritableMemory.allocate(len);
-      MemorySegment seg = mem.toMemorySegment();
+      MemorySegment seg = mem.toMemorySegment(null, 8);
       assertEquals(seg.byteSize(), len);
     }
     {
       int len = 13 * 2;
       WritableMemory mem = WritableMemory.allocate(len);
-      MemorySegment seg = mem.toMemorySegment();
+      MemorySegment seg = mem.toMemorySegment(null, 8);
       assertEquals(seg.byteSize(), len);
     }
     {
       int len = 13;
       WritableMemory mem = WritableMemory.allocate(len);
-      MemorySegment seg = mem.toMemorySegment();
+      MemorySegment seg = mem.toMemorySegment(null, 8);
       assertEquals(seg.byteSize(), len);
     }
   }


### PR DESCRIPTION
The Java 21 FFM API changed considerably from the Java 17 FFM API. 
- Allocation of off-heap memory is no longer performed from MemorySegment, it is now in Arena.
- Closing of a segment is no longer performed from the MemorySegment, it must be done from the owning Arena.
- An Arena can manage multiple segments and Arena::close() closes everything that an Arena owns.

**Problems with the 5.0.0 release:**
- Although version 5.0.0 could work, the Resource class (the base of the Memory hierarchy) extended _AutoCloseable_, which was a subtle mistake, because one cannot close just one Memory, which wraps a MemorySegment.  This could confuse the user by implying that a single Memory could be closed when it actually depends on what else the Arena is managing.  
- In Java 21, Arena extends _AutoCloseable_, not _MemorySegment.ResourceScope_ of Java 17.  And the Arena that is used to create a MemorySegment is not recoverable from the MemorySegment.  This means that a MemorySegment plays no role in its off-heap creation and no role in closing the off-heap collection of resources under an Arena, unlike in Java 17.
- To fix this required making sure that every path in Memory that could create off-heap memory also required providing an Arena (as well as the alignment bytes).   
- As a result, the user must choose the type of Arena appropriate for their use-case (danger: don't use Arena types that allow multi-threading, because the rest of the code is not thread-safe).  This Arena is passed to Memory, and, when done, the user must close the Arena.  There is no way that Memory can take on those roles.  Once given an Arena to use, Memory can use it to create the underlying MemorySegment, and in certain cases, facilitate the closing.  
- Creating a memory-mapped MemorySegment is a bit more involved and Memory deals with all of that for the user.
- Most of the changes in this PR are in the /test/ tree. Every test TWR block had to be updated to be based on an Arena, and not on a segment.  A simple change, but there are a lot of them.  Also where and how Arenas are closed had to be done carefully, with suitable warnings.