### PR TITLE
Update license paths and pom manifest info.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -225,7 +225,7 @@ APPENDIX B: Additional licenses relevant to this product:
     Code locations:
     -------------------------------------------------------------
     This product contains a method to create a dummy read-only ByteBuffer using unsafe:
-      * datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/AccessByteBuffer.java,
+      * datasketches-memory-common/src/main/java/org/apache/datasketches/memory/internal/AccessByteBuffer.java,
         Method: getDummyReadOnlyDirectByteBuffer(...)
     and adapted from Java source code located at:
       * src/one/nio/mem/DirectMemory.java,
@@ -242,10 +242,10 @@ APPENDIX B: Additional licenses relevant to this product:
     Code locations:
     -------------------------------------------------------------
     This product contains code to implement and test the xxHash function:
-      * datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/XxHash64.java
-      * datasketches-memory-java8-tests/src/test/java/org/apache/datasketches/memory/test/XxHash64Test.java
+      * datasketches-memory-common/src/main/java/org/apache/datasketches/memory/internal/XxHash64.java
+      * datasketches-memory-common/src/test/java/org/apache/datasketches/memory/internal/XxHash64Test.java
         Method: collisionTest(),
-      * datasketches-memory-java8-tests/src/test/java/org/apache/datasketches/memory/test/XxHash64LoopingTest.java
+      * datasketches-memory-common/src/test/java/org/apache/datasketches/memory/internal/XxHash64LoopingTest.java
         Method: testWithSeed() and HASHES_OF_LOOPING_BYTES_WITH_SEED_42 test data,
     and adapted from Java source code located at:
       * https://github.com/OpenHFT/Zero-Allocation-Hashing
@@ -283,8 +283,8 @@ APPENDIX B: Additional licenses relevant to this product:
     Code locations:
     -------------------------------------------------------------    
     This product contains code for encoding, decoding and testing xxHash:
-      * datasketches-memory-java8/src/main/java/org/apache/datasketches/memory/internal/XxHash64.java
-    and adapted from C++ code located at:
+      * datasketches-memory-common/src/main/java/org/apache/datasketches/memory/internal/XxHash64.java,
+    which has been adapted from C++ code located at:
       * https://github.com/Cyan4973/xxHash/blob/dev/xxhash.c,
       * https://github.com/Cyan4973/xxHash/blob/dev/xxhash.h
 
@@ -295,8 +295,8 @@ APPENDIX B: Additional licenses relevant to this product:
     =============================================================
       This product contains the text of Lincoln's Gettysburg Address, which is in the public domain,
       and is used in various file tests. This file is read-only and tested for its exact character 
-      sequence and cannot be appended with any additional text.
-      * datasketches-memory-java8-tests/src/test/java/org/apache/datasketches/memory/test/AllocateDirectMapMemoryTest.java
-      * datasketches-memory-java8-tests/src/test/java/org/apache/datasketches/memory/test/AllocateDirectWritableMapMemoryTest.java
-      * datasketches-memory-java8-tests/src/test/java/org/apache/datasketches/memory/test/MemoryTest.java
-      * datasketches-memory-java8-tests/src/test/java/org/apache/datasketches/memory/test/UtilTest.java
+      sequence and cannot be appended with any additional text. Approximate locations:
+      * datasketches-memory-java11/src/test/java/org/apache/datasketches/memory/internal/AllocateDirectMapMemoryTest.java
+      * datasketches-memory-java11/src/test/java/org/apache/datasketches/memory/internal/AllocateDirectWritableMapMemoryTest.java
+      * datasketches-memory-java11/src/test/java/org/apache/datasketches/memory/internal/UtilTest.java
+      * datasketches-memory-java11/src/test/java/org/apache/datasketches/memory/internal/ThreadTest.java

--- a/pom.xml
+++ b/pom.xml
@@ -362,7 +362,7 @@ under the License.
                    maven-javadoc-plugin and maven-source-plugin with the sole exception of the
                    Automatic-Module-Name, which only belongs here. -->
               <manifestEntries>
-                <Build-Jdk-Spec>${java.specification.version}</Build-Jdk-Spec>
+                <Build-Jdk-Spec>${java.runtime.version}</Build-Jdk-Spec>
                 <Build-OS>${os.name} ${os.arch} ${os.version}</Build-OS>
                 <Implementation-Vendor>The Apache Software Foundation</Implementation-Vendor>
                 <Group-ArtifactId  >${project.groupId}:${project.artifactId}</Group-ArtifactId  >
@@ -397,7 +397,7 @@ under the License.
                    make sure that all of these entries are identical across the maven-jar-plugin,
                    maven-javadoc-plugin and maven-source-plugin. -->
               <manifestEntries>
-                <Build-Jdk-Spec>${java.specification.version}</Build-Jdk-Spec>
+                <Build-Jdk-Spec>${java.runtime.version}</Build-Jdk-Spec>
                 <Build-OS>${os.name} ${os.arch} ${os.version}</Build-OS>
                 <Implementation-Vendor>The Apache Software Foundation</Implementation-Vendor>
                 <Group-ArtifactId  >${project.groupId}:${project.artifactId}</Group-ArtifactId  >
@@ -451,7 +451,7 @@ under the License.
                    make sure that all of these entries are identical across the maven-jar-plugin,
                    maven-javadoc-plugin and maven-source-plugin. -->
               <manifestEntries>
-                <Build-Jdk-Spec>${java.specification.version}</Build-Jdk-Spec>
+                <Build-Jdk-Spec>${java.runtime.version}</Build-Jdk-Spec>
                 <Build-OS>${os.name} ${os.arch} ${os.version}</Build-OS>
                 <Implementation-Vendor>The Apache Software Foundation</Implementation-Vendor>
                 <Group-ArtifactId  >${project.groupId}:${project.artifactId}</Group-ArtifactId  >


### PR DESCRIPTION
This corrects two minor issues:

- The LICENSE file satisfies all the licensing requirements. However, it optionally added path information to where the 3rd party code was being used. These paths were obsolete and need to be updated.
- The Manifest information inserted into the jar files had a reference to the Major Java version. However, to insure the Reproducible Build Goal the Java version string in the Manifest should include the full Java version string including patch number. 
- These changes are minor and do not invalidate the current 7.0.0 release.
- These changes will be applied to any subsequent releases.