### PR TITLE
Allow to run ds-memory 3.0 on Java 25

### DIFF
--- a/.github/workflows/auto-jdk-matrix.yml
+++ b/.github/workflows/auto-jdk-matrix.yml
@@ -19,19 +19,19 @@ jobs:
 
         steps:
         - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-          uses: actions/checkout@v3.3.0
+          uses: actions/checkout@v4
           with:
               persist-credentials: false
 
         - name: Cache local Maven repository
-          uses: actions/cache@v3.2.3
+          uses: actions/cache@v4
           with:
               path: ~/.m2/repository
               key: build-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
               restore-keys: build-${{ runner.os }}-maven-
 
         - name: Install Matrix JDK
-          uses: actions/setup-java@v3
+          uses: actions/setup-java@v4
           with:
               java-version: |
                   8

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Generate JavaDoc
         run: mvn javadoc:javadoc
       - name: Deploy JavaDoc

--- a/.github/workflows/manual-coverage.yml
+++ b/.github/workflows/manual-coverage.yml
@@ -31,19 +31,19 @@ jobs:
 
         steps:
         - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
           with:
               persist-credentials: false
 
         - name: Cache local Maven repository
-          uses: actions/cache@v3
+          uses: actions/cache@v4
           with:
               path: ~/.m2/repository
               key: build-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
               restore-keys: build-${{ runner.os }}-maven-
 
         - name: Install Matrix JDK
-          uses: actions/setup-java@v3
+          uses: actions/setup-java@v4
           with:
               java-version: ${{ matrix.jdk }}
               distribution: 'temurin'

--- a/.github/workflows/manual-os-matrix.yml
+++ b/.github/workflows/manual-os-matrix.yml
@@ -34,19 +34,19 @@ jobs:
 
         steps:
         - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
           with:
               persist-credentials: false
 
         - name: Cache local Maven repository
-          uses: actions/cache@v3
+          uses: actions/cache@v4
           with:
               path: ~/.m2/repository
               key: build-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
               restore-keys: build-${{ runner.os }}-maven-
 
         - name: Install Matrix JDK
-          uses: actions/setup-java@v3
+          uses: actions/setup-java@v4
           with:
               java-version: ${{ matrix.jdk }}
               distribution: 'temurin'

--- a/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/ResourceImpl.java
+++ b/datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/ResourceImpl.java
@@ -151,9 +151,9 @@ public abstract class ResourceImpl implements Resource {
    * @param p1 The second number group
    */
   static void checkJavaVersion(final String jdkVer, final int p0, final int p1 ) {
-    final boolean ok = ((p0 == 1) && (p1 == 8)) || (p0 == 8) || (p0 == 11) || (p0 == 17 || (p0 == 21));
+    final boolean ok = ((p0 == 1) && (p1 == 8)) || (p0 == 8) || (p0 == 11) || (p0 == 17) || (p0 == 21) || (p0 == 25);
     if (!ok) { throw new IllegalArgumentException(
-        "Unsupported JDK Major Version. It must be one of 1.8, 8, 11, 17, 21: " + jdkVer);
+        "Unsupported JDK Major Version. It must be one of 1.8, 8, 11, 17, 21, 25: " + jdkVer);
     }
   }
 


### PR DESCRIPTION
This PR relaxes runtime Java version check - add Java 25 to the allow list, for `datasketches-memory` 3.0.

I understand that Java 17/21/25 is not supported by datasketches-memory 3.0.2, but I'd like to run it in limited mode with Java 25, as it does on Java 17/21.


Verification:

Have done somke test with Apache Spark, see details at https://github.com/apache/datasketches-memory/issues/270#issuecomment-3828240772

I can run integration tests with Spark if `datasketches-memory` can have a SNAPSHOT or RC release (includes this patch) available on a public Maven repo

---

UPDATE:

I have made this change and deployed to our internal Maven repo, and integrated with internal Spark, I confirm all Spark cases work well with Java 25, so I think `datasketches-memory` 3.0 can work well in limited mode on Java 25, as it does on Java 17/21.