### PR TITLE
Update workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Check the default branch (main)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+
+  # Check the 'workflows' branch
+  - package-ecosystem: "github-actions"
+    directory: "/" 
+    target-branch: "workflows"
+    schedule:
+      interval: "monthly"
+
+  # Check the '7.0.X' branch
+  - package-ecosystem: "github-actions"
+    directory: "/" 
+    target-branch: "7.0.X"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/stageReleaseSources.yml
+++ b/.github/workflows/stageReleaseSources.yml
@@ -94,3 +94,50 @@ jobs:
           name: datasketches-memory-release-source-bundle
           path: staging_dir/
           retention-days: 15
+
+  test-source-candidate:
+    name: Test Source Candidate on ${{ matrix.os }}
+    needs: assemble-source-candidate
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      # 1. Download the zipped artifact uploaded by the previous job
+      - name: Download Source ZIP Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: datasketches-memory-release-source-bundle
+          path: downloaded-bundle
+
+      # 2. Extract the source distribution
+      - name: Extract Source Distribution
+        shell: bash
+        run: |
+          # The downloaded artifact folder contains the zip file
+          ZIP_FILE=$(ls downloaded-bundle/*.zip)
+          echo "Unzipping $ZIP_FILE..."
+          unzip -q $ZIP_FILE -d test-workspace
+          
+      # 3. Setup Java Toolchain (11, 17, and 21)
+      - name: Setup Java Toolchains
+        uses: actions/setup-java@v5
+        with:
+          java-version: |
+            11
+            17
+            21
+          distribution: 'temurin'
+          
+      # 4. Run the tests on the unzipped sources
+      - name: Execute Tests
+        shell: bash
+        run: |
+          # Enter the unzipped directory (which will be named datasketches-memory-X.Y.Z-src)
+          cd test-workspace/*
+          echo "Running tests in $(pwd)"
+          
+          # Run the standard test phase (this validates line-endings, missing files, and fallbacks!)
+          mvn clean test

--- a/.github/workflows/stageReleaseSources.yml
+++ b/.github/workflows/stageReleaseSources.yml
@@ -89,7 +89,7 @@ jobs:
 
       # 7. Package and upload the staged bundle as a secure workflow archive
       - name: 7. Upload Release Candidate Assets for Local Signing
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: datasketches-memory-release-source-bundle
           path: staging_dir/
@@ -107,7 +107,7 @@ jobs:
     steps:
       # 1. Download the zipped artifact uploaded by the previous job
       - name: Download Source ZIP Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: datasketches-memory-release-source-bundle
           path: downloaded-bundle

--- a/datasketches-memory-java11/src/test/java/org/apache/datasketches/memory/internal/AllocateDirectMapMemoryTest.java
+++ b/datasketches-memory-java11/src/test/java/org/apache/datasketches/memory/internal/AllocateDirectMapMemoryTest.java
@@ -29,11 +29,13 @@ import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.datasketches.memory.Memory;
+import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class AllocateDirectMapMemoryTest {
   private static final String LS = System.getProperty("line.separator");
+  private static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase().contains("windows");
   private File gettyFile;
   private long gettySize;
   
@@ -116,6 +118,10 @@ public class AllocateDirectMapMemoryTest {
 
   @Test
   public void testLoad() throws IOException  {
+    if (IS_WINDOWS) {
+      throw new SkipException("isLoaded() is unreliable on Windows VMM; skipping test.");
+    }
+    
     long memCapacity = gettySize;
     try (Memory mem = Memory.map(gettyFile, 0, memCapacity, ByteOrder.nativeOrder())) {
       mem.load();

--- a/datasketches-memory-java11/src/test/java/org/apache/datasketches/memory/internal/AllocateDirectWritableMapMemoryTest.java
+++ b/datasketches-memory-java11/src/test/java/org/apache/datasketches/memory/internal/AllocateDirectWritableMapMemoryTest.java
@@ -34,11 +34,13 @@ import java.nio.ByteOrder;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.ReadOnlyException;
 import org.apache.datasketches.memory.WritableMemory;
+import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class AllocateDirectWritableMapMemoryTest {
   private static final String LS = System.getProperty("line.separator");
+  private static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase().contains("windows");
   private File gettyFile;
   
   @BeforeClass
@@ -140,6 +142,10 @@ public class AllocateDirectWritableMapMemoryTest {
 
   @Test
   public void testForce() throws Exception {
+    if (IS_WINDOWS) {
+      throw new SkipException("isLoaded() is unreliable on Windows VMM; skipping test.");
+    }
+    
     String origStr = "Corectng spellng mistks";
     File origFile = createFile("force_original.txt", origStr); //23
     assertTrue(origFile.setWritable(true, false));


### PR DESCRIPTION
I wanted to do the same test that Claude did, which is to rebuild the project from the deployed source zip and run all the unit tests across 3 OSs (MacOS, Ubuntu, and Windows). 

In the process I discovered that in an off-heap file-mapped memory situation Windows does not instantly respond to a isLoaded() query, while MacOS and Ubuntu do. This caused two little tests to fail.  It turns out that Windows  considers these queries as "suggestions" and takes its time in actually confirming that the file has been loaded.  This lapse in time is what caused these two tests to fail.  It is ironic that this hasn't shown up earlier, but it is probabilistic and not deterministic.

Nonetheless, If this happens, it will print a warning message to the console to this effect and the affected test was skipped.

Keeping the github/actions "plugins" up-to-date" has become a chore, so I added a script (dependabot.yml) provided by GitHub to check the GHA plugins versions and create a PR, if one of them needs to be upgraded. 