### PR TITLE
More comprehensive tests.

### DIFF
--- a/src/main/java/org/apache/datasketches/memory/internal/NativeWritableBufferImpl.java
+++ b/src/main/java/org/apache/datasketches/memory/internal/NativeWritableBufferImpl.java
@@ -41,10 +41,10 @@ final class NativeWritableBufferImpl extends WritableBufferImpl {
 
   //Pass-through ctor
   NativeWritableBufferImpl(
-      final Arena arena,
       final MemorySegment seg,
       final int typeId,
-      final MemoryRequestServer memReqSvr) {
+      final MemoryRequestServer memReqSvr,
+      final Arena arena) {
     super(seg, typeId, memReqSvr, arena);
   }
 

--- a/src/main/java/org/apache/datasketches/memory/internal/ResourceImpl.java
+++ b/src/main/java/org/apache/datasketches/memory/internal/ResourceImpl.java
@@ -220,7 +220,7 @@ abstract class ResourceImpl implements Resource {
     final MemoryRequestServer memReqSvr2 = (byteBufferType || mapType) ? null : memReqSvr;
     final WritableBuffer wbuf;
     if (nativeBOType) {
-      wbuf = new NativeWritableBufferImpl(null, segment, type, memReqSvr2);
+      wbuf = new NativeWritableBufferImpl(segment, type, memReqSvr2, null);
     } else { //non-native BO
       wbuf = new NonNativeWritableBufferImpl(segment, type, memReqSvr2, null);
     }

--- a/src/main/java/org/apache/datasketches/memory/internal/WritableBufferImpl.java
+++ b/src/main/java/org/apache/datasketches/memory/internal/WritableBufferImpl.java
@@ -90,7 +90,7 @@ public abstract class WritableBufferImpl extends PositionalImpl implements Writa
       type |= NONNATIVE_BO;
       wbuf = new NonNativeWritableBufferImpl(seg, type, memReqSvr, null);
     } else {
-      wbuf = new NativeWritableBufferImpl(null, seg, type, memReqSvr);
+      wbuf = new NativeWritableBufferImpl(seg, type, memReqSvr, null);
     }
     wbuf.setStartPositionEnd(0, byteBuffer.position(), byteBuffer.limit());
     return wbuf;

--- a/src/test/java/org/apache/datasketches/memory/internal/NativeWritableBufferImplTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/NativeWritableBufferImplTest.java
@@ -20,7 +20,14 @@
 package org.apache.datasketches.memory.internal;
 
 import java.lang.foreign.Arena;
-import static org.apache.datasketches.memory.internal.ResourceImpl.NON_NATIVE_BYTE_ORDER;
+import static org.apache.datasketches.memory.internal.UtilForTest.CB;
+import static org.apache.datasketches.memory.internal.UtilForTest.DB;
+import static org.apache.datasketches.memory.internal.UtilForTest.FB;
+import static org.apache.datasketches.memory.internal.UtilForTest.IB;
+import static org.apache.datasketches.memory.internal.UtilForTest.LB;
+import static org.apache.datasketches.memory.internal.UtilForTest.NBO;
+import static org.apache.datasketches.memory.internal.UtilForTest.NNBO;
+import static org.apache.datasketches.memory.internal.UtilForTest.SB;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -38,6 +45,9 @@ import org.apache.datasketches.memory.WritableMemory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+/**
+ * @author Lee Rhodes
+ */
 public class NativeWritableBufferImplTest {
   private static final MemoryRequestServer memReqSvr = Resource.defaultMemReqSvr;
 
@@ -55,239 +65,170 @@ public class NativeWritableBufferImplTest {
     try { wmem.getArena().close(); } catch (IllegalStateException e) { }
   }
 
-  //Simple Heap arrays
+  //Check primitives
 
   @Test
-  public void checkGetByteArray() {
+  public void checkPutGetBooleans() {
+    boolean[] srcArray = {true, false, true, false, false, true, false, true};
+    final int len = srcArray.length;
+    final int half = len / 2;
+    WritableBuffer wbuf = WritableMemory.allocate(len, NBO).asWritableBuffer();
+    //put
+    for (int i = 0; i < half; i++) { wbuf.putBoolean(srcArray[i]); }       //put*(value)
+    for (int i = half; i < len; i++) { wbuf.putBoolean(i, srcArray[i]); }  //put*(add, value)
+    wbuf.resetPosition();
+    //get
+    boolean[] dstArray = new boolean[len];
+    for (int i = 0; i < half; i++) { dstArray[i] = wbuf.getBoolean(); }    //get*()
+    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getBoolean(i); } //get*(add)
+    assertEquals(srcArray, dstArray);
+  }
+
+  @Test
+  public void checkPutGetBytes() {
     byte[] srcArray = { 1, -2, 3, -4, 5, -6, 7, -8 };
     final int len = srcArray.length;
     final int half = len / 2;
+    WritableBuffer wbuf = WritableMemory.allocate(len, NBO).asWritableBuffer();
+    //put
+    wbuf.putByte(srcArray[0]);                        //put*(value)
+    wbuf.putByteArray(srcArray, 1, 2);                //put*Array(src[], srcOff, len)
+    wbuf.putByte(srcArray[3]);                        //put*(value)
+    for (int i = half; i < len; i++) { wbuf.putByte(i, srcArray[i]); } //put*(add, value)
+    wbuf.resetPosition();
+    //get
     byte[] dstArray = new byte[len];
-
-    Buffer buf = Memory.wrap(srcArray).asBuffer();
-    buf.getByteArray(dstArray, 0, half);
-    buf.getByteArray(dstArray, half, half);
-    assertEquals(dstArray, srcArray);
-
-    WritableBuffer wbuf = WritableMemory.writableWrap(srcArray).asWritableBuffer();
-    wbuf.getByteArray(dstArray, 0, half);
-    wbuf.getByteArray(dstArray, half, half);
-    assertEquals(dstArray, srcArray);
+    dstArray[0] = wbuf.getByte();                     //get*()
+    wbuf.getByteArray(dstArray, 1, 2);                //get*Array(dst[], dstOff, len)
+    dstArray[3] = wbuf.getByte();                     //get*()
+    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getByte(i); } //get*(add)
+    assertEquals(srcArray, dstArray);
   }
 
   @Test
-  public void checkPutByteArray() {
-    byte[] srcArray = { 1, -2, 3, -4, 5, -6, 7, -8 };
+  public void checkPutGetNativeCharacters() {
+    char[] srcArray = { 'a','b','c','d','e','f','g','h' };
     final int len = srcArray.length;
     final int half = len / 2;
-    byte[] dstArray = new byte[len];
-
-    WritableBuffer wbuf = WritableMemory.allocate(len * Byte.BYTES).asWritableBuffer();
-    wbuf.putByteArray(srcArray, 0, half);
-    wbuf.putByteArray(srcArray, half, half);
+    WritableBuffer wbuf = WritableMemory.allocate(len * CB, NBO).asWritableBuffer();
+    //put
+    wbuf.putChar(srcArray[0]);                        //put*(value)
+    wbuf.putCharArray(srcArray, 1, 2);                //put*Array(src[], srcOff, len)
+    wbuf.putChar(srcArray[3]);                        //put*(value)
+    for (int i = half; i < len; i++) { wbuf.putChar(i * CB, srcArray[i]); } //put*(add, value)
     wbuf.resetPosition();
-    wbuf.getByteArray(dstArray, 0, len);
-    assertEquals(dstArray, srcArray);
-  }
-
-  @Test
-  public void checkGetCharArray() {
-    char[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
-    final int len = srcArray.length;
-    final int half = len / 2;
+    //get
     char[] dstArray = new char[len];
-
-    Buffer buf = Memory.wrap(srcArray).asBuffer();
-    buf.getCharArray(dstArray, 0, half);
-    buf.getCharArray(dstArray, half, half);
-    assertEquals(dstArray, srcArray);
-
-    WritableBuffer wbuf = WritableMemory.writableWrap(srcArray).asWritableBuffer();
-    wbuf.getCharArray(dstArray, 0, half);
-    wbuf.getCharArray(dstArray, half, half);
-    assertEquals(dstArray, srcArray);
+    dstArray[0] = wbuf.getChar();                     //get*()
+    wbuf.getCharArray(dstArray, 1, 2);                //get*Array(dst[], dstOff, len)
+    dstArray[3] = wbuf.getChar();                     //get*()
+    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getChar(i * CB); } //get*(add)
+    assertEquals(srcArray, dstArray);
   }
 
   @Test
-  public void checkPutCharArray() {
-    char[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
+  public void checkPutGetNativeDoubles() {
+    double[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
     final int len = srcArray.length;
     final int half = len / 2;
-    char[] dstArray = new char[len];
-
-    WritableBuffer wbuf = WritableMemory.allocate(len * Character.BYTES).asWritableBuffer();
-    wbuf.putCharArray(srcArray, 0, half);
-    wbuf.putCharArray(srcArray, half, half);
+    WritableBuffer wbuf = WritableMemory.allocate(len * DB, NBO).asWritableBuffer();
+    //put
+    wbuf.putDouble(srcArray[0]);                        //put*(value)
+    wbuf.putDoubleArray(srcArray, 1, 2);                //put*Array(src[], srcOff, len)
+    wbuf.putDouble(srcArray[3]);                        //put*(value)
+    for (int i = half; i < len; i++) { wbuf.putDouble(i * DB, srcArray[i]); } //put*(add, value)
     wbuf.resetPosition();
-    wbuf.getCharArray(dstArray, 0, len);
-    assertEquals(dstArray, srcArray);
-  }
-
-  @Test
-  public void checkGetShortArray() {
-    short[] srcArray = { 1, -2, 3, -4, 5, -6, 7, -8 };
-    final int len = srcArray.length;
-    final int half = len / 2;
-    short[] dstArray = new short[len];
-
-    Buffer buf = Memory.wrap(srcArray).asBuffer();
-    buf.getShortArray(dstArray, 0, half);
-    buf.getShortArray(dstArray, half, half);
-    assertEquals(dstArray, srcArray);
-
-    WritableBuffer wbuf = WritableMemory.writableWrap(srcArray).asWritableBuffer();
-    wbuf.getShortArray(dstArray, 0, half);
-    wbuf.getShortArray(dstArray, half, half);
-    assertEquals(dstArray, srcArray);
-  }
-
-  @Test
-  public void checkPutShortArray() {
-    short[] srcArray = { 1, -2, 3, -4, 5, -6, 7, -8 };
-    final int len = srcArray.length;
-    final int half = len / 2;
-    short[] dstArray = new short[len];
-
-    WritableBuffer wbuf = WritableMemory.allocate(len * Short.BYTES).asWritableBuffer();
-    wbuf.putShortArray(srcArray, 0, half);
-    wbuf.putShortArray(srcArray, half, half);
-    wbuf.resetPosition();
-    wbuf.getShortArray(dstArray, 0, len);
-    assertEquals(dstArray, srcArray);
-  }
-
-  @Test
-  public void checkGetIntArray() {
-    int[] srcArray = { 1, -2, 3, -4, 5, -6, 7, -8 };
-    final int len = srcArray.length;
-    final int half = len / 2;
-    int[] dstArray = new int[len];
-
-    Buffer buf = Memory.wrap(srcArray).asBuffer();
-    buf.getIntArray(dstArray, 0, half);
-    buf.getIntArray(dstArray, half, half);
-    assertEquals(dstArray, srcArray);
-
-    WritableBuffer wbuf = WritableMemory.writableWrap(srcArray).asWritableBuffer();
-    wbuf.getIntArray(dstArray, 0, half);
-    wbuf.getIntArray(dstArray, half, half);
-    assertEquals(dstArray, srcArray);
-  }
-
-  @Test
-  public void checkPutIntArray() {
-    int[] srcArray = { 1, -2, 3, -4, 5, -6, 7, -8 };
-    final int len = srcArray.length;
-    final int half = len / 2;
-    int[] dstArray = new int[len];
-
-    WritableBuffer wbuf = WritableMemory.allocate(len * Integer.BYTES).asWritableBuffer();
-    wbuf.putIntArray(srcArray, 0, half);
-    wbuf.putIntArray(srcArray, half, half);
-    wbuf.resetPosition();
-    wbuf.getIntArray(dstArray, 0, len);
-    assertEquals(dstArray, srcArray);
-  }
-
-  @Test
-  public void checkGetLongArray() {
-    long[] srcArray = { 1, -2, 3, -4, 5, -6, 7, -8 };
-    final int len = srcArray.length;
-    final int half = len / 2;
-    long[] dstArray = new long[len];
-
-    Buffer buf = Memory.wrap(srcArray).asBuffer();
-    buf.getLongArray(dstArray, 0, half);
-    buf.getLongArray(dstArray, half, half);
-    assertEquals(dstArray, srcArray);
-
-    WritableBuffer wbuf = WritableMemory.writableWrap(srcArray).asWritableBuffer();
-    wbuf.getLongArray(dstArray, 0, half);
-    wbuf.getLongArray(dstArray, half, half);
-    assertEquals(dstArray, srcArray);
-  }
-
-  @Test
-  public void checkPutLongArray() {
-    long[] srcArray = { 1, -2, 3, -4, 5, -6, 7, -8 };
-    final int len = srcArray.length;
-    final int half = len / 2;
-    long[] dstArray = new long[len];
-
-    WritableBuffer wbuf = WritableMemory.allocate(len * Long.BYTES).asWritableBuffer();
-    wbuf.putLongArray(srcArray, 0, half);
-    wbuf.putLongArray(srcArray, half, half);
-    wbuf.resetPosition();
-    wbuf.getLongArray(dstArray, 0, len);
-    assertEquals(dstArray, srcArray);
-  }
-
-  @Test
-  public void checkGetFloatArray() {
-    float[] srcArray = { 1, -2, 3, -4, 5, -6, 7, -8 };
-    final int len = srcArray.length;
-    final int half = len / 2;
-    float[] dstArray = new float[len];
-
-    Buffer buf = Memory.wrap(srcArray).asBuffer();
-    buf.getFloatArray(dstArray, 0, half);
-    buf.getFloatArray(dstArray, half, half);
-    assertEquals(dstArray, srcArray);
-
-
-    WritableBuffer wbuf = WritableMemory.writableWrap(srcArray).asWritableBuffer();
-    wbuf.getFloatArray(dstArray, 0, half);
-    wbuf.getFloatArray(dstArray, half, half);
-    assertEquals(dstArray, srcArray);
-  }
-
-  @Test
-  public void checkPutFloatArray() {
-    float[] srcArray = { 1, -2, 3, -4, 5, -6, 7, -8 };
-    final int len = srcArray.length;
-    final int half = len / 2;
-    float[] dstArray = new float[len];
-
-    WritableBuffer wbuf = WritableMemory.allocate(len * Float.BYTES).asWritableBuffer();
-    wbuf.putFloatArray(srcArray, 0, half);
-    wbuf.putFloatArray(srcArray, half, half);
-    wbuf.resetPosition();
-    wbuf.getFloatArray(dstArray, 0, len);
-    assertEquals(dstArray, srcArray);
-  }
-
-  @Test
-  public void checkGetDoubleArray() {
-    double[] srcArray = { 1, -2, 3, -4, 5, -6, 7, -8 };
-    final int len = srcArray.length;
-    final int half = len / 2;
+    //get
     double[] dstArray = new double[len];
-
-    Buffer buf = Memory.wrap(srcArray).asBuffer();
-    buf.getDoubleArray(dstArray, 0, half);
-    buf.getDoubleArray(dstArray, half, half);
-    assertEquals(dstArray, srcArray);
-
-
-    WritableBuffer wbuf = WritableMemory.writableWrap(srcArray).asWritableBuffer();
-    wbuf.getDoubleArray(dstArray, 0, half);
-    wbuf.getDoubleArray(dstArray, half, half);
-    assertEquals(dstArray, srcArray);
+    dstArray[0] = wbuf.getDouble();                     //get*()
+    wbuf.getDoubleArray(dstArray, 1, 2);                //get*Array(dst[], dstOff, len)
+    dstArray[3] = wbuf.getDouble();                     //get*()
+    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getDouble(i * DB); } //get*(add)
+    assertEquals(srcArray, dstArray);
   }
 
   @Test
-  public void checkPutDoubleArray() {
-    double[] srcArray = { 1, -2, 3, -4, 5, -6, 7, -8 };
+  public void checkPutGetNativeFloats() {
+    float[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
     final int len = srcArray.length;
     final int half = len / 2;
-    double[] dstArray = new double[len];
-
-    WritableBuffer wbuf = WritableMemory.allocate(len * Double.BYTES).asWritableBuffer();
-    wbuf.putDoubleArray(srcArray, 0, half);
-    wbuf.putDoubleArray(srcArray, half, half);
+    WritableBuffer wbuf = WritableMemory.allocate(len * FB, NBO).asWritableBuffer();
+    //put
+    wbuf.putFloat(srcArray[0]);                        //put*(value)
+    wbuf.putFloatArray(srcArray, 1, 2);                //put*Array(src[], srcOff, len)
+    wbuf.putFloat(srcArray[3]);                        //put*(value)
+    for (int i = half; i < len; i++) { wbuf.putFloat(i * FB, srcArray[i]); } //put*(add, value)
     wbuf.resetPosition();
-    wbuf.getDoubleArray(dstArray, 0, len);
-    assertEquals(dstArray, srcArray);
+    //get
+    float[] dstArray = new float[len];
+    dstArray[0] = wbuf.getFloat();                     //get*()
+    wbuf.getFloatArray(dstArray, 1, 2);                //get*Array(dst[], dstOff, len)
+    dstArray[3] = wbuf.getFloat();                     //get*()
+    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getFloat(i * FB); } //get*(add)
+    assertEquals(srcArray, dstArray);
+  }
+
+  @Test
+  public void checkPutGetNativeInts() {
+    int[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    final int len = srcArray.length;
+    final int half = len / 2;
+    WritableBuffer wbuf = WritableMemory.allocate(len * IB, NBO).asWritableBuffer();
+    //put
+    wbuf.putInt(srcArray[0]);                        //put*(value)
+    wbuf.putIntArray(srcArray, 1, 2);                //put*Array(src[], srcOff, len)
+    wbuf.putInt(srcArray[3]);                        //put*(value)
+    for (int i = half; i < len; i++) { wbuf.putInt(i * IB, srcArray[i]); } //put*(add, value)
+    wbuf.resetPosition();
+    //get
+    int[] dstArray = new int[len];
+    dstArray[0] = wbuf.getInt();                     //get*()
+    wbuf.getIntArray(dstArray, 1, 2);                //get*Array(dst[], dstOff, len)
+    dstArray[3] = wbuf.getInt();                     //get*()
+    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getInt(i * IB); } //get*(add)
+    assertEquals(srcArray, dstArray);
+  }
+
+  @Test
+  public void checkPutGetNativeLongs() {
+    long[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    final int len = srcArray.length;
+    final int half = len / 2;
+    WritableBuffer wbuf = WritableMemory.allocate(len * LB, NNBO).asWritableBuffer();
+    //put
+    wbuf.putLong(srcArray[0]);                        //put*(value)
+    wbuf.putLongArray(srcArray, 1, 2);                //put*Array(src[], srcOff, len)
+    wbuf.putLong(srcArray[3]);                        //put*(value)
+    for (int i = half; i < len; i++) { wbuf.putLong(i * LB, srcArray[i]); } //put*(add, value)
+    wbuf.resetPosition();
+    //get
+    long[] dstArray = new long[len];
+    dstArray[0] = wbuf.getLong();                     //get*()
+    wbuf.getLongArray(dstArray, 1, 2);                //get*Array(dst[], dstOff, len)
+    dstArray[3] = wbuf.getLong();                     //get*()
+    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getLong(i * LB); } //get*(add)
+    assertEquals(srcArray, dstArray);
+  }
+
+  @Test
+  public void checkPutGetNativeShorts() {
+    short[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    final int len = srcArray.length;
+    final int half = len / 2;
+    WritableBuffer wbuf = WritableMemory.allocate(len * SB, NBO).asWritableBuffer();
+    //put
+    wbuf.putShort(srcArray[0]);                        //put*(value)
+    wbuf.putShortArray(srcArray, 1, 2);                //put*Array(src[], srcOff, len)
+    wbuf.putShort(srcArray[3]);                        //put*(value)
+    for (int i = half; i < len; i++) { wbuf.putShort(i * SB, srcArray[i]); } //put*(add, value)
+    wbuf.resetPosition();
+    //get
+    short[] dstArray = new short[len];
+    dstArray[0] = wbuf.getShort();                     //get*()
+    wbuf.getShortArray(dstArray, 1, 2);                //get*Array(dst[], dstOff, len)
+    dstArray[3] = wbuf.getShort();                     //get*()
+    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getShort(i * SB); } //get*(add)
+    assertEquals(srcArray, dstArray);
   }
 
   @Test
@@ -571,7 +512,7 @@ public class NativeWritableBufferImplTest {
   public void checkDuplicateNonNative() {
     WritableMemory wmem = WritableMemory.allocate(64);
     wmem.putShort(0, (short) 1);
-    Buffer buf = wmem.asWritableBuffer().duplicate(NON_NATIVE_BYTE_ORDER);
+    Buffer buf = wmem.asWritableBuffer().duplicate(NNBO);
     assertEquals(buf.getShort(0), 256);
   }
 

--- a/src/test/java/org/apache/datasketches/memory/internal/NativeWritableMemoryImplTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/NativeWritableMemoryImplTest.java
@@ -19,7 +19,14 @@
 
 package org.apache.datasketches.memory.internal;
 
-import static org.apache.datasketches.memory.internal.ResourceImpl.NON_NATIVE_BYTE_ORDER;
+import static org.apache.datasketches.memory.internal.UtilForTest.CB;
+import static org.apache.datasketches.memory.internal.UtilForTest.DB;
+import static org.apache.datasketches.memory.internal.UtilForTest.FB;
+import static org.apache.datasketches.memory.internal.UtilForTest.IB;
+import static org.apache.datasketches.memory.internal.UtilForTest.LB;
+import static org.apache.datasketches.memory.internal.UtilForTest.NBO;
+import static org.apache.datasketches.memory.internal.UtilForTest.NNBO;
+import static org.apache.datasketches.memory.internal.UtilForTest.SB;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -58,231 +65,159 @@ public class NativeWritableMemoryImplTest {
     try { wmem.getArena().close(); } catch (IllegalStateException e) { }
   }
 
-  //Simple Heap arrays
+  //Check primitives
 
   @Test
-  public void checkGetByteArray() {
+  public void checkPutGetBooleans() {
+    boolean[] srcArray = {true, false, true, false, false, true, false, true};
+    final int len = srcArray.length;
+    WritableMemory wmem = WritableMemory.allocate(len, NBO);
+    //put
+    for (int i = 0; i < len; i++) { wmem.putBoolean(i, srcArray[i]); }  //put*(add, value)
+    //get
+    boolean[] dstArray = new boolean[len];
+    for (int i = 0; i < len; i++) { dstArray[i] = wmem.getBoolean(i); } //get*(add)
+    assertEquals(srcArray, dstArray);
+  }
+
+  @Test
+  public void checkPutGetBytes() {
     byte[] srcArray = { 1, -2, 3, -4, 5, -6, 7, -8 };
     final int len = srcArray.length;
     final int half = len / 2;
+    WritableMemory wmem = WritableMemory.allocate(len, NBO);
+    //put
+    wmem.putByte(0, srcArray[0]);                     //put*(add, value)
+    wmem.putByteArray(1, srcArray, 1, 2);             //put*Array(add, src[], srcOff, len)
+    wmem.putByte(3, srcArray[3]);                     //put*(add, value)
+    for (int i = half; i < len; i++) { wmem.putByte(i, srcArray[i]); } //put*(add, value)
+    //get
     byte[] dstArray = new byte[len];
-
-    Memory mem = Memory.wrap(srcArray);
-    mem.getByteArray(0, dstArray, 0, half);
-    mem.getByteArray(half, dstArray, half, half);
-    assertEquals(dstArray, srcArray);
-
-    WritableMemory wmem = WritableMemory.writableWrap(srcArray);
-    wmem.getByteArray(0, dstArray, 0, half);
-    wmem.getByteArray(half, dstArray, half, half);
-    assertEquals(dstArray, srcArray);
+    dstArray[0] = wmem.getByte(0);                    //get*(add)
+    wmem.getByteArray(1, dstArray, 1, 2);             //get*Array(add, dst[], dstOff, len)
+    dstArray[3] = wmem.getByte(3);                    //get*(add)
+    for (int i = half; i < len; i++) { dstArray[i] = wmem.getByte(i); } //get*(add)
+    assertEquals(srcArray, dstArray);
   }
 
   @Test
-  public void checkPutByteArray() {
-    byte[] srcArray = { 1, -2, 3, -4, 5, -6, 7, -8 };
+  public void checkPutGetNativeCharacters() {
+    char[] srcArray = { 'a','b','c','d','e','f','g','h' };
     final int len = srcArray.length;
     final int half = len / 2;
-    byte[] dstArray = new byte[len];
-
-    WritableMemory wmem = WritableMemory.allocate(len * Byte.BYTES);
-    wmem.putByteArray(0, srcArray, 0, half);
-    wmem.putByteArray(half * Byte.BYTES, srcArray, half, half);
-    wmem.getByteArray(0, dstArray, 0, len);
-    assertEquals(dstArray, srcArray);
-  }
-
-  @Test
-  public void checkGetCharArray() {
-    char[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
-    final int len = srcArray.length;
-    final int half = len / 2;
+    WritableMemory wmem = WritableMemory.allocate(len * CB, NBO);
+    //put
+    wmem.putChar(0, srcArray[0]);                     //put*(add, value)
+    wmem.putCharArray(1 * CB, srcArray, 1, 2);        //put*Array(add, src[], srcOff, len)
+    wmem.putChar(3 * CB, srcArray[3]);                //put*(add, value)
+    for (int i = half; i < len; i++) { wmem.putChar(i * CB, srcArray[i]); } //put*(add, value)
+    //get
     char[] dstArray = new char[len];
-
-    Memory mem = Memory.wrap(srcArray);
-    mem.getCharArray(0, dstArray, 0, half);
-    mem.getCharArray(half * Character.BYTES, dstArray, half, half);
-    assertEquals(dstArray, srcArray);
-
-    WritableMemory wmem = WritableMemory.writableWrap(srcArray);
-    wmem.getCharArray(0, dstArray, 0, half);
-    wmem.getCharArray(half * Character.BYTES, dstArray, half, half);
-    assertEquals(dstArray, srcArray);
+    dstArray[0] = wmem.getChar(0);                    //get*(add)
+    wmem.getCharArray(1 * CB, dstArray, 1, 2);        //get*Array(add, dst[], dstOff, len)
+    dstArray[3] = wmem.getChar(3 * CB);               //get*(add)
+    for (int i = half; i < len; i++) { dstArray[i] = wmem.getChar(i * CB); } //get*(add)
+    assertEquals(srcArray, dstArray);
   }
 
   @Test
-  public void checkPutCharArray() {
-    char[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
+  public void checkPutGetNativeDoubles() {
+    double[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
     final int len = srcArray.length;
     final int half = len / 2;
-    char[] dstArray = new char[len];
-
-    WritableMemory wmem = WritableMemory.allocate(len * Character.BYTES);
-    wmem.putCharArray(0, srcArray, 0, half);
-    wmem.putCharArray(half * Character.BYTES, srcArray, half, half);
-    wmem.getCharArray(0, dstArray, 0, len);
-    assertEquals(dstArray, srcArray);
-  }
-
-  @Test
-  public void checkGetShortArray() {
-    short[] srcArray = { 1, -2, 3, -4, 5, -6, 7, -8 };
-    final int len = srcArray.length;
-    final int half = len / 2;
-    short[] dstArray = new short[len];
-
-    Memory mem = Memory.wrap(srcArray);
-    mem.getShortArray(0, dstArray, 0, half);
-    mem.getShortArray(half * Short.BYTES, dstArray, half, half);
-    assertEquals(dstArray, srcArray);
-
-    WritableMemory wmem = WritableMemory.writableWrap(srcArray);
-    wmem.getShortArray(0, dstArray, 0, half);
-    wmem.getShortArray(half * Short.BYTES, dstArray, half, half);
-    assertEquals(dstArray, srcArray);
-  }
-
-  @Test
-  public void checkPutShortArray() {
-    short[] srcArray = { 1, -2, 3, -4, 5, -6, 7, -8 };
-    final int len = srcArray.length;
-    final int half = len / 2;
-    short[] dstArray = new short[len];
-
-    WritableMemory wmem = WritableMemory.allocate(len * Short.BYTES);
-    wmem.putShortArray(0, srcArray, 0, half);
-    wmem.putShortArray(half * Short.BYTES, srcArray, half, half);
-    wmem.getShortArray(0, dstArray, 0, len);
-    assertEquals(dstArray, srcArray);
-  }
-
-  @Test
-  public void checkGetIntArray() {
-    int[] srcArray = { 1, -2, 3, -4, 5, -6, 7, -8 };
-    final int len = srcArray.length;
-    final int half = len / 2;
-    int[] dstArray = new int[len];
-
-    Memory mem = Memory.wrap(srcArray);
-    mem.getIntArray(0, dstArray, 0, half);
-    mem.getIntArray(half * Integer.BYTES, dstArray, half, half);
-    assertEquals(dstArray, srcArray);
-
-    WritableMemory wmem = WritableMemory.writableWrap(srcArray);
-    wmem.getIntArray(0, dstArray, 0, half);
-    wmem.getIntArray(half * Integer.BYTES, dstArray, half, half);
-    assertEquals(dstArray, srcArray);
-  }
-
-  @Test
-  public void checkPutIntArray() {
-    int[] srcArray = { 1, -2, 3, -4, 5, -6, 7, -8 };
-    final int len = srcArray.length;
-    final int half = len / 2;
-    int[] dstArray = new int[len];
-
-    WritableMemory wmem = WritableMemory.allocate(len * Integer.BYTES);
-    wmem.putIntArray(0, srcArray, 0, half);
-    wmem.putIntArray(half * Integer.BYTES, srcArray, half, half);
-    wmem.getIntArray(0, dstArray, 0, len);
-    assertEquals(dstArray, srcArray);
-  }
-
-  @Test
-  public void checkGetLongArray() {
-    long[] srcArray = { 1, -2, 3, -4, 5, -6, 7, -8 };
-    final int len = srcArray.length;
-    final int half = len / 2;
-    long[] dstArray = new long[len];
-
-    Memory mem = Memory.wrap(srcArray);
-    mem.getLongArray(0, dstArray, 0, half);
-    mem.getLongArray(half * Long.BYTES, dstArray, half, half);
-    assertEquals(dstArray, srcArray);
-
-    WritableMemory wmem = WritableMemory.writableWrap(srcArray);
-    wmem.getLongArray(0, dstArray, 0, half);
-    wmem.getLongArray(half * Long.BYTES, dstArray, half, half);
-    assertEquals(dstArray, srcArray);
-  }
-
-  @Test
-  public void checkPutLongArray() {
-    long[] srcArray = { 1, -2, 3, -4, 5, -6, 7, -8 };
-    final int len = srcArray.length;
-    final int half = len / 2;
-    long[] dstArray = new long[len];
-
-    WritableMemory wmem = WritableMemory.allocate(len * Long.BYTES);
-    wmem.putLongArray(0, srcArray, 0, half);
-    wmem.putLongArray(half * Long.BYTES, srcArray, half, half);
-    wmem.getLongArray(0, dstArray, 0, len);
-    assertEquals(dstArray, srcArray);
-  }
-
-
-  @Test
-  public void checkGetFloatArray() {
-    float[] srcArray = { 1, -2, 3, -4, 5, -6, 7, -8 };
-    final int len = srcArray.length;
-    final int half = len / 2;
-    float[] dstArray = new float[len];
-
-    Memory mem = Memory.wrap(srcArray);
-    mem.getFloatArray(0, dstArray, 0, half);
-    mem.getFloatArray(half * Float.BYTES, dstArray, half, half);
-    assertEquals(dstArray, srcArray);
-
-    WritableMemory wmem = WritableMemory.writableWrap(srcArray);
-    wmem.getFloatArray(0, dstArray, 0, half);
-    wmem.getFloatArray(half * Float.BYTES, dstArray, half, half);
-    assertEquals(dstArray, srcArray);
-  }
-
-  @Test
-  public void checkPutFloatArray() {
-    float[] srcArray = { 1, -2, 3, -4, 5, -6, 7, -8 };
-    final int len = srcArray.length;
-    final int half = len / 2;
-    float[] dstArray = new float[len];
-
-    WritableMemory wmem = WritableMemory.allocate(len * Float.BYTES);
-    wmem.putFloatArray(0, srcArray, 0, half);
-    wmem.putFloatArray(half * Float.BYTES, srcArray, half, half);
-    wmem.getFloatArray(0, dstArray, 0, len);
-    assertEquals(dstArray, srcArray);
-  }
-
-  @Test
-  public void checkGetDoubleArray() {
-    double[] srcArray = { 1, -2, 3, -4, 5, -6, 7, -8 };
-    final int len = srcArray.length;
-    final int half = len / 2;
-    double[] dstArray = new double[8];
-
-    Memory mem = Memory.wrap(srcArray);
-    mem.getDoubleArray(0, dstArray, 0, half);
-    mem.getDoubleArray(half * Double.BYTES, dstArray, half, half);
-    assertEquals(dstArray, srcArray);
-
-    WritableMemory wmem = WritableMemory.writableWrap(srcArray);
-    wmem.getDoubleArray(0, dstArray, 0, half);
-    wmem.getDoubleArray(half * Double.BYTES, dstArray, half, half);
-    assertEquals(dstArray, srcArray);
-  }
-
-  @Test
-  public void checkPutDoubleArray() {
-    double[] srcArray = { 1, -2, 3, -4, 5, -6, 7, -8 };
-    final int len = srcArray.length;
-    final int half = len / 2;
+    WritableMemory wmem = WritableMemory.allocate(len * DB, NBO);
+    //put
+    wmem.putDouble(0, srcArray[0]);                     //put*(add, value)
+    wmem.putDoubleArray(1 * DB, srcArray, 1, 2);        //put*Array(add, src[], srcOff, len)
+    wmem.putDouble(3 * DB, srcArray[3]);                //put*(add, value)
+    for (int i = half; i < len; i++) { wmem.putDouble(i * DB, srcArray[i]); } //put*(add, value)
+    //get
     double[] dstArray = new double[len];
+    dstArray[0] = wmem.getDouble(0);                    //get*(add)
+    wmem.getDoubleArray(1 * DB, dstArray, 1, 2);        //get*Array(add, dst[], dstOff, len)
+    dstArray[3] = wmem.getDouble(3 * DB);               //get*(add)
+    for (int i = half; i < len; i++) { dstArray[i] = wmem.getDouble(i * DB); } //get*(add)
+    assertEquals(srcArray, dstArray);
+  }
 
-    WritableMemory wmem = WritableMemory.allocate(len * Double.BYTES);
-    wmem.putDoubleArray(0, srcArray, 0, half);
-    wmem.putDoubleArray(half * Double.BYTES, srcArray, half, half);
-    wmem.getDoubleArray(0, dstArray, 0, len);
-    assertEquals(dstArray, srcArray);
+  @Test
+  public void checkPutGetNativeFloats() {
+    float[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    final int len = srcArray.length;
+    final int half = len / 2;
+    WritableMemory wmem = WritableMemory.allocate(len * FB, NBO);
+    //put
+    wmem.putFloat(0, srcArray[0]);                     //put*(add, value)
+    wmem.putFloatArray(1 * FB, srcArray, 1, 2);        //put*Array(add, src[], srcOff, len)
+    wmem.putFloat(3 * FB, srcArray[3]);                //put*(add, value)
+    for (int i = half; i < len; i++) { wmem.putFloat(i * FB, srcArray[i]); } //put*(add, value)
+    //get
+    float[] dstArray = new float[len];
+    dstArray[0] = wmem.getFloat(0);                    //get*(add)
+    wmem.getFloatArray(1 * FB, dstArray, 1, 2);        //get*Array(add, dst[], dstOff, len)
+    dstArray[3] = wmem.getFloat(3 * FB);               //get*(add)
+    for (int i = half; i < len; i++) { dstArray[i] = wmem.getFloat(i * FB); } //get*(add)
+    assertEquals(srcArray, dstArray);
+  }
+
+  @Test
+  public void checkPutGetNativeInts() {
+    int[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    final int len = srcArray.length;
+    final int half = len / 2;
+    WritableMemory wmem = WritableMemory.allocate(len * IB, NBO);
+    //put
+    wmem.putInt(0, srcArray[0]);                     //put*(add, value)
+    wmem.putIntArray(1 * IB, srcArray, 1, 2);        //put*Array(add, src[], srcOff, len)
+    wmem.putInt(3 * IB, srcArray[3]);                //put*(add, value)
+    for (int i = half; i < len; i++) { wmem.putInt(i * IB, srcArray[i]); } //put*(add, value)
+    //get
+    int[] dstArray = new int[len];
+    dstArray[0] = wmem.getInt(0);                    //get*(add)
+    wmem.getIntArray(1 * IB, dstArray, 1, 2);        //get*Array(add, dst[], dstOff, len)
+    dstArray[3] = wmem.getInt(3 * IB);               //get*(add)
+    for (int i = half; i < len; i++) { dstArray[i] = wmem.getInt(i * IB); } //get*(add)
+    assertEquals(srcArray, dstArray);
+  }
+
+  @Test
+  public void checkPutGetNativeLongs() {
+    long[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    final int len = srcArray.length;
+    final int half = len / 2;
+    WritableMemory wmem = WritableMemory.allocate(len * LB, NBO);
+    //put
+    wmem.putLong(0, srcArray[0]);                     //put*(add, value)
+    wmem.putLongArray(1 * LB, srcArray, 1, 2);        //put*Array(add, src[], srcOff, len)
+    wmem.putLong(3 * LB, srcArray[3]);                //put*(add, value)
+    for (int i = half; i < len; i++) { wmem.putLong(i * LB, srcArray[i]); } //put*(add, value)
+    //get
+    long[] dstArray = new long[len];
+    dstArray[0] = wmem.getLong(0);                    //get*(add)
+    wmem.getLongArray(1 * LB, dstArray, 1, 2);        //get*Array(add, dst[], dstOff, len)
+    dstArray[3] = wmem.getLong(3 * LB);               //get*(add)
+    for (int i = half; i < len; i++) { dstArray[i] = wmem.getLong(i * LB); } //get*(add)
+    assertEquals(srcArray, dstArray);
+  }
+
+  @Test
+  public void checkPutGetNativeShorts() {
+    short[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    final int len = srcArray.length;
+    final int half = len / 2;
+    WritableMemory wmem = WritableMemory.allocate(len * SB, NBO);
+    //put
+    wmem.putShort(0, srcArray[0]);                     //put*(add, value)
+    wmem.putShortArray(1 * SB, srcArray, 1, 2);        //put*Array(add, src[], srcOff, len)
+    wmem.putShort(3 * SB, srcArray[3]);                //put*(add, value)
+    for (int i = half; i < len; i++) { wmem.putShort(i * SB, srcArray[i]); } //put*(add, value)
+    //get
+    short[] dstArray = new short[len];
+    dstArray[0] = wmem.getShort(0);                    //get*(add)
+    wmem.getShortArray(1 * SB, dstArray, 1, 2);        //get*Array(add, dst[], dstOff, len)
+    dstArray[3] = wmem.getShort(3 * SB);               //get*(add)
+    for (int i = half; i < len; i++) { dstArray[i] = wmem.getShort(i * SB); } //get*(add)
+    assertEquals(srcArray, dstArray);
   }
 
   @Test
@@ -695,7 +630,7 @@ public class NativeWritableMemoryImplTest {
   public void checkAsBufferNonNative() {
     WritableMemory wmem = WritableMemory.allocate(64);
     wmem.putShort(0, (short) 1);
-    Buffer buf = wmem.asBuffer(NON_NATIVE_BYTE_ORDER);
+    Buffer buf = wmem.asBuffer(NNBO);
     assertEquals(buf.getShort(0), 256);
   }
 

--- a/src/test/java/org/apache/datasketches/memory/internal/NonNativeWritableBufferImplTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/NonNativeWritableBufferImplTest.java
@@ -19,14 +19,16 @@
 
 package org.apache.datasketches.memory.internal;
 
-import static org.apache.datasketches.memory.internal.NonNativeWritableMemoryImplTest.doubleReverseBytes;
-import static org.apache.datasketches.memory.internal.NonNativeWritableMemoryImplTest.floatReverseBytes;
-import static org.apache.datasketches.memory.internal.ResourceImpl.NATIVE_BYTE_ORDER;
-import static org.apache.datasketches.memory.internal.ResourceImpl.NON_NATIVE_BYTE_ORDER;
+import static org.apache.datasketches.memory.internal.UtilForTest.CB;
+import static org.apache.datasketches.memory.internal.UtilForTest.DB;
+import static org.apache.datasketches.memory.internal.UtilForTest.FB;
+import static org.apache.datasketches.memory.internal.UtilForTest.IB;
+import static org.apache.datasketches.memory.internal.UtilForTest.LB;
+import static org.apache.datasketches.memory.internal.UtilForTest.NBO;
+import static org.apache.datasketches.memory.internal.UtilForTest.NNBO;
+import static org.apache.datasketches.memory.internal.UtilForTest.SB;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
-
-import java.nio.ByteOrder;
 
 import org.apache.datasketches.memory.Buffer;
 import org.apache.datasketches.memory.Memory;
@@ -43,26 +45,34 @@ public class NonNativeWritableBufferImplTest {
 
   @Test
   public void checkPutGetNonNativeCharacters() {
-    char[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    char[] srcArray = { 'a','b','c','d','e','f','g','h' };
     final int len = srcArray.length;
     final int half = len / 2;
-    WritableBuffer wbuf = WritableMemory.allocate(len * Character.BYTES, NON_NATIVE_BYTE_ORDER).asWritableBuffer();
-    wbuf.putCharArray(srcArray, 0, half);
-    wbuf.putCharArray(srcArray, half, half);
+    final int qtr = len / 4;
+    WritableBuffer wbuf = WritableMemory.allocate(len * CB, NNBO).asWritableBuffer();
+    //put
+    wbuf.putCharArray(srcArray, 0, qtr);              //put*Array(src[], srcOff, len)
+    wbuf.putChar(qtr * CB, srcArray[qtr]);            //put*(add, value)
+    wbuf.putChar((qtr + 1) * CB, srcArray[qtr + 1]);  //put*(add, value)
+    wbuf.setPosition(half * CB);
+    for (int i = half; i < len; i++) { wbuf.putChar(srcArray[i]); } //put*(value)
     wbuf.resetPosition();
     //confirm
-    WritableBuffer wbuf2 = WritableMemory.allocate(len * Character.BYTES, NATIVE_BYTE_ORDER).asWritableBuffer();
-    for (int i = 0; i < len * Character.BYTES; i++) { wbuf2.putByte(wbuf.getByte()); }
+    WritableBuffer wbuf2 = WritableMemory.allocate(len * CB, NBO).asWritableBuffer();
+    for (int i = 0; i < len * CB; i++) { wbuf2.putByte(wbuf.getByte()); }
     wbuf.resetPosition();
     wbuf2.resetPosition();
     for (int i = 0; i < len; i++) {
       assertTrue(srcArray[i] == Character.reverseBytes(wbuf2.getChar()));
     }
-    wbuf2.resetPosition();
     //get
+    wbuf2.resetPosition();
     char[] dstArray = new char[len];
-    wbuf.getCharArray(dstArray, 0, half);
-    wbuf.getCharArray(dstArray, half, half);
+    wbuf.getCharArray(dstArray, 0, qtr);              //get*Array(dst[], dstOff, len)
+    dstArray[qtr] = wbuf.getChar(qtr * CB);           //get*(add)
+    dstArray[qtr + 1] = wbuf.getChar((qtr + 1) * CB); //get*(add)
+    wbuf.setPosition(half * CB);
+    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getChar(); } //get*()
     assertEquals(srcArray, dstArray);
   }
 
@@ -71,23 +81,31 @@ public class NonNativeWritableBufferImplTest {
     double[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
     final int len = srcArray.length;
     final int half = len / 2;
-    WritableBuffer wbuf = WritableMemory.allocate(len * Double.BYTES, NON_NATIVE_BYTE_ORDER).asWritableBuffer();
-    wbuf.putDoubleArray(srcArray, 0, half);
-    wbuf.putDoubleArray(srcArray, half, half);
+    final int qtr = len / 4;
+    WritableBuffer wbuf = WritableMemory.allocate(len * DB, NNBO).asWritableBuffer();
+    //put
+    wbuf.putDoubleArray(srcArray, 0, qtr);              //put*Array(src[], srcOff, len)
+    wbuf.putDouble(qtr * DB, srcArray[qtr]);            //put*(add, value)
+    wbuf.putDouble((qtr + 1) * DB, srcArray[qtr + 1]);  //put*(add, value)
+    wbuf.setPosition(half * DB);
+    for (int i = half; i < len; i++) { wbuf.putDouble(srcArray[i]); } //put*(value)
     wbuf.resetPosition();
     //confirm
-    WritableBuffer wbuf2 = WritableMemory.allocate(len * Double.BYTES, NATIVE_BYTE_ORDER).asWritableBuffer();
-    for (int i = 0; i < len * Double.BYTES; i++) { wbuf2.putByte(wbuf.getByte()); }
+    WritableBuffer wbuf2 = WritableMemory.allocate(len * DB, NBO).asWritableBuffer();
+    for (int i = 0; i < len * DB; i++) { wbuf2.putByte(wbuf.getByte()); }
     wbuf.resetPosition();
     wbuf2.resetPosition();
     for (int i = 0; i < len; i++) {
-      assertTrue(srcArray[i] == doubleReverseBytes(wbuf2.getDouble()));
+      assertTrue(srcArray[i] == UtilForTest.doubleReverseBytes(wbuf2.getDouble()));
     }
-    wbuf2.resetPosition();
     //get
+    wbuf2.resetPosition();
     double[] dstArray = new double[len];
-    wbuf.getDoubleArray(dstArray, 0, half);
-    wbuf.getDoubleArray(dstArray, half, half);
+    wbuf.getDoubleArray(dstArray, 0, qtr);              //get*Array(dst[], dstOff, len)
+    dstArray[qtr] = wbuf.getDouble(qtr * DB);           //get*(add)
+    dstArray[qtr + 1] = wbuf.getDouble((qtr + 1) * DB); //get*(add)
+    wbuf.setPosition(half * DB);
+    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getDouble(); } //get*()
     assertEquals(srcArray, dstArray);
   }
 
@@ -96,23 +114,31 @@ public class NonNativeWritableBufferImplTest {
     float[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
     final int len = srcArray.length;
     final int half = len / 2;
-    WritableBuffer wbuf = WritableMemory.allocate(len * Float.BYTES, NON_NATIVE_BYTE_ORDER).asWritableBuffer();
-    wbuf.putFloatArray(srcArray, 0, half);
-    wbuf.putFloatArray(srcArray, half, half);
+    final int qtr = len / 4;
+    WritableBuffer wbuf = WritableMemory.allocate(len * FB, NNBO).asWritableBuffer();
+    //put
+    wbuf.putFloatArray(srcArray, 0, qtr);              //put*Array(src[], srcOff, len)
+    wbuf.putFloat(qtr * FB, srcArray[qtr]);            //put*(add, value)
+    wbuf.putFloat((qtr + 1) * FB, srcArray[qtr + 1]);  //put*(add, value)
+    wbuf.setPosition(half * FB);
+    for (int i = half; i < len; i++) { wbuf.putFloat(srcArray[i]); } //put*(value)
     wbuf.resetPosition();
     //confirm
-    WritableBuffer wbuf2 = WritableMemory.allocate(len * Float.BYTES, NATIVE_BYTE_ORDER).asWritableBuffer();
-    for (int i = 0; i < len * Float.BYTES; i++) { wbuf2.putByte(wbuf.getByte()); }
+    WritableBuffer wbuf2 = WritableMemory.allocate(len * FB, NBO).asWritableBuffer();
+    for (int i = 0; i < len * FB; i++) { wbuf2.putByte(wbuf.getByte()); }
     wbuf.resetPosition();
     wbuf2.resetPosition();
     for (int i = 0; i < len; i++) {
-      assertTrue(srcArray[i] == floatReverseBytes(wbuf2.getFloat()));
+      assertTrue(srcArray[i] == UtilForTest.floatReverseBytes(wbuf2.getFloat()));
     }
-    wbuf2.resetPosition();
     //get
+    wbuf2.resetPosition();
     float[] dstArray = new float[len];
-    wbuf.getFloatArray(dstArray, 0, half);
-    wbuf.getFloatArray(dstArray, half, half);
+    wbuf.getFloatArray(dstArray, 0, qtr);              //get*Array(dst[], dstOff, len)
+    dstArray[qtr] = wbuf.getFloat(qtr * FB);           //get*(add)
+    dstArray[qtr + 1] = wbuf.getFloat((qtr + 1) * FB); //get*(add)
+    wbuf.setPosition(half * FB);
+    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getFloat(); } //get*()
     assertEquals(srcArray, dstArray);
   }
 
@@ -121,23 +147,31 @@ public class NonNativeWritableBufferImplTest {
     int[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
     final int len = srcArray.length;
     final int half = len / 2;
-    WritableBuffer wbuf = WritableMemory.allocate(len * Integer.BYTES, NON_NATIVE_BYTE_ORDER).asWritableBuffer();
-    wbuf.putIntArray(srcArray, 0, half);
-    wbuf.putIntArray(srcArray, half, half);
+    final int qtr = len / 4;
+    WritableBuffer wbuf = WritableMemory.allocate(len * IB, NNBO).asWritableBuffer();
+    //put
+    wbuf.putIntArray(srcArray, 0, qtr);              //put*Array(src[], srcOff, len)
+    wbuf.putInt(qtr * IB, srcArray[qtr]);            //put*(add, value)
+    wbuf.putInt((qtr + 1) * IB, srcArray[qtr + 1]);  //put*(add, value)
+    wbuf.setPosition(half * IB);
+    for (int i = half; i < len; i++) { wbuf.putInt(srcArray[i]); } //put*(value)
     wbuf.resetPosition();
     //confirm
-    WritableBuffer wbuf2 = WritableMemory.allocate(len * Integer.BYTES, NATIVE_BYTE_ORDER).asWritableBuffer();
-    for (int i = 0; i < len * Integer.BYTES; i++) { wbuf2.putByte(wbuf.getByte()); }
+    WritableBuffer wbuf2 = WritableMemory.allocate(len * IB, NBO).asWritableBuffer();
+    for (int i = 0; i < len * IB; i++) { wbuf2.putByte(wbuf.getByte()); }
     wbuf.resetPosition();
     wbuf2.resetPosition();
     for (int i = 0; i < len; i++) {
       assertTrue(srcArray[i] == Integer.reverseBytes(wbuf2.getInt()));
     }
-    wbuf2.resetPosition();
     //get
+    wbuf2.resetPosition();
     int[] dstArray = new int[len];
-    wbuf.getIntArray(dstArray, 0, half);
-    wbuf.getIntArray(dstArray, half, half);
+    wbuf.getIntArray(dstArray, 0, qtr);              //get*Array(dst[], dstOff, len)
+    dstArray[qtr] = wbuf.getInt(qtr * IB);           //get*(add)
+    dstArray[qtr + 1] = wbuf.getInt((qtr + 1) * IB); //get*(add)
+    wbuf.setPosition(half * IB);
+    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getInt(); } //get*()
     assertEquals(srcArray, dstArray);
   }
 
@@ -146,23 +180,31 @@ public class NonNativeWritableBufferImplTest {
     long[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
     final int len = srcArray.length;
     final int half = len / 2;
-    WritableBuffer wbuf = WritableMemory.allocate(len * Long.BYTES, NON_NATIVE_BYTE_ORDER).asWritableBuffer();
-    wbuf.putLongArray(srcArray, 0, half);
-    wbuf.putLongArray(srcArray, half, half);
+    final int qtr = len / 4;
+    WritableBuffer wbuf = WritableMemory.allocate(len * LB, NNBO).asWritableBuffer();
+    //put
+    wbuf.putLongArray(srcArray, 0, qtr);              //put*Array(src[], srcOff, len)
+    wbuf.putLong(qtr * LB, srcArray[qtr]);            //put*(add, value)
+    wbuf.putLong((qtr + 1) * LB, srcArray[qtr + 1]);  //put*(add, value)
+    wbuf.setPosition(half * LB);
+    for (int i = half; i < len; i++) { wbuf.putLong(srcArray[i]); } //put*(value)
     wbuf.resetPosition();
     //confirm
-    WritableBuffer wbuf2 = WritableMemory.allocate(len * Long.BYTES, NATIVE_BYTE_ORDER).asWritableBuffer();
-    for (int i = 0; i < len * Long.BYTES; i++) { wbuf2.putByte(wbuf.getByte()); }
+    WritableBuffer wbuf2 = WritableMemory.allocate(len * LB, NBO).asWritableBuffer();
+    for (int i = 0; i < len * LB; i++) { wbuf2.putByte(wbuf.getByte()); }
     wbuf.resetPosition();
     wbuf2.resetPosition();
     for (int i = 0; i < len; i++) {
       assertTrue(srcArray[i] == Long.reverseBytes(wbuf2.getLong()));
     }
-    wbuf2.resetPosition();
     //get
+    wbuf2.resetPosition();
     long[] dstArray = new long[len];
-    wbuf.getLongArray(dstArray, 0, half);
-    wbuf.getLongArray(dstArray, half, half);
+    wbuf.getLongArray(dstArray, 0, qtr);              //get*Array(dst[], dstOff, len)
+    dstArray[qtr] = wbuf.getLong(qtr * LB);           //get*(add)
+    dstArray[qtr + 1] = wbuf.getLong((qtr + 1) * LB); //get*(add)
+    wbuf.setPosition(half * LB);
+    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getLong(); } //get*()
     assertEquals(srcArray, dstArray);
   }
 
@@ -171,23 +213,31 @@ public class NonNativeWritableBufferImplTest {
     short[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
     final int len = srcArray.length;
     final int half = len / 2;
-    WritableBuffer wbuf = WritableMemory.allocate(len * Short.BYTES, NON_NATIVE_BYTE_ORDER).asWritableBuffer();
-    wbuf.putShortArray(srcArray, 0, half);
-    wbuf.putShortArray(srcArray, half, half);
+    final int qtr = len / 4;
+    WritableBuffer wbuf = WritableMemory.allocate(len * SB, NNBO).asWritableBuffer();
+    //put
+    wbuf.putShortArray(srcArray, 0, qtr);              //put*Array(src[], srcOff, len)
+    wbuf.putShort(qtr * SB, srcArray[qtr]);            //put*(add, value)
+    wbuf.putShort((qtr + 1) * SB, srcArray[qtr + 1]);  //put*(add, value)
+    wbuf.setPosition(half * SB);
+    for (int i = half; i < len; i++) { wbuf.putShort(srcArray[i]); } //put*(value)
     wbuf.resetPosition();
     //confirm
-    WritableBuffer wbuf2 = WritableMemory.allocate(len * Short.BYTES, NATIVE_BYTE_ORDER).asWritableBuffer();
-    for (int i = 0; i < len * Short.BYTES; i++) { wbuf2.putByte(wbuf.getByte()); }
+    WritableBuffer wbuf2 = WritableMemory.allocate(len * SB, NBO).asWritableBuffer();
+    for (int i = 0; i < len * SB; i++) { wbuf2.putByte(wbuf.getByte()); }
     wbuf.resetPosition();
     wbuf2.resetPosition();
     for (int i = 0; i < len; i++) {
       assertTrue(srcArray[i] == Short.reverseBytes(wbuf2.getShort()));
     }
-    wbuf2.resetPosition();
     //get
+    wbuf2.resetPosition();
     short[] dstArray = new short[len];
-    wbuf.getShortArray(dstArray, 0, half);
-    wbuf.getShortArray(dstArray, half, half);
+    wbuf.getShortArray(dstArray, 0, qtr);              //get*Array(dst[], dstOff, len)
+    dstArray[qtr] = wbuf.getShort(qtr * SB);           //get*(add)
+    dstArray[qtr + 1] = wbuf.getShort((qtr + 1) * SB); //get*(add)
+    wbuf.setPosition(half * SB);
+    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getShort(); } //get*()
     assertEquals(srcArray, dstArray);
   }
 
@@ -195,48 +245,48 @@ public class NonNativeWritableBufferImplTest {
   @Test
   public void checkDuplicate() {
     byte[] bArr = new byte[8];
-    WritableMemory wmem = WritableMemory.writableWrap(bArr, NON_NATIVE_BYTE_ORDER);
+    WritableMemory wmem = WritableMemory.writableWrap(bArr, NNBO);
     WritableBuffer wbuf = wmem.asWritableBuffer();
     WritableBuffer wdup = wbuf.writableDuplicate();
-    assertEquals(wdup.getTypeByteOrder(), NON_NATIVE_BYTE_ORDER);
+    assertEquals(wdup.getTypeByteOrder(), NNBO);
 
     WritableBuffer wreg = wbuf.writableRegion();
-    assertEquals(wreg.getTypeByteOrder(), NON_NATIVE_BYTE_ORDER);
+    assertEquals(wreg.getTypeByteOrder(), NNBO);
   }
 
   @Test
   public void checkConversionByteOrder() {
     byte[] bArr = new byte[8];
     bArr[1] = 1;
-    WritableMemory wmem = WritableMemory.writableWrap(bArr, NON_NATIVE_BYTE_ORDER);
-    assertEquals(wmem.getTypeByteOrder(), NON_NATIVE_BYTE_ORDER);
+    WritableMemory wmem = WritableMemory.writableWrap(bArr, NNBO);
+    assertEquals(wmem.getTypeByteOrder(), NNBO);
     assertEquals(wmem.getChar(0), 1);
 
     Buffer buf = wmem.asBuffer();
-    assertEquals(buf.getTypeByteOrder(), NON_NATIVE_BYTE_ORDER); //
+    assertEquals(buf.getTypeByteOrder(), NNBO); //
     assertEquals(buf.getChar(0), 1);
 
     Buffer dup = buf.duplicate();
-    assertEquals(dup.getTypeByteOrder(), NON_NATIVE_BYTE_ORDER);
+    assertEquals(dup.getTypeByteOrder(), NNBO);
     assertEquals(dup.getChar(0), 1);
 
     Buffer reg = buf.region();
-    assertEquals(reg.getTypeByteOrder(), NON_NATIVE_BYTE_ORDER);
+    assertEquals(reg.getTypeByteOrder(), NNBO);
     assertEquals(reg.getChar(0), 1);
 
     Memory mem = reg.asMemory();
-    assertEquals(mem.getTypeByteOrder(), NON_NATIVE_BYTE_ORDER);
+    assertEquals(mem.getTypeByteOrder(), NNBO);
     assertEquals(mem.getChar(0), 1);
 
     Memory mreg = mem.region(0, 8);
-    assertEquals(mreg.getTypeByteOrder(), NON_NATIVE_BYTE_ORDER);
+    assertEquals(mreg.getTypeByteOrder(), NNBO);
     assertEquals(mreg.getChar(0), 1);
   }
 
   @Test
   public void checkPutIntArray() {
-    WritableMemory wmem = WritableMemory.allocate(12, NON_NATIVE_BYTE_ORDER);
-    WritableBuffer wbuf = wmem.asWritableBuffer(NON_NATIVE_BYTE_ORDER);
+    WritableMemory wmem = WritableMemory.allocate(12, NNBO);
+    WritableBuffer wbuf = wmem.asWritableBuffer(NNBO);
 
     wbuf.putInt(1);
     int[] array = new int[] { 2 };

--- a/src/test/java/org/apache/datasketches/memory/internal/NonNativeWritableBufferImplTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/NonNativeWritableBufferImplTest.java
@@ -48,31 +48,27 @@ public class NonNativeWritableBufferImplTest {
     char[] srcArray = { 'a','b','c','d','e','f','g','h' };
     final int len = srcArray.length;
     final int half = len / 2;
-    final int qtr = len / 4;
     WritableBuffer wbuf = WritableMemory.allocate(len * CB, NNBO).asWritableBuffer();
     //put
-    wbuf.putCharArray(srcArray, 0, qtr);              //put*Array(src[], srcOff, len)
-    wbuf.putChar(qtr * CB, srcArray[qtr]);            //put*(add, value)
-    wbuf.putChar((qtr + 1) * CB, srcArray[qtr + 1]);  //put*(add, value)
-    wbuf.setPosition(half * CB);
-    for (int i = half; i < len; i++) { wbuf.putChar(srcArray[i]); } //put*(value)
+    wbuf.putChar(srcArray[0]);                        //put*(value)
+    wbuf.putCharArray(srcArray, 1, 2);                //put*Array(src[], srcOff, len)
+    wbuf.putChar(srcArray[3]);                        //put*(value)
+    for (int i = half; i < len; i++) { wbuf.putChar(i * CB, srcArray[i]); } //put*(add, value)
     wbuf.resetPosition();
     //confirm
     WritableBuffer wbuf2 = WritableMemory.allocate(len * CB, NBO).asWritableBuffer();
     for (int i = 0; i < len * CB; i++) { wbuf2.putByte(wbuf.getByte()); }
-    wbuf.resetPosition();
     wbuf2.resetPosition();
     for (int i = 0; i < len; i++) {
       assertTrue(srcArray[i] == Character.reverseBytes(wbuf2.getChar()));
     }
     //get
-    wbuf2.resetPosition();
+    wbuf.resetPosition();
     char[] dstArray = new char[len];
-    wbuf.getCharArray(dstArray, 0, qtr);              //get*Array(dst[], dstOff, len)
-    dstArray[qtr] = wbuf.getChar(qtr * CB);           //get*(add)
-    dstArray[qtr + 1] = wbuf.getChar((qtr + 1) * CB); //get*(add)
-    wbuf.setPosition(half * CB);
-    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getChar(); } //get*()
+    dstArray[0] = wbuf.getChar();                     //get*()
+    wbuf.getCharArray(dstArray, 1, 2);                //get*Array(dst[], dstOff, len)
+    dstArray[3] = wbuf.getChar();                     //get*()
+    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getChar(i * CB); } //get*(add)
     assertEquals(srcArray, dstArray);
   }
 
@@ -81,31 +77,27 @@ public class NonNativeWritableBufferImplTest {
     double[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
     final int len = srcArray.length;
     final int half = len / 2;
-    final int qtr = len / 4;
     WritableBuffer wbuf = WritableMemory.allocate(len * DB, NNBO).asWritableBuffer();
     //put
-    wbuf.putDoubleArray(srcArray, 0, qtr);              //put*Array(src[], srcOff, len)
-    wbuf.putDouble(qtr * DB, srcArray[qtr]);            //put*(add, value)
-    wbuf.putDouble((qtr + 1) * DB, srcArray[qtr + 1]);  //put*(add, value)
-    wbuf.setPosition(half * DB);
-    for (int i = half; i < len; i++) { wbuf.putDouble(srcArray[i]); } //put*(value)
+    wbuf.putDouble(srcArray[0]);                        //put*(value)
+    wbuf.putDoubleArray(srcArray, 1, 2);                //put*Array(src[], srcOff, len)
+    wbuf.putDouble(srcArray[3]);                        //put*(value)
+    for (int i = half; i < len; i++) { wbuf.putDouble(i * DB, srcArray[i]); } //put*(add, value)
     wbuf.resetPosition();
     //confirm
     WritableBuffer wbuf2 = WritableMemory.allocate(len * DB, NBO).asWritableBuffer();
     for (int i = 0; i < len * DB; i++) { wbuf2.putByte(wbuf.getByte()); }
-    wbuf.resetPosition();
     wbuf2.resetPosition();
     for (int i = 0; i < len; i++) {
       assertTrue(srcArray[i] == UtilForTest.doubleReverseBytes(wbuf2.getDouble()));
     }
     //get
-    wbuf2.resetPosition();
+    wbuf.resetPosition();
     double[] dstArray = new double[len];
-    wbuf.getDoubleArray(dstArray, 0, qtr);              //get*Array(dst[], dstOff, len)
-    dstArray[qtr] = wbuf.getDouble(qtr * DB);           //get*(add)
-    dstArray[qtr + 1] = wbuf.getDouble((qtr + 1) * DB); //get*(add)
-    wbuf.setPosition(half * DB);
-    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getDouble(); } //get*()
+    dstArray[0] = wbuf.getDouble();                     //get*()
+    wbuf.getDoubleArray(dstArray, 1, 2);                //get*Array(dst[], dstOff, len)
+    dstArray[3] = wbuf.getDouble();                     //get*()
+    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getDouble(i * DB); } //get*(add)
     assertEquals(srcArray, dstArray);
   }
 
@@ -114,31 +106,27 @@ public class NonNativeWritableBufferImplTest {
     float[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
     final int len = srcArray.length;
     final int half = len / 2;
-    final int qtr = len / 4;
     WritableBuffer wbuf = WritableMemory.allocate(len * FB, NNBO).asWritableBuffer();
     //put
-    wbuf.putFloatArray(srcArray, 0, qtr);              //put*Array(src[], srcOff, len)
-    wbuf.putFloat(qtr * FB, srcArray[qtr]);            //put*(add, value)
-    wbuf.putFloat((qtr + 1) * FB, srcArray[qtr + 1]);  //put*(add, value)
-    wbuf.setPosition(half * FB);
-    for (int i = half; i < len; i++) { wbuf.putFloat(srcArray[i]); } //put*(value)
+    wbuf.putFloat(srcArray[0]);                        //put*(value)
+    wbuf.putFloatArray(srcArray, 1, 2);                //put*Array(src[], srcOff, len)
+    wbuf.putFloat(srcArray[3]);                        //put*(value)
+    for (int i = half; i < len; i++) { wbuf.putFloat(i * FB, srcArray[i]); } //put*(add, value)
     wbuf.resetPosition();
     //confirm
     WritableBuffer wbuf2 = WritableMemory.allocate(len * FB, NBO).asWritableBuffer();
     for (int i = 0; i < len * FB; i++) { wbuf2.putByte(wbuf.getByte()); }
-    wbuf.resetPosition();
     wbuf2.resetPosition();
     for (int i = 0; i < len; i++) {
       assertTrue(srcArray[i] == UtilForTest.floatReverseBytes(wbuf2.getFloat()));
     }
     //get
-    wbuf2.resetPosition();
+    wbuf.resetPosition();
     float[] dstArray = new float[len];
-    wbuf.getFloatArray(dstArray, 0, qtr);              //get*Array(dst[], dstOff, len)
-    dstArray[qtr] = wbuf.getFloat(qtr * FB);           //get*(add)
-    dstArray[qtr + 1] = wbuf.getFloat((qtr + 1) * FB); //get*(add)
-    wbuf.setPosition(half * FB);
-    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getFloat(); } //get*()
+    dstArray[0] = wbuf.getFloat();                     //get*()
+    wbuf.getFloatArray(dstArray, 1, 2);                //get*Array(dst[], dstOff, len)
+    dstArray[3] = wbuf.getFloat();                     //get*()
+    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getFloat(i * FB); } //get*(add)
     assertEquals(srcArray, dstArray);
   }
 
@@ -147,31 +135,27 @@ public class NonNativeWritableBufferImplTest {
     int[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
     final int len = srcArray.length;
     final int half = len / 2;
-    final int qtr = len / 4;
     WritableBuffer wbuf = WritableMemory.allocate(len * IB, NNBO).asWritableBuffer();
     //put
-    wbuf.putIntArray(srcArray, 0, qtr);              //put*Array(src[], srcOff, len)
-    wbuf.putInt(qtr * IB, srcArray[qtr]);            //put*(add, value)
-    wbuf.putInt((qtr + 1) * IB, srcArray[qtr + 1]);  //put*(add, value)
-    wbuf.setPosition(half * IB);
-    for (int i = half; i < len; i++) { wbuf.putInt(srcArray[i]); } //put*(value)
+    wbuf.putInt(srcArray[0]);                        //put*(value)
+    wbuf.putIntArray(srcArray, 1, 2);                //put*Array(src[], srcOff, len)
+    wbuf.putInt(srcArray[3]);                        //put*(value)
+    for (int i = half; i < len; i++) { wbuf.putInt(i * IB, srcArray[i]); } //put*(add, value)
     wbuf.resetPosition();
     //confirm
     WritableBuffer wbuf2 = WritableMemory.allocate(len * IB, NBO).asWritableBuffer();
     for (int i = 0; i < len * IB; i++) { wbuf2.putByte(wbuf.getByte()); }
-    wbuf.resetPosition();
     wbuf2.resetPosition();
     for (int i = 0; i < len; i++) {
       assertTrue(srcArray[i] == Integer.reverseBytes(wbuf2.getInt()));
     }
     //get
-    wbuf2.resetPosition();
+    wbuf.resetPosition();
     int[] dstArray = new int[len];
-    wbuf.getIntArray(dstArray, 0, qtr);              //get*Array(dst[], dstOff, len)
-    dstArray[qtr] = wbuf.getInt(qtr * IB);           //get*(add)
-    dstArray[qtr + 1] = wbuf.getInt((qtr + 1) * IB); //get*(add)
-    wbuf.setPosition(half * IB);
-    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getInt(); } //get*()
+    dstArray[0] = wbuf.getInt();                     //get*()
+    wbuf.getIntArray(dstArray, 1, 2);                //get*Array(dst[], dstOff, len)
+    dstArray[3] = wbuf.getInt();                     //get*()
+    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getInt(i * IB); } //get*(add)
     assertEquals(srcArray, dstArray);
   }
 
@@ -180,31 +164,27 @@ public class NonNativeWritableBufferImplTest {
     long[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
     final int len = srcArray.length;
     final int half = len / 2;
-    final int qtr = len / 4;
     WritableBuffer wbuf = WritableMemory.allocate(len * LB, NNBO).asWritableBuffer();
     //put
-    wbuf.putLongArray(srcArray, 0, qtr);              //put*Array(src[], srcOff, len)
-    wbuf.putLong(qtr * LB, srcArray[qtr]);            //put*(add, value)
-    wbuf.putLong((qtr + 1) * LB, srcArray[qtr + 1]);  //put*(add, value)
-    wbuf.setPosition(half * LB);
-    for (int i = half; i < len; i++) { wbuf.putLong(srcArray[i]); } //put*(value)
+    wbuf.putLong(srcArray[0]);                        //put*(value)
+    wbuf.putLongArray(srcArray, 1, 2);                //put*Array(src[], srcOff, len)
+    wbuf.putLong(srcArray[3]);                        //put*(value)
+    for (int i = half; i < len; i++) { wbuf.putLong(i * LB, srcArray[i]); } //put*(add, value)
     wbuf.resetPosition();
     //confirm
     WritableBuffer wbuf2 = WritableMemory.allocate(len * LB, NBO).asWritableBuffer();
     for (int i = 0; i < len * LB; i++) { wbuf2.putByte(wbuf.getByte()); }
-    wbuf.resetPosition();
     wbuf2.resetPosition();
     for (int i = 0; i < len; i++) {
       assertTrue(srcArray[i] == Long.reverseBytes(wbuf2.getLong()));
     }
     //get
-    wbuf2.resetPosition();
+    wbuf.resetPosition();
     long[] dstArray = new long[len];
-    wbuf.getLongArray(dstArray, 0, qtr);              //get*Array(dst[], dstOff, len)
-    dstArray[qtr] = wbuf.getLong(qtr * LB);           //get*(add)
-    dstArray[qtr + 1] = wbuf.getLong((qtr + 1) * LB); //get*(add)
-    wbuf.setPosition(half * LB);
-    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getLong(); } //get*()
+    dstArray[0] = wbuf.getLong();                     //get*()
+    wbuf.getLongArray(dstArray, 1, 2);                //get*Array(dst[], dstOff, len)
+    dstArray[3] = wbuf.getLong();                     //get*()
+    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getLong(i * LB); } //get*(add)
     assertEquals(srcArray, dstArray);
   }
 
@@ -213,31 +193,27 @@ public class NonNativeWritableBufferImplTest {
     short[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
     final int len = srcArray.length;
     final int half = len / 2;
-    final int qtr = len / 4;
     WritableBuffer wbuf = WritableMemory.allocate(len * SB, NNBO).asWritableBuffer();
     //put
-    wbuf.putShortArray(srcArray, 0, qtr);              //put*Array(src[], srcOff, len)
-    wbuf.putShort(qtr * SB, srcArray[qtr]);            //put*(add, value)
-    wbuf.putShort((qtr + 1) * SB, srcArray[qtr + 1]);  //put*(add, value)
-    wbuf.setPosition(half * SB);
-    for (int i = half; i < len; i++) { wbuf.putShort(srcArray[i]); } //put*(value)
+    wbuf.putShort(srcArray[0]);                        //put*(value)
+    wbuf.putShortArray(srcArray, 1, 2);                //put*Array(src[], srcOff, len)
+    wbuf.putShort(srcArray[3]);                        //put*(value)
+    for (int i = half; i < len; i++) { wbuf.putShort(i * SB, srcArray[i]); } //put*(add, value)
     wbuf.resetPosition();
     //confirm
     WritableBuffer wbuf2 = WritableMemory.allocate(len * SB, NBO).asWritableBuffer();
     for (int i = 0; i < len * SB; i++) { wbuf2.putByte(wbuf.getByte()); }
-    wbuf.resetPosition();
     wbuf2.resetPosition();
     for (int i = 0; i < len; i++) {
       assertTrue(srcArray[i] == Short.reverseBytes(wbuf2.getShort()));
     }
     //get
-    wbuf2.resetPosition();
+    wbuf.resetPosition();
     short[] dstArray = new short[len];
-    wbuf.getShortArray(dstArray, 0, qtr);              //get*Array(dst[], dstOff, len)
-    dstArray[qtr] = wbuf.getShort(qtr * SB);           //get*(add)
-    dstArray[qtr + 1] = wbuf.getShort((qtr + 1) * SB); //get*(add)
-    wbuf.setPosition(half * SB);
-    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getShort(); } //get*()
+    dstArray[0] = wbuf.getShort();                     //get*()
+    wbuf.getShortArray(dstArray, 1, 2);                //get*Array(dst[], dstOff, len)
+    dstArray[3] = wbuf.getShort();                     //get*()
+    for (int i = half; i < len; i++) { dstArray[i] = wbuf.getShort(i * SB); } //get*(add)
     assertEquals(srcArray, dstArray);
   }
 

--- a/src/test/java/org/apache/datasketches/memory/internal/NonNativeWritableMemoryImplTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/NonNativeWritableMemoryImplTest.java
@@ -52,10 +52,10 @@ public class NonNativeWritableMemoryImplTest {
     final int half = len / 2;
     WritableMemory wmem = WritableMemory.allocate(len * CB, NNBO);
     //put
-    wmem.putCharArray(0, srcArray, 0, half);             //put*Array(add, src[], srcOff, len)
-    for (int i = 0; i < half; i++) {
-      wmem.putChar((half + i) * CB, srcArray[half + i]); //put*(add, value)
-    }
+    wmem.putChar(0, srcArray[0]);                     //put*(add, value)
+    wmem.putCharArray(1 * CB, srcArray, 1, 2);        //put*Array(add, src[], srcOff, len)
+    wmem.putChar(3 * CB, srcArray[3]);                //put*(add, value)
+    for (int i = half; i < len; i++) { wmem.putChar(i * CB, srcArray[i]); } //put*(add, value)
     //confirm
     WritableMemory wmem2 = WritableMemory.allocate(len * CB, NBO);
     wmem.copyTo(0, wmem2, 0, len * CB);
@@ -64,10 +64,10 @@ public class NonNativeWritableMemoryImplTest {
     }
     //get
     char[] dstArray = new char[len];
-    wmem.getCharArray(0, dstArray, 0, half);             //get*Array(add, dst[], dstOff, len)
-    for (int i = half; i < len; i++) {
-      dstArray[i] = wmem.getChar(i * CB);                //get*(add)
-    }
+    dstArray[0] = wmem.getChar(0);                    //get*(add)
+    wmem.getCharArray(1 * CB, dstArray, 1, 2);        //get*Array(add, dst[], dstOff, len)
+    dstArray[3] = wmem.getChar(3 * CB);               //get*(add)
+    for (int i = half; i < len; i++) { dstArray[i] = wmem.getChar(i * CB); } //get*(add)
     assertEquals(srcArray, dstArray);
   }
 
@@ -77,10 +77,11 @@ public class NonNativeWritableMemoryImplTest {
     final int len = srcArray.length;
     final int half = len / 2;
     WritableMemory wmem = WritableMemory.allocate(len * DB, NNBO);
-    wmem.putDoubleArray(0, srcArray, 0, half);             //put*Array(add, src[], srcOff, len)
-    for (int i = 0; i < half; i++) {
-      wmem.putDouble((half + i) * DB, srcArray[half + i]); //put*(add, value)
-    }
+    //put
+    wmem.putDouble(0, srcArray[0]);                     //put*(add, value)
+    wmem.putDoubleArray(1 * DB, srcArray, 1, 2);        //put*Array(add, src[], srcOff, len)
+    wmem.putDouble(3 * DB, srcArray[3]);                //put*(add, value)
+    for (int i = half; i < len; i++) { wmem.putDouble(i * DB, srcArray[i]); } //put*(add, value)
     //confirm
     WritableMemory wmem2 = WritableMemory.allocate(len * DB, NBO);
     wmem.copyTo(0, wmem2, 0, len * DB);
@@ -89,10 +90,10 @@ public class NonNativeWritableMemoryImplTest {
     }
     //get
     double[] dstArray = new double[len];
-    wmem.getDoubleArray(0, dstArray, 0, half);             //get*Array(add, dst[], dstOff, len)
-    for (int i = half; i < len; i++) {
-      dstArray[i] = wmem.getDouble(i * DB);                //get*(add)
-    }
+    dstArray[0] = wmem.getDouble(0);                    //get*(add)
+    wmem.getDoubleArray(1 * DB, dstArray, 1, 2);        //get*Array(add, dst[], dstOff, len)
+    dstArray[3] = wmem.getDouble(3 * DB);               //get*(add)
+    for (int i = half; i < len; i++) { dstArray[i] = wmem.getDouble(i * DB); } //get*(add)
     assertEquals(srcArray, dstArray);
   }
 
@@ -102,10 +103,11 @@ public class NonNativeWritableMemoryImplTest {
     final int len = srcArray.length;
     final int half = len / 2;
     WritableMemory wmem = WritableMemory.allocate(len * FB, NNBO);
-    wmem.putFloatArray(0, srcArray, 0, half);             //put*Array(add, src[], srcOff, len)
-    for (int i = 0; i < half; i++) {
-      wmem.putFloat((half + i) * FB, srcArray[half + i]); //put*(add, value)
-    }
+    //put
+    wmem.putFloat(0, srcArray[0]);                     //put*(add, value)
+    wmem.putFloatArray(1 * FB, srcArray, 1, 2);        //put*Array(add, src[], srcOff, len)
+    wmem.putFloat(3 * FB, srcArray[3]);                //put*(add, value)
+    for (int i = half; i < len; i++) { wmem.putFloat(i * FB, srcArray[i]); } //put*(add, value)
     //confirm
     WritableMemory wmem2 = WritableMemory.allocate(len * FB, NBO);
     wmem.copyTo(0, wmem2, 0, len * FB);
@@ -114,10 +116,10 @@ public class NonNativeWritableMemoryImplTest {
     }
     //get
     float[] dstArray = new float[len];
-    wmem.getFloatArray(0, dstArray, 0, half);             //get*Array(add, dst[], dstOff, len)
-    for (int i = half; i < len; i++) {
-      dstArray[i] = wmem.getFloat(i * FB);                //get*(add)
-    }
+    dstArray[0] = wmem.getFloat(0);                    //get*(add)
+    wmem.getFloatArray(1 * FB, dstArray, 1, 2);        //get*Array(add, dst[], dstOff, len)
+    dstArray[3] = wmem.getFloat(3 * FB);               //get*(add)
+    for (int i = half; i < len; i++) { dstArray[i] = wmem.getFloat(i * FB); } //get*(add)
     assertEquals(srcArray, dstArray);
   }
 
@@ -127,10 +129,11 @@ public class NonNativeWritableMemoryImplTest {
     final int len = srcArray.length;
     final int half = len / 2;
     WritableMemory wmem = WritableMemory.allocate(len * IB, NNBO);
-    wmem.putIntArray(0, srcArray, 0, half);             //put*Array(add, src[], srcOff, len)
-    for (int i = 0; i < half; i++) {
-      wmem.putInt((half + i) * IB, srcArray[half + i]); //put*(add, value)
-    }
+    //put
+    wmem.putInt(0, srcArray[0]);                     //put*(add, value)
+    wmem.putIntArray(1 * IB, srcArray, 1, 2);        //put*Array(add, src[], srcOff, len)
+    wmem.putInt(3 * IB, srcArray[3]);                //put*(add, value)
+    for (int i = half; i < len; i++) { wmem.putInt(i * IB, srcArray[i]); } //put*(add, value)
     //confirm
     WritableMemory wmem2 = WritableMemory.allocate(len * IB, NBO);
     wmem.copyTo(0, wmem2, 0, len * IB);
@@ -139,10 +142,10 @@ public class NonNativeWritableMemoryImplTest {
     }
     //get
     int[] dstArray = new int[len];
-    wmem.getIntArray(0, dstArray, 0, half);             //get*Array(add, dst[], dstOff, len)
-    for (int i = half; i < len; i++) {
-      dstArray[i] = wmem.getInt(i * IB);                //get*(add)
-    }
+    dstArray[0] = wmem.getInt(0);                    //get*(add)
+    wmem.getIntArray(1 * IB, dstArray, 1, 2);        //get*Array(add, dst[], dstOff, len)
+    dstArray[3] = wmem.getInt(3 * IB);               //get*(add)
+    for (int i = half; i < len; i++) { dstArray[i] = wmem.getInt(i * IB); } //get*(add)
     assertEquals(srcArray, dstArray);
   }
 
@@ -152,10 +155,11 @@ public class NonNativeWritableMemoryImplTest {
     final int len = srcArray.length;
     final int half = len / 2;
     WritableMemory wmem = WritableMemory.allocate(len * LB, NNBO);
-    wmem.putLongArray(0, srcArray, 0, half);             //put*Array(add, src[], srcOff, len)
-    for (int i = 0; i < half; i++) {
-      wmem.putLong((half + i) * LB, srcArray[half + i]); //put*(add, value)
-    }
+    //put
+    wmem.putLong(0, srcArray[0]);                     //put*(add, value)
+    wmem.putLongArray(1 * LB, srcArray, 1, 2);        //put*Array(add, src[], srcOff, len)
+    wmem.putLong(3 * LB, srcArray[3]);                //put*(add, value)
+    for (int i = half; i < len; i++) { wmem.putLong(i * LB, srcArray[i]); } //put*(add, value)
     //confirm
     WritableMemory wmem2 = WritableMemory.allocate(len * LB, NBO);
     wmem.copyTo(0, wmem2, 0, len * LB);
@@ -164,10 +168,10 @@ public class NonNativeWritableMemoryImplTest {
     }
     //get
     long[] dstArray = new long[len];
-    wmem.getLongArray(0, dstArray, 0, half);             //get*Array(add, dst[], dstOff, len)
-    for (int i = half; i < len; i++) {
-      dstArray[i] = wmem.getLong(i *LB);                 //get*(add)
-    }
+    dstArray[0] = wmem.getLong(0);                    //get*(add)
+    wmem.getLongArray(1 * LB, dstArray, 1, 2);        //get*Array(add, dst[], dstOff, len)
+    dstArray[3] = wmem.getLong(3 * LB);               //get*(add)
+    for (int i = half; i < len; i++) { dstArray[i] = wmem.getLong(i * LB); } //get*(add)
     assertEquals(srcArray, dstArray);
   }
 
@@ -177,10 +181,11 @@ public class NonNativeWritableMemoryImplTest {
     final int len = srcArray.length;
     final int half = len / 2;
     WritableMemory wmem = WritableMemory.allocate(len * SB, NNBO);
-    wmem.putShortArray(0, srcArray, 0, half);             //put*Array(add, src[], srcOff, len)
-    for (int i = 0; i < half; i++) {
-      wmem.putShort((half + i) * SB, srcArray[half + i]); //put*(add, value)
-    }
+    //put
+    wmem.putShort(0, srcArray[0]);                     //put*(add, value)
+    wmem.putShortArray(1 * SB, srcArray, 1, 2);        //put*Array(add, src[], srcOff, len)
+    wmem.putShort(3 * SB, srcArray[3]);                //put*(add, value)
+    for (int i = half; i < len; i++) { wmem.putShort(i * SB, srcArray[i]); } //put*(add, value)
     //confirm
     WritableMemory wmem2 = WritableMemory.allocate(len * SB, NBO);
     wmem.copyTo(0, wmem2, 0, len * SB);
@@ -189,10 +194,10 @@ public class NonNativeWritableMemoryImplTest {
     }
     //get
     short[] dstArray = new short[len];
-    wmem.getShortArray(0, dstArray, 0, half);             //get*Array(add, dst[], dstOff, len)
-    for (int i = half; i < len; i++) {
-      dstArray[i] = wmem.getShort(i *SB);                 //get*(add)
-    }
+    dstArray[0] = wmem.getShort(0);                    //get*(add)
+    wmem.getShortArray(1 * SB, dstArray, 1, 2);        //get*Array(add, dst[], dstOff, len)
+    dstArray[3] = wmem.getShort(3 * SB);               //get*(add)
+    for (int i = half; i < len; i++) { dstArray[i] = wmem.getShort(i * SB); } //get*(add)
     assertEquals(srcArray, dstArray);
   }
 

--- a/src/test/java/org/apache/datasketches/memory/internal/NonNativeWritableMemoryImplTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/NonNativeWritableMemoryImplTest.java
@@ -19,8 +19,14 @@
 
 package org.apache.datasketches.memory.internal;
 
-import static org.apache.datasketches.memory.internal.ResourceImpl.NATIVE_BYTE_ORDER;
-import static org.apache.datasketches.memory.internal.ResourceImpl.NON_NATIVE_BYTE_ORDER;
+import static org.apache.datasketches.memory.internal.UtilForTest.CB;
+import static org.apache.datasketches.memory.internal.UtilForTest.DB;
+import static org.apache.datasketches.memory.internal.UtilForTest.FB;
+import static org.apache.datasketches.memory.internal.UtilForTest.IB;
+import static org.apache.datasketches.memory.internal.UtilForTest.LB;
+import static org.apache.datasketches.memory.internal.UtilForTest.NBO;
+import static org.apache.datasketches.memory.internal.UtilForTest.NNBO;
+import static org.apache.datasketches.memory.internal.UtilForTest.SB;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -35,28 +41,33 @@ import org.testng.annotations.Test;
  */
 public class NonNativeWritableMemoryImplTest {
   private byte[] bArr = new byte[8];
-  private final WritableMemory wmem = WritableMemory.writableWrap(bArr, ByteOrder.BIG_ENDIAN);
+  private final WritableMemory wmem = WritableMemory.writableWrap(bArr, NNBO);
 
   //Check primitives
 
   @Test
   public void checkPutGetNonNativeCharacters() {
-    char[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    char[] srcArray = { 'a','b','c','d','e','f','g','h' };
     final int len = srcArray.length;
     final int half = len / 2;
-    WritableMemory wmem = WritableMemory.allocate(len * Character.BYTES, NON_NATIVE_BYTE_ORDER);
-    wmem.putCharArray(0, srcArray, 0, half);
-    wmem.putCharArray(half * Character.BYTES, srcArray, half, half);
+    WritableMemory wmem = WritableMemory.allocate(len * CB, NNBO);
+    //put
+    wmem.putCharArray(0, srcArray, 0, half);             //put*Array(add, src[], srcOff, len)
+    for (int i = 0; i < half; i++) {
+      wmem.putChar((half + i) * CB, srcArray[half + i]); //put*(add, value)
+    }
     //confirm
-    WritableMemory wmem2 = WritableMemory.allocate(len * Character.BYTES, NATIVE_BYTE_ORDER);
-    wmem.copyTo(0, wmem2, 0, len * Character.BYTES);
+    WritableMemory wmem2 = WritableMemory.allocate(len * CB, NBO);
+    wmem.copyTo(0, wmem2, 0, len * CB);
     for (int i = 0; i < len; i++) {
-      assertTrue(srcArray[i] == Character.reverseBytes(wmem2.getChar(i * Character.BYTES)));
+      assertTrue(srcArray[i] == Character.reverseBytes(wmem2.getChar(i * CB)));
     }
     //get
     char[] dstArray = new char[len];
-    wmem.getCharArray(0, dstArray, 0, half);
-    wmem.getCharArray(half * Character.BYTES, dstArray, half, half);
+    wmem.getCharArray(0, dstArray, 0, half);             //get*Array(add, dst[], dstOff, len)
+    for (int i = half; i < len; i++) {
+      dstArray[i] = wmem.getChar(i * CB);                //get*(add)
+    }
     assertEquals(srcArray, dstArray);
   }
 
@@ -65,19 +76,23 @@ public class NonNativeWritableMemoryImplTest {
     double[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
     final int len = srcArray.length;
     final int half = len / 2;
-    WritableMemory wmem = WritableMemory.allocate(len * Double.BYTES, NON_NATIVE_BYTE_ORDER);
-    wmem.putDoubleArray(0, srcArray, 0, half);
-    wmem.putDoubleArray(half * Double.BYTES, srcArray, half, half);
+    WritableMemory wmem = WritableMemory.allocate(len * DB, NNBO);
+    wmem.putDoubleArray(0, srcArray, 0, half);             //put*Array(add, src[], srcOff, len)
+    for (int i = 0; i < half; i++) {
+      wmem.putDouble((half + i) * DB, srcArray[half + i]); //put*(add, value)
+    }
     //confirm
-    WritableMemory wmem2 = WritableMemory.allocate(len * Double.BYTES, NATIVE_BYTE_ORDER);
-    wmem.copyTo(0, wmem2, 0, len * Double.BYTES);
+    WritableMemory wmem2 = WritableMemory.allocate(len * DB, NBO);
+    wmem.copyTo(0, wmem2, 0, len * DB);
     for (int i = 0; i < len; i++) {
-      assertTrue(srcArray[i] == doubleReverseBytes(wmem2.getDouble(i * Double.BYTES)));
+      assertTrue(srcArray[i] == UtilForTest.doubleReverseBytes(wmem2.getDouble(i * DB)));
     }
     //get
     double[] dstArray = new double[len];
-    wmem.getDoubleArray(0, dstArray, 0, half);
-    wmem.getDoubleArray(half * Double.BYTES, dstArray, half, half);
+    wmem.getDoubleArray(0, dstArray, 0, half);             //get*Array(add, dst[], dstOff, len)
+    for (int i = half; i < len; i++) {
+      dstArray[i] = wmem.getDouble(i * DB);                //get*(add)
+    }
     assertEquals(srcArray, dstArray);
   }
 
@@ -86,19 +101,23 @@ public class NonNativeWritableMemoryImplTest {
     float[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
     final int len = srcArray.length;
     final int half = len / 2;
-    WritableMemory wmem = WritableMemory.allocate(len * Float.BYTES, NON_NATIVE_BYTE_ORDER);
-    wmem.putFloatArray(0, srcArray, 0, half);
-    wmem.putFloatArray(half * Float.BYTES, srcArray, half, half);
+    WritableMemory wmem = WritableMemory.allocate(len * FB, NNBO);
+    wmem.putFloatArray(0, srcArray, 0, half);             //put*Array(add, src[], srcOff, len)
+    for (int i = 0; i < half; i++) {
+      wmem.putFloat((half + i) * FB, srcArray[half + i]); //put*(add, value)
+    }
     //confirm
-    WritableMemory wmem2 = WritableMemory.allocate(len * Float.BYTES, NATIVE_BYTE_ORDER);
-    wmem.copyTo(0, wmem2, 0, len * Float.BYTES);
+    WritableMemory wmem2 = WritableMemory.allocate(len * FB, NBO);
+    wmem.copyTo(0, wmem2, 0, len * FB);
     for (int i = 0; i < len; i++) {
-      assertTrue(srcArray[i] == floatReverseBytes(wmem2.getFloat(i * Float.BYTES)));
+      assertTrue(srcArray[i] == UtilForTest.floatReverseBytes(wmem2.getFloat(i * FB)));
     }
     //get
     float[] dstArray = new float[len];
-    wmem.getFloatArray(0, dstArray, 0, half);
-    wmem.getFloatArray(half * Float.BYTES, dstArray, half, half);
+    wmem.getFloatArray(0, dstArray, 0, half);             //get*Array(add, dst[], dstOff, len)
+    for (int i = half; i < len; i++) {
+      dstArray[i] = wmem.getFloat(i * FB);                //get*(add)
+    }
     assertEquals(srcArray, dstArray);
   }
 
@@ -107,19 +126,23 @@ public class NonNativeWritableMemoryImplTest {
     int[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
     final int len = srcArray.length;
     final int half = len / 2;
-    WritableMemory wmem = WritableMemory.allocate(len * Integer.BYTES, NON_NATIVE_BYTE_ORDER);
-    wmem.putIntArray(0, srcArray, 0, half);
-    wmem.putIntArray(half * Integer.BYTES, srcArray, half, half);
+    WritableMemory wmem = WritableMemory.allocate(len * IB, NNBO);
+    wmem.putIntArray(0, srcArray, 0, half);             //put*Array(add, src[], srcOff, len)
+    for (int i = 0; i < half; i++) {
+      wmem.putInt((half + i) * IB, srcArray[half + i]); //put*(add, value)
+    }
     //confirm
-    WritableMemory wmem2 = WritableMemory.allocate(len * Integer.BYTES, NATIVE_BYTE_ORDER);
-    wmem.copyTo(0, wmem2, 0, len * Integer.BYTES);
+    WritableMemory wmem2 = WritableMemory.allocate(len * IB, NBO);
+    wmem.copyTo(0, wmem2, 0, len * IB);
     for (int i = 0; i < len; i++) {
-      assertTrue(srcArray[i] == Integer.reverseBytes(wmem2.getInt(i * Integer.BYTES)));
+      assertTrue(srcArray[i] == Integer.reverseBytes(wmem2.getInt(i * IB)));
     }
     //get
     int[] dstArray = new int[len];
-    wmem.getIntArray(0, dstArray, 0, half);
-    wmem.getIntArray(half * Integer.BYTES, dstArray, half, half);
+    wmem.getIntArray(0, dstArray, 0, half);             //get*Array(add, dst[], dstOff, len)
+    for (int i = half; i < len; i++) {
+      dstArray[i] = wmem.getInt(i * IB);                //get*(add)
+    }
     assertEquals(srcArray, dstArray);
   }
 
@@ -128,19 +151,23 @@ public class NonNativeWritableMemoryImplTest {
     long[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
     final int len = srcArray.length;
     final int half = len / 2;
-    WritableMemory wmem = WritableMemory.allocate(len * Long.BYTES, NON_NATIVE_BYTE_ORDER);
-    wmem.putLongArray(0, srcArray, 0, half);
-    wmem.putLongArray(half * Long.BYTES, srcArray, half, half);
+    WritableMemory wmem = WritableMemory.allocate(len * LB, NNBO);
+    wmem.putLongArray(0, srcArray, 0, half);             //put*Array(add, src[], srcOff, len)
+    for (int i = 0; i < half; i++) {
+      wmem.putLong((half + i) * LB, srcArray[half + i]); //put*(add, value)
+    }
     //confirm
-    WritableMemory wmem2 = WritableMemory.allocate(len * Long.BYTES, NATIVE_BYTE_ORDER);
-    wmem.copyTo(0, wmem2, 0, len * Long.BYTES);
+    WritableMemory wmem2 = WritableMemory.allocate(len * LB, NBO);
+    wmem.copyTo(0, wmem2, 0, len * LB);
     for (int i = 0; i < len; i++) {
-      assertTrue(srcArray[i] == Long.reverseBytes(wmem2.getLong(i * Long.BYTES)));
+      assertTrue(srcArray[i] == Long.reverseBytes(wmem2.getLong(i * LB)));
     }
     //get
     long[] dstArray = new long[len];
-    wmem.getLongArray(0, dstArray, 0, half);
-    wmem.getLongArray(half * Long.BYTES, dstArray, half, half);
+    wmem.getLongArray(0, dstArray, 0, half);             //get*Array(add, dst[], dstOff, len)
+    for (int i = half; i < len; i++) {
+      dstArray[i] = wmem.getLong(i *LB);                 //get*(add)
+    }
     assertEquals(srcArray, dstArray);
   }
 
@@ -149,19 +176,23 @@ public class NonNativeWritableMemoryImplTest {
     short[] srcArray = { 1, 2, 3, 4, 5, 6, 7, 8 };
     final int len = srcArray.length;
     final int half = len / 2;
-    WritableMemory wmem = WritableMemory.allocate(len * Short.BYTES, NON_NATIVE_BYTE_ORDER);
-    wmem.putShortArray(0, srcArray, 0, half);
-    wmem.putShortArray(half * Short.BYTES, srcArray, half, half);
+    WritableMemory wmem = WritableMemory.allocate(len * SB, NNBO);
+    wmem.putShortArray(0, srcArray, 0, half);             //put*Array(add, src[], srcOff, len)
+    for (int i = 0; i < half; i++) {
+      wmem.putShort((half + i) * SB, srcArray[half + i]); //put*(add, value)
+    }
     //confirm
-    WritableMemory wmem2 = WritableMemory.allocate(len * Short.BYTES, NATIVE_BYTE_ORDER);
-    wmem.copyTo(0, wmem2, 0, len * Short.BYTES);
+    WritableMemory wmem2 = WritableMemory.allocate(len * SB, NBO);
+    wmem.copyTo(0, wmem2, 0, len * SB);
     for (int i = 0; i < len; i++) {
-      assertTrue(srcArray[i] == Short.reverseBytes(wmem2.getShort(i * Short.BYTES)));
+      assertTrue(srcArray[i] == Short.reverseBytes(wmem2.getShort(i * SB)));
     }
     //get
     short[] dstArray = new short[len];
-    wmem.getShortArray(0, dstArray, 0, half);
-    wmem.getShortArray(half * Short.BYTES, dstArray, half, half);
+    wmem.getShortArray(0, dstArray, 0, half);             //get*Array(add, dst[], dstOff, len)
+    for (int i = half; i < len; i++) {
+      dstArray[i] = wmem.getShort(i *SB);                 //get*(add)
+    }
     assertEquals(srcArray, dstArray);
   }
 
@@ -171,21 +202,7 @@ public class NonNativeWritableMemoryImplTest {
   @Test
   public void checkRegion() {
     WritableMemory wreg = wmem.writableRegion(0, wmem.getCapacity());
-    assertEquals(wreg.getTypeByteOrder(), ByteOrder.BIG_ENDIAN);
-  }
-
-  //Java does not provide reverse bytes on doubles or floats
-
-  static double doubleReverseBytes(double value) {
-    long longIn = Double.doubleToRawLongBits(value);
-    long longOut = Long.reverseBytes(longIn);
-    return Double.longBitsToDouble(longOut);
-  }
-
-  static float floatReverseBytes(float value) {
-    int intIn = Float.floatToRawIntBits(value);
-    int intOut = Integer.reverseBytes(intIn);
-    return Float.intBitsToFloat(intOut);
+    assertEquals(wreg.getTypeByteOrder(), NNBO);
   }
 
 }

--- a/src/test/java/org/apache/datasketches/memory/internal/ResourceTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/ResourceTest.java
@@ -270,6 +270,27 @@ public class ResourceTest {
     assertTrue(out != 0);
   }
 
+  @Test
+  public void checkMismatch() {
+    byte[] arr1 = {1,2,3,4};
+    byte[] arr2 = {1,2,3,4};
+    byte[] arr3 = {1,2,3,4,5};
+    Memory mem1 = Memory.wrap(arr1);
+    Memory mem2 = Memory.wrap(arr2);
+    Memory mem3 = Memory.wrap(arr3);
+    assertEquals(mem1.mismatch(mem2), -1);
+    assertEquals(mem1.mismatch(mem3), 4);
+
+    byte[] arr4 = {9,9,1,2,3,4,9,9};
+    byte[] arr5 = {8,8,8,1,2,3,4,8};
+    byte[] arr6 = {8,8,8,1,2,3,4,5};
+    Memory mem4 = Memory.wrap(arr4);
+    Memory mem5 = Memory.wrap(arr5);
+    Memory mem6 = Memory.wrap(arr6);
+    assertEquals(mem4.mismatch(mem4, 2, 6, mem5, 3, 7), -1);
+    assertEquals(mem4.mismatch(mem4, 2, 7, mem6, 3, 8), 4);
+  }
+
   /********************/
   @Test
   public void printlnTest() {

--- a/src/test/java/org/apache/datasketches/memory/internal/UtilForTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/UtilForTest.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.datasketches.memory.internal;
 
 import static org.apache.datasketches.memory.internal.ResourceImpl.NATIVE_BYTE_ORDER;

--- a/src/test/java/org/apache/datasketches/memory/internal/UtilForTest.java
+++ b/src/test/java/org/apache/datasketches/memory/internal/UtilForTest.java
@@ -1,0 +1,34 @@
+package org.apache.datasketches.memory.internal;
+
+import static org.apache.datasketches.memory.internal.ResourceImpl.NATIVE_BYTE_ORDER;
+import static org.apache.datasketches.memory.internal.ResourceImpl.NON_NATIVE_BYTE_ORDER;
+
+import java.nio.ByteOrder;
+
+public class UtilForTest {
+
+  static final int BB = Byte.BYTES;
+  static final int CB = Character.BYTES;
+  static final int SB = Short.BYTES;
+  static final int IB = Integer.BYTES;
+  static final int LB = Long.BYTES;
+  static final int DB = Double.BYTES;
+  static final int FB = Float.BYTES;
+  static ByteOrder NNBO = NON_NATIVE_BYTE_ORDER;
+  static ByteOrder NBO = NATIVE_BYTE_ORDER;
+
+  //Java does not provide reverse bytes on doubles or floats
+
+  static double doubleReverseBytes(double value) {
+    long longIn = Double.doubleToRawLongBits(value);
+    long longOut = Long.reverseBytes(longIn);
+    return Double.longBitsToDouble(longOut);
+  }
+
+  static float floatReverseBytes(float value) {
+    int intIn = Float.floatToRawIntBits(value);
+    int intOut = Integer.reverseBytes(intIn);
+    return Float.intBitsToFloat(intOut);
+  }
+
+}


### PR DESCRIPTION
In examining the test coverage I discovered some large gaps in coverage in the same classes where the @pawel-wiejacha bug was found.  I refactored the tests again for more comprehensive coverage.  This brought the coverage from 90% to 95.7%.  And for the target native and non-native buffer & memory leaf classes the coverage is 100%.

The actual test code has changed a great deal, which may make it difficult to review in this GitHub context.