### PR TITLE
Print warning message instead of throwing exception for unsupported Java versions

### DIFF
--- a/datasketches-memory-java11/src/main/java/org/apache/datasketches/memory/internal/ResourceImpl.java
+++ b/datasketches-memory-java11/src/main/java/org/apache/datasketches/memory/internal/ResourceImpl.java
@@ -143,10 +143,13 @@ public abstract class ResourceImpl implements Resource {
    * Checks the runtime Java Version string. 
    * @param javaMajor the first number from the <i>System.getProperty("java.version")</i> string."
    */
-  static void checkJavaVersion(final int javaMajor) {
+  static boolean checkJavaVersion(final int javaMajor) {
     final boolean ok = javaMajor == 11;
-    if (!ok) { throw new IllegalArgumentException("This Java version is not supported: " + javaMajor);
+    if (!ok) {
+      System.err.println("WARNING: Java " + javaMajor + " is not officially supported " +
+          "by Apache DataSketches Memory, use at your own risk.");
     }
+    return ok;
   }
 
   void checkNotReadOnly() {

--- a/datasketches-memory-java11/src/test/java/org/apache/datasketches/memory/internal/ResourceTest.java
+++ b/datasketches-memory-java11/src/test/java/org/apache/datasketches/memory/internal/ResourceTest.java
@@ -131,45 +131,33 @@ public class ResourceTest {
     for (int i = 0; i < len; i++) {
       jdkVer = good1_Strings[i];
       jdkMaj = ResourceImpl.parseJavaVersion(jdkVer);
-      ResourceImpl.checkJavaVersion(jdkMaj);
-    }
-    try {
-      jdkVer = "14.0.4"; //invalid string
-      jdkMaj = ResourceImpl.parseJavaVersion(jdkVer);
-      ResourceImpl.checkJavaVersion(jdkMaj); //throws
-      fail();
-    } catch (IllegalArgumentException e) {
-      println("" + e);
+      assertTrue(ResourceImpl.checkJavaVersion(jdkMaj));
     }
 
-    try {
-      jdkVer = "1.7.0_80"; //invalid string
-      jdkMaj = ResourceImpl.parseJavaVersion(jdkVer);
-      ResourceImpl.checkJavaVersion(jdkMaj); //throws
-      fail();
-    } catch (IllegalArgumentException e) {
-      println("" + e);
-    }
-    try {
-      jdkVer = "1.6.0_65"; //invalid string
-      jdkMaj = ResourceImpl.parseJavaVersion(jdkVer);
-      ResourceImpl.checkJavaVersion(jdkMaj); //throws
-      fail();
-    } catch (IllegalArgumentException e) {
-      println("" + e);
-    }
+    jdkVer = "14.0.4"; //invalid string
+    jdkMaj = ResourceImpl.parseJavaVersion(jdkVer);
+    assertFalse(ResourceImpl.checkJavaVersion(jdkMaj));
+
+    jdkVer = "1.7.0_80"; //invalid string
+    jdkMaj = ResourceImpl.parseJavaVersion(jdkVer);
+    assertFalse(ResourceImpl.checkJavaVersion(jdkMaj));
+
+    jdkVer = "1.6.0_65"; //invalid string
+    jdkMaj = ResourceImpl.parseJavaVersion(jdkVer);
+    assertFalse(ResourceImpl.checkJavaVersion(jdkMaj));
+
     try {
       jdkVer = "b"; //invalid string
-      jdkMaj = ResourceImpl.parseJavaVersion(jdkVer);
-      ResourceImpl.checkJavaVersion(jdkMaj); //throws
+      jdkMaj = ResourceImpl.parseJavaVersion(jdkVer); //throws
+      assertFalse(ResourceImpl.checkJavaVersion(jdkMaj));
       fail();
     } catch (IllegalArgumentException e) {
       println("" + e);
     }
     try {
       jdkVer = ""; //invalid string
-      jdkMaj = ResourceImpl.parseJavaVersion(jdkVer);
-      ResourceImpl.checkJavaVersion(jdkMaj); //throws
+      jdkMaj = ResourceImpl.parseJavaVersion(jdkVer);  //throws
+      assertFalse(ResourceImpl.checkJavaVersion(jdkMaj));
       fail();
     } catch (IllegalArgumentException e) {
       println("" + e);

--- a/datasketches-memory-java17_21/src/main/java/org/apache/datasketches/memory/internal/ResourceImpl.java
+++ b/datasketches-memory-java17_21/src/main/java/org/apache/datasketches/memory/internal/ResourceImpl.java
@@ -143,12 +143,13 @@ public abstract class ResourceImpl implements Resource {
    * Checks the runtime Java Version string. 
    * @param javaMajor the first number from the <i>System.getProperty("java.version")</i> string."
    */
-  static void checkJavaVersion(final int javaMajor) {
+  static boolean checkJavaVersion(final int javaMajor) {
     final boolean ok = ( (javaMajor == 17) || (javaMajor == 21) ); 
     if (!ok) {
       System.err.println("WARNING: Java " + javaMajor + " is not officially supported " +
           "by Apache DataSketches Memory, use at your own risk.");
     }
+    return ok;
   }
 
   void checkNotReadOnly() {

--- a/datasketches-memory-java17_21/src/main/java/org/apache/datasketches/memory/internal/ResourceImpl.java
+++ b/datasketches-memory-java17_21/src/main/java/org/apache/datasketches/memory/internal/ResourceImpl.java
@@ -145,7 +145,9 @@ public abstract class ResourceImpl implements Resource {
    */
   static void checkJavaVersion(final int javaMajor) {
     final boolean ok = ( (javaMajor == 17) || (javaMajor == 21) ); 
-    if (!ok) { throw new IllegalArgumentException("This Java version is not supported: " + javaMajor);
+    if (!ok) {
+      System.err.println("WARNING: Java " + javaMajor + " is not officially supported " +
+          "by Apache DataSketches Memory, use at your own risk.");
     }
   }
 

--- a/datasketches-memory-java17_21/src/test/java/org/apache/datasketches/memory/internal/ResourceTest.java
+++ b/datasketches-memory-java17_21/src/test/java/org/apache/datasketches/memory/internal/ResourceTest.java
@@ -131,45 +131,33 @@ public class ResourceTest {
     for (int i = 0; i < len; i++) {
       jdkVer = good1_Strings[i];
       jdkMaj = ResourceImpl.parseJavaVersion(jdkVer);
-      ResourceImpl.checkJavaVersion(jdkMaj);
-    }
-    try {
-      jdkVer = "14.0.4"; //invalid string
-      jdkMaj = ResourceImpl.parseJavaVersion(jdkVer);
-      ResourceImpl.checkJavaVersion(jdkMaj); //throws
-      fail();
-    } catch (IllegalArgumentException e) {
-      println("" + e);
+      assertTrue(ResourceImpl.checkJavaVersion(jdkMaj));
     }
 
-    try {
-      jdkVer = "1.7.0_80"; //invalid string
-      jdkMaj = ResourceImpl.parseJavaVersion(jdkVer);
-      ResourceImpl.checkJavaVersion(jdkMaj); //throws
-      fail();
-    } catch (IllegalArgumentException e) {
-      println("" + e);
-    }
-    try {
-      jdkVer = "1.6.0_65"; //invalid string
-      jdkMaj = ResourceImpl.parseJavaVersion(jdkVer);
-      ResourceImpl.checkJavaVersion(jdkMaj); //throws
-      fail();
-    } catch (IllegalArgumentException e) {
-      println("" + e);
-    }
+    jdkVer = "14.0.4"; //invalid string
+    jdkMaj = ResourceImpl.parseJavaVersion(jdkVer);
+    assertFalse(ResourceImpl.checkJavaVersion(jdkMaj));
+
+    jdkVer = "1.7.0_80"; //invalid string
+    jdkMaj = ResourceImpl.parseJavaVersion(jdkVer);
+    assertFalse(ResourceImpl.checkJavaVersion(jdkMaj));
+
+    jdkVer = "1.6.0_65"; //invalid string
+    jdkMaj = ResourceImpl.parseJavaVersion(jdkVer);
+    assertFalse(ResourceImpl.checkJavaVersion(jdkMaj));
+
     try {
       jdkVer = "b"; //invalid string
-      jdkMaj = ResourceImpl.parseJavaVersion(jdkVer);
-      ResourceImpl.checkJavaVersion(jdkMaj); //throws
+      jdkMaj = ResourceImpl.parseJavaVersion(jdkVer); //throws
+      assertFalse(ResourceImpl.checkJavaVersion(jdkMaj));
       fail();
     } catch (IllegalArgumentException e) {
       println("" + e);
     }
     try {
       jdkVer = ""; //invalid string
-      jdkMaj = ResourceImpl.parseJavaVersion(jdkVer);
-      ResourceImpl.checkJavaVersion(jdkMaj); //throws
+      jdkMaj = ResourceImpl.parseJavaVersion(jdkVer);  //throws
+      assertFalse(ResourceImpl.checkJavaVersion(jdkMaj));
       fail();
     } catch (IllegalArgumentException e) {
       println("" + e);


### PR DESCRIPTION
My local test shows it also works with JDK 25.